### PR TITLE
test: add node:test suite with mocked external calls

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+**/*.spec.js
+test
+docs
+.git
+.github
+.idea
+.vscode
+.env*
+tmp
+coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test

--- a/docs/superpowers/plans/2026-08-06-test-suite.md
+++ b/docs/superpowers/plans/2026-08-06-test-suite.md
@@ -1,0 +1,1489 @@
+# Test Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dotare `substack-mcp` di una suite di unit e integration test con il test runner nativo di Node, in cui ogni chiamata HTTP in uscita è intercettata e mockata, così da bloccare le regressioni nel tempo.
+
+**Architecture:** I test sono colocati accanto ai sorgenti come `<nome>.spec.js`. Le chiamate HTTP verso Substack sono intercettate da MSW configurato con `onUnhandledRequest: 'error'`, che fa fallire il test su qualsiasi richiesta non mockata. Il layer MCP viene reso testabile estraendo `createServer()` in `src/server.js`, e viene esercitato tramite un `Client` reale dell'SDK collegato con `InMemoryTransport`. I file `.spec.js` sono esclusi dal tarball npm e dall'immagine Docker.
+
+**Tech Stack:** Node 22 (`node:test`, `node:assert/strict`), ESM, MSW 2.15.0, `@modelcontextprotocol/sdk` 1.11.2, Zod 3.24.4.
+
+**Spec di riferimento:** `docs/superpowers/specs/2026-08-06-test-suite-design.md`
+
+---
+
+## Note per chi implementa
+
+**I test sono di caratterizzazione.** Bloccano il comportamento *attuale*, non quello
+desiderato. Il piano contiene test che documentano esplicitamente delle anomalie (sono
+etichettati "comportamento corrente"). **Non correggere il codice di produzione per farle
+sparire.** Se un test di caratterizzazione fallisce, il bug è nel test, non nel sorgente.
+
+**Fatti verificati empiricamente** durante la stesura del piano, di cui fidarsi:
+
+1. `node --test` **non** scopre i file `.spec.js` con i pattern di default. Serve il glob
+   esplicito `'src/**/*.spec.js'`, tra virgolette singole perché lo espanda Node e non la shell.
+2. Gli errori del server MCP arrivano al client come `McpError` con messaggio prefissato
+   `MCP error -32603: `. Le asserzioni sui messaggi usano quindi `assert.match`, mai
+   `assert.equal`.
+3. `client.callTool()` restituisce `{content: [{type: 'text', text: '"OK"'}]}` — le virgolette
+   fanno parte della stringa, perché il server applica `JSON.stringify` al valore di ritorno
+   dell'handler.
+4. MSW intercetta axios e cattura gli header `Cookie` e `referer`; `server.use()` sovrascrive
+   l'handler per singolo test; una risposta 500 fa lanciare axios con `err.response.status === 500`.
+5. `"files": ["src", "!src/**/*.spec.js"]` esclude davvero gli spec dal tarball npm
+   (confermato con `npm pack --dry-run`).
+
+---
+
+## File Structure
+
+| File | Responsabilità |
+|---|---|
+| `test/helpers/env.js` | Env var di test + funzione di ripristino. Nessuna logica di rete. |
+| `test/helpers/msw-server.js` | Server MSW, handler di default per `/drafts`, registrazione delle richieste intercettate. |
+| `test/helpers/mcp-harness.js` | Collega un `Client` MCP reale a `createServer()` via `InMemoryTransport`. |
+| `src/server.js` | **Nuovo.** `createServer()`: costruisce il `Server` MCP e registra gli handler. Nessun side-effect all'import. |
+| `src/index.js` | **Modificato.** Solo entrypoint: check env, `createServer()`, connessione stdio. |
+| `src/api/substack/SubstackPost.spec.js` | Unit test del builder. Nessuna rete. |
+| `src/api/substack/SubstackApi.spec.js` | Integration test del client HTTP contro MSW. |
+| `src/tools/create_draft_post.spec.js` | Integration test dell'handler del tool contro MSW. |
+| `src/server.spec.js` | Integration test del protocollo MCP end-to-end. |
+| `.dockerignore` | **Nuovo.** Esclude test, `node_modules`, `.git`, `docs` dal contesto di build. |
+| `.github/workflows/test.yml` | **Nuovo.** Esegue la suite su push e pull request. |
+
+Percorsi relativi verso gli helper, da tenere a mente:
+
+- da `src/` → `../test/helpers/`
+- da `src/tools/` → `../../test/helpers/`
+- da `src/api/substack/` → `../../../test/helpers/`
+
+---
+
+## Task 1: Infrastruttura di test
+
+**Files:**
+- Modify: `package.json`
+- Create: `.dockerignore`
+
+- [ ] **Step 1: Installare MSW come dipendenza di sviluppo**
+
+```bash
+yarn add --dev --exact msw@2.15.0
+```
+
+- [ ] **Step 2: Verificare che sia finita nelle devDependencies**
+
+Run: `node -e "const p=require('./package.json'); console.log(p.devDependencies)"`
+Expected: `{ msw: '2.15.0' }`
+
+- [ ] **Step 3: Aggiungere gli script di test e il campo `files` a `package.json`**
+
+Aggiungere le tre voci in `scripts` accanto a `start`:
+
+```json
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test 'src/**/*.spec.js'",
+    "test:watch": "node --test --watch 'src/**/*.spec.js'",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-exclude='**/*.spec.js' --test-coverage-exclude='test/**' 'src/**/*.spec.js'"
+  },
+```
+
+E aggiungere il campo `files` subito dopo `bin`:
+
+```json
+  "files": [
+    "src",
+    "!src/**/*.spec.js"
+  ],
+```
+
+- [ ] **Step 4: Verificare che `npm test` giri (senza spec, deve trovare 0 test)**
+
+Run: `npm test`
+Expected: esce con successo, output `# tests 0` / `# fail 0`.
+
+- [ ] **Step 5: Creare `.dockerignore`**
+
+```
+node_modules
+**/*.spec.js
+test
+docs
+.git
+.github
+.idea
+.vscode
+.env*
+tmp
+coverage
+```
+
+- [ ] **Step 6: Verificare l'esclusione dal tarball npm**
+
+Run: `npm pack --dry-run 2>&1 | grep -c 'spec.js'`
+Expected: `0`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json yarn.lock .dockerignore
+git commit -m "chore: add test scripts, msw dev dependency and packaging excludes"
+```
+
+---
+
+## Task 2: Helper `env.js`
+
+**Files:**
+- Create: `test/helpers/env.js`
+
+- [ ] **Step 1: Scrivere l'helper**
+
+```js
+export const TEST_ENV = {
+  SUBSTACK_PUBLICATION_URL: 'https://test.substack.com',
+  SUBSTACK_SESSION_TOKEN: 'test-session-token',
+  SUBSTACK_USER_ID: '12345',
+};
+
+/**
+ * Imposta le env var di test e restituisce una funzione che ripristina i valori precedenti,
+ * così un file di test non altera l'ambiente visto dagli altri.
+ */
+export function setTestEnv(overrides = {}) {
+  const values = {...TEST_ENV, ...overrides};
+  const saved = {};
+
+  for (const key of Object.keys(values)) {
+    saved[key] = process.env[key];
+    process.env[key] = values[key];
+  }
+
+  return function restoreEnv() {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+```
+
+- [ ] **Step 2: Verificare che il modulo si importi e faccia round-trip**
+
+Run:
+```bash
+node -e "
+import('./test/helpers/env.js').then(({setTestEnv}) => {
+  process.env.SUBSTACK_USER_ID = 'original';
+  const restore = setTestEnv();
+  console.assert(process.env.SUBSTACK_USER_ID === '12345', 'set failed');
+  restore();
+  console.assert(process.env.SUBSTACK_USER_ID === 'original', 'restore failed');
+  console.log('env helper OK');
+});
+"
+```
+Expected: `env helper OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/helpers/env.js
+git commit -m "test: add env var helper"
+```
+
+---
+
+## Task 3: Helper `msw-server.js`
+
+**Files:**
+- Create: `test/helpers/msw-server.js`
+
+Ogni richiesta viene registrata dentro l'handler stesso, non tramite gli eventi di MSW: così
+anche gli override creati con `server.use()` finiscono nel registro, purché costruiti con
+`draftsHandler()`.
+
+- [ ] **Step 1: Scrivere l'helper**
+
+```js
+import {setupServer} from 'msw/node';
+import {http, HttpResponse} from 'msw';
+import {TEST_ENV} from './env.js';
+
+export const DRAFTS_URL = `${TEST_ENV.SUBSTACK_PUBLICATION_URL}/api/v1/drafts`;
+
+export const DRAFT_RESPONSE = {
+  id: 167712345,
+  draft_title: 'Test title',
+  draft_subtitle: 'Test subtitle',
+  is_published: false,
+};
+
+/**
+ * Crea il server MSW usato dagli integration test.
+ *
+ * `requests` accumula ogni richiesta intercettata: {method, url, headers, body}.
+ * `draftsHandler(responder)` costruisce un handler per POST /drafts che registra la
+ * richiesta e poi delega la risposta a `responder`. Usalo anche negli override via
+ * `server.use()`, altrimenti quella richiesta non finisce nel registro.
+ */
+export function createMswServer() {
+  const requests = [];
+
+  async function record(request) {
+    const raw = await request.clone().text();
+
+    let body;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      body = raw;
+    }
+
+    requests.push({
+      method: request.method,
+      url: request.url,
+      headers: Object.fromEntries(request.headers.entries()),
+      body,
+    });
+  }
+
+  function draftsHandler(responder) {
+    return http.post(DRAFTS_URL, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
+  const server = setupServer(
+    draftsHandler(() => HttpResponse.json(DRAFT_RESPONSE, {status: 200}))
+  );
+
+  return {
+    server,
+    requests,
+    draftsHandler,
+    start() {
+      server.listen({onUnhandledRequest: 'error'});
+    },
+    reset() {
+      server.resetHandlers();
+      requests.length = 0;
+    },
+    stop() {
+      server.close();
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Verificare l'helper con uno smoke test temporaneo**
+
+Creare `test/helpers/msw-server.smoke.spec.js` — **file temporaneo, cancellato allo Step 5**.
+Va in `test/helpers/`, quindi non è raggiunto dal glob di `npm test`: si esegue a mano.
+
+```js
+import {test, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import axios from 'axios';
+import {HttpResponse} from 'msw';
+import {createMswServer, DRAFTS_URL, DRAFT_RESPONSE} from './msw-server.js';
+
+const msw = createMswServer();
+
+before(() => msw.start());
+afterEach(() => msw.reset());
+after(() => msw.stop());
+
+test('intercetta axios e registra la richiesta', async () => {
+  const res = await axios.post(DRAFTS_URL, {draft_title: 'Hello'}, {
+    headers: {Cookie: 'substack.sid=tok;', referer: 'https://test.substack.com/publish/post'},
+  });
+
+  assert.deepEqual(res.data, DRAFT_RESPONSE);
+  assert.equal(msw.requests.length, 1);
+  assert.equal(msw.requests[0].url, DRAFTS_URL);
+  assert.equal(msw.requests[0].headers.cookie, 'substack.sid=tok;');
+  assert.deepEqual(msw.requests[0].body, {draft_title: 'Hello'});
+});
+
+test('una richiesta non gestita fa fallire la chiamata', async () => {
+  await assert.rejects(() => axios.get('https://not-mocked.example.com/leak'));
+});
+
+test('server.use con draftsHandler registra comunque la richiesta', async () => {
+  msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+  const err = await axios.post(DRAFTS_URL, {}).catch((e) => e);
+
+  assert.equal(err.response.status, 500);
+  assert.equal(msw.requests.length, 1);
+});
+```
+
+- [ ] **Step 3: Eseguire lo smoke test**
+
+Run: `node --test 'test/helpers/msw-server.smoke.spec.js'`
+Expected: `# pass 3` / `# fail 0`
+
+- [ ] **Step 4: Cancellare lo smoke test**
+
+```bash
+rm test/helpers/msw-server.smoke.spec.js
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/helpers/msw-server.js
+git commit -m "test: add msw server helper with request recording"
+```
+
+---
+
+## Task 4: Unit test di `SubstackPost` — costruttore e serializzazione
+
+**Files:**
+- Create: `src/api/substack/SubstackPost.spec.js`
+
+- [ ] **Step 1: Scrivere i test**
+
+```js
+import {test, describe} from 'node:test';
+import assert from 'node:assert/strict';
+import SubstackPost from './SubstackPost.js';
+
+describe('SubstackPost — costruttore', () => {
+  test('applica i default e converte user_id a intero', () => {
+    const post = new SubstackPost({user_id: '12345'});
+
+    assert.equal(post.draft_title, null);
+    assert.equal(post.draft_subtitle, null);
+    assert.deepEqual(post.draft_body, {type: 'doc', content: []});
+    assert.deepEqual(post.draft_bylines, [{id: 12345, is_guest: false}]);
+    assert.equal(post.audience, 'everyone');
+    assert.equal(post.draft_section_id, null);
+    assert.equal(post.section_chosen, true);
+  });
+
+  test('accetta titolo e sottotitolo dal costruttore', () => {
+    const post = new SubstackPost({user_id: '1', title: 'T', subtitle: 'S'});
+
+    assert.equal(post.draft_title, 'T');
+    assert.equal(post.draft_subtitle, 'S');
+  });
+
+  test('write_comment_permissions segue audience quando non specificato', () => {
+    const post = new SubstackPost({user_id: '1', audience: 'only_paid'});
+
+    assert.equal(post.audience, 'only_paid');
+    assert.equal(post.write_comment_permissions, 'only_paid');
+  });
+
+  test('write_comment_permissions esplicito vince su audience', () => {
+    const post = new SubstackPost({
+      user_id: '1',
+      audience: 'only_paid',
+      write_comment_permissions: 'everyone',
+    });
+
+    assert.equal(post.write_comment_permissions, 'everyone');
+  });
+
+  test('senza subscriber_set_id non imposta subscriber_set_id né type', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    assert.equal(post.subscriber_set_id, undefined);
+    assert.equal(post.type, undefined);
+  });
+
+  test('con subscriber_set_id imposta anche type adhoc_email', () => {
+    const post = new SubstackPost({user_id: '1', subscriber_set_id: 77});
+
+    assert.equal(post.subscriber_set_id, 77);
+    assert.equal(post.type, 'adhoc_email');
+  });
+});
+
+describe('SubstackPost — setter', () => {
+  test('setTitle, setSubtitle e setBody aggiornano lo stato', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.setTitle('Nuovo titolo');
+    post.setSubtitle('Nuovo sottotitolo');
+    post.setBody({type: 'doc', content: [{type: 'paragraph'}]});
+
+    assert.equal(post.draft_title, 'Nuovo titolo');
+    assert.equal(post.draft_subtitle, 'Nuovo sottotitolo');
+    assert.deepEqual(post.draft_body, {type: 'doc', content: [{type: 'paragraph'}]});
+  });
+});
+
+describe('SubstackPost — getDraft', () => {
+  test('serializza draft_body in stringa e conserva le altre proprietà', () => {
+    const post = new SubstackPost({user_id: '42', title: 'T', subtitle: 'S'});
+
+    const draft = post.getDraft();
+
+    assert.equal(draft.draft_title, 'T');
+    assert.equal(draft.draft_subtitle, 'S');
+    assert.deepEqual(draft.draft_bylines, [{id: 42, is_guest: false}]);
+    assert.equal(draft.audience, 'everyone');
+    assert.equal(typeof draft.draft_body, 'string');
+    assert.equal(draft.draft_body, '{"type":"doc","content":[]}');
+  });
+
+  test('non muta l\'istanza', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.getDraft();
+
+    assert.deepEqual(post.draft_body, {type: 'doc', content: []});
+  });
+
+  // CARATTERIZZAZIONE — comportamento corrente, probabile anomalia.
+  // createDraftPostHandler passa una stringa a setBody, quindi getDraft applica
+  // JSON.stringify a una stringa e draft_body finisce doppiamente serializzato.
+  test('setBody con una stringa produce un draft_body doppiamente serializzato', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.setBody('testo semplice');
+
+    assert.equal(post.getDraft().draft_body, '"testo semplice"');
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire i test**
+
+Run: `npm test`
+Expected: `# fail 0`, con 11 test passati. Se il test sul doppio `JSON.stringify` fallisce,
+il sorgente è cambiato: **non modificare `SubstackPost.js`**, verificare cos'è successo.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/substack/SubstackPost.spec.js
+git commit -m "test: cover SubstackPost constructor, setters and getDraft"
+```
+
+---
+
+## Task 5: Unit test di `SubstackPost` — costruzione del contenuto
+
+**Files:**
+- Modify: `src/api/substack/SubstackPost.spec.js`
+
+- [ ] **Step 1: Aggiungere i test in coda al file**
+
+```js
+describe('SubstackPost — blocchi di contenuto', () => {
+  test('paragraph con testo semplice', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph('Ciao');
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'paragraph', content: [{type: 'text', text: 'Ciao'}]},
+    ]);
+  });
+
+  test('paragraph senza argomenti produce un paragrafo vuoto', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph();
+
+    assert.deepEqual(post.draft_body.content, [{type: 'paragraph'}]);
+  });
+
+  test('heading imposta attrs.level', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.heading({content: 'Titolo', level: 2});
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'heading', content: [{type: 'text', text: 'Titolo'}], attrs: {level: 2}},
+    ]);
+  });
+
+  test('heading usa level 1 come default', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.heading({content: 'Titolo'});
+
+    assert.equal(post.draft_body.content[0].attrs.level, 1);
+  });
+
+  test('horizontalRule e paywall', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.horizontalRule();
+    post.paywall();
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'horizontal_rule'},
+      {type: 'paywall'},
+    ]);
+  });
+
+  test('bulletList costruisce list_item annidati', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.bulletList(['uno', 'due']);
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'bullet_list',
+        content: [
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'uno'}]}]},
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'due'}]}]},
+        ],
+      },
+    ]);
+  });
+
+  test('orderedList aggiunge attrs start/order', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.orderedList(['uno']);
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'ordered_list',
+        attrs: {start: 1, order: 1},
+        content: [
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'uno'}]}]},
+        ],
+      },
+    ]);
+  });
+
+  test('bold e italic producono paragrafi con i mark corrispondenti', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.bold('grassetto');
+    post.italic('corsivo');
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'paragraph', content: [{type: 'text', marks: [{type: 'strong'}], text: 'grassetto'}]},
+      {type: 'paragraph', content: [{type: 'text', marks: [{type: 'em'}], text: 'corsivo'}]},
+    ]);
+  });
+
+  test('shareButton, commentButton e customButton', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.shareButton();
+    post.commentButton();
+    post.customButton({url: 'https://example.com', text: 'Vai'});
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'button', attrs: {url: '%%share_url%%', text: 'Share', action: null, class: 'button-wrapper'}},
+      {type: 'button', attrs: {url: '%%half_magic_comments_url%%', text: 'Leave a comment', action: null, class: 'button-wrapper'}},
+      {type: 'button', attrs: {url: 'https://example.com', text: 'Vai', action: null, class: 'button-wrapper'}},
+    ]);
+  });
+
+  test('removeLastParagraph rimuove l\'ultimo blocco', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph('primo');
+    post.paragraph('secondo');
+    post.removeLastParagraph();
+
+    assert.equal(post.draft_body.content.length, 1);
+    assert.deepEqual(post.draft_body.content[0].content, [{type: 'text', text: 'primo'}]);
+  });
+
+  test('captionedImage annida un nodo image2 con i default', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'captionedImage', src: 'https://img.example/a.png'});
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'captionedImage',
+        content: [
+          {
+            type: 'image2',
+            attrs: {
+              src: 'https://img.example/a.png',
+              fullscreen: false,
+              imageSize: 'normal',
+              height: 819,
+              width: 1456,
+              resizeWidth: 728,
+              bytes: null,
+              alt: null,
+              title: null,
+              type: null,
+              href: null,
+              belowTheFold: false,
+              internalRedirect: null,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('SubstackPost — youtubeVideo', () => {
+  const cases = [
+    ['URL youtube.com con parametro v', 'https://www.youtube.com/watch?v=0chZFIZLR_0'],
+    ['URL breve youtu.be', 'https://youtu.be/0chZFIZLR_0?si=-Gp9e_RKG3g1SdVG'],
+    ['ID nudo', '0chZFIZLR_0'],
+  ];
+
+  for (const [label, input] of cases) {
+    test(`estrae il video id da: ${label}`, () => {
+      const post = new SubstackPost({user_id: '1'});
+
+      post.youtubeVideo(input);
+
+      assert.deepEqual(post.draft_body.content, [
+        {type: 'youtube2', attrs: {videoId: '0chZFIZLR_0'}},
+      ]);
+    });
+  }
+});
+
+describe('SubstackPost — testo con mark', () => {
+  test('addComplexText con un array applica i mark per chunk', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph([
+      {content: 'in grassetto', marks: [{type: 'strong'}]},
+      {content: ' e normale'},
+    ]);
+
+    assert.deepEqual(post.draft_body.content[0].content, [
+      {type: 'text', text: 'in grassetto', marks: [{type: 'strong'}]},
+      {type: 'text', text: ' e normale', marks: []},
+    ]);
+  });
+
+  test('un mark link produce attrs.href', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph([
+      {content: 'clicca qui', marks: [{type: 'link', href: 'https://example.com'}]},
+    ]);
+
+    assert.deepEqual(post.draft_body.content[0].content, [
+      {
+        type: 'text',
+        text: 'clicca qui',
+        marks: [{type: 'link', attrs: {href: 'https://example.com'}}],
+      },
+    ]);
+  });
+});
+
+describe('SubstackPost — setSection', () => {
+  test('imposta draft_section_id quando la sezione esiste', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.setSection('News', [{name: 'Altro', id: 1}, {name: 'News', id: 7}]);
+
+    assert.equal(post.draft_section_id, 7);
+  });
+
+  test('lancia quando la sezione non esiste', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    assert.throws(
+      () => post.setSection('Mancante', [{name: 'News', id: 7}]),
+      /Section Mancante does not exist/
+    );
+  });
+});
+
+describe('SubstackPost — subscribeWidget', () => {
+  test('add con subscribeWidget senza messaggio usa il testo di default', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'subscribeWidget'});
+
+    const [node] = post.draft_body.content;
+    assert.equal(node.type, 'subscribeWidget');
+    assert.deepEqual(node.attrs, {url: '%%checkout_url%%', text: 'Subscribe', language: 'en'});
+    assert.equal(node.content[0].type, 'ctaCaption');
+    assert.match(node.content[0].content[0].text, /^Thanks for reading this newsletter!/);
+    assert.match(node.content[0].content[0].text, /Subscribe for free/);
+  });
+
+  test('add con subscribeWidget e messaggio personalizzato', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'subscribeWidget', message: 'Messaggio mio'});
+
+    assert.equal(post.draft_body.content[0].content[0].content[0].text, 'Messaggio mio');
+  });
+
+  // CARATTERIZZAZIONE — comportamento corrente, probabile copia-incolla dal ramo
+  // subscribeWidget: add() con type 'bullet_list' applica la caption di iscrizione
+  // invece di costruire una lista.
+  test('add con bullet_list applica la caption di iscrizione', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'bullet_list', message: 'Messaggio mio'});
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'bullet_list',
+        attrs: {url: '%%checkout_url%%', text: 'Subscribe', language: 'en'},
+        content: [{type: 'ctaCaption', content: [{type: 'text', text: 'Messaggio mio'}]}],
+      },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire i test**
+
+Run: `npm test`
+Expected: `# fail 0`. Il file `SubstackPost.spec.js` ha ora circa 32 test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/substack/SubstackPost.spec.js
+git commit -m "test: cover SubstackPost content builders, marks and sections"
+```
+
+---
+
+## Task 6: Integration test di `SubstackApi`
+
+**Files:**
+- Create: `src/api/substack/SubstackApi.spec.js`
+
+- [ ] **Step 1: Scrivere i test**
+
+```js
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {HttpResponse} from 'msw';
+import SubstackApi from './SubstackApi.js';
+import {createMswServer, DRAFTS_URL, DRAFT_RESPONSE} from '../../../test/helpers/msw-server.js';
+import {TEST_ENV} from '../../../test/helpers/env.js';
+
+const msw = createMswServer();
+
+before(() => msw.start());
+afterEach(() => msw.reset());
+after(() => msw.stop());
+
+function createApi() {
+  return new SubstackApi({
+    publication_url: TEST_ENV.SUBSTACK_PUBLICATION_URL,
+    auth_token: TEST_ENV.SUBSTACK_SESSION_TOKEN,
+  });
+}
+
+describe('SubstackApi — costruttore', () => {
+  test('deriva publication_url e hostname', () => {
+    const api = createApi();
+
+    assert.equal(api.publication_url, 'https://test.substack.com/api/v1');
+    assert.equal(api.hostname, 'https://test.substack.com');
+  });
+
+  test('base_url ha un default su substack.com', () => {
+    const api = createApi();
+
+    assert.equal(api.base_url, 'https://substack.com/api/v1');
+  });
+
+  test('base_url esplicito vince sul default', () => {
+    const api = new SubstackApi({
+      publication_url: TEST_ENV.SUBSTACK_PUBLICATION_URL,
+      auth_token: 'tok',
+      base_url: 'https://custom.example/api/v9',
+    });
+
+    assert.equal(api.base_url, 'https://custom.example/api/v9');
+  });
+
+  test('costruisce il cookie con entrambi i nomi di sessione', () => {
+    const api = createApi();
+
+    assert.equal(
+      api.auth_cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+});
+
+describe('SubstackApi — postDraft', () => {
+  test('invia POST all\'endpoint drafts con header e body corretti', async () => {
+    const api = createApi();
+
+    const result = await api.postDraft({draft_title: 'Titolo', draft_body: '{}'});
+
+    assert.deepEqual(result, DRAFT_RESPONSE);
+    assert.equal(msw.requests.length, 1);
+
+    const [request] = msw.requests;
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, DRAFTS_URL);
+    assert.equal(
+      request.headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+    assert.equal(request.headers.referer, 'https://test.substack.com/publish/post');
+    assert.deepEqual(request.body, {draft_title: 'Titolo', draft_body: '{}'});
+  });
+
+  test('restituisce il payload della risposta', async () => {
+    msw.server.use(
+      msw.draftsHandler(() => HttpResponse.json({id: 42, custom: true}, {status: 201}))
+    );
+
+    const result = await createApi().postDraft({});
+
+    assert.deepEqual(result, {id: 42, custom: true});
+  });
+
+  // CARATTERIZZAZIONE — axios lancia sulle risposte non-2xx prima che handleResponse
+  // possa valutare lo status, quindi il ramo SubstackAPIException è irraggiungibile.
+  test('su 500 lancia un AxiosError, non un SubstackAPIException', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const error = await createApi().postDraft({}).catch((e) => e);
+
+    assert.equal(error.name, 'AxiosError');
+    assert.equal(error.response.status, 500);
+    assert.doesNotMatch(error.message, /SubstackAPIException/);
+  });
+
+  test('su 401 lancia e registra comunque la richiesta', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('unauthorized', {status: 401})));
+
+    const error = await createApi().postDraft({}).catch((e) => e);
+
+    assert.equal(error.response.status, 401);
+    assert.equal(msw.requests.length, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire i test**
+
+Run: `npm test`
+Expected: `# fail 0`, con gli 8 nuovi test di `SubstackApi` in verde.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/substack/SubstackApi.spec.js
+git commit -m "test: cover SubstackApi request shape and error behaviour"
+```
+
+---
+
+## Task 7: Integration test di `createDraftPostHandler`
+
+**Files:**
+- Create: `src/tools/create_draft_post.spec.js`
+
+- [ ] **Step 1: Scrivere i test**
+
+```js
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {createDraftPostHandler, createDraftPostSchema} from './create_draft_post.js';
+import {createMswServer, DRAFTS_URL} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+
+afterEach(() => msw.reset());
+
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const VALID_ARGS = {title: 'Il mio titolo', subtitle: 'Il mio sottotitolo', body: 'Il corpo'};
+
+describe('createDraftPostSchema', () => {
+  test('accetta title, subtitle e body come stringhe', () => {
+    assert.deepEqual(createDraftPostSchema.parse(VALID_ARGS), VALID_ARGS);
+  });
+
+  test('richiede tutti e tre i campi', () => {
+    assert.throws(() => createDraftPostSchema.parse({title: 'solo il titolo'}), z.ZodError);
+  });
+});
+
+describe('createDraftPostHandler — successo', () => {
+  test('restituisce OK', async () => {
+    assert.equal(await createDraftPostHandler(VALID_ARGS), 'OK');
+  });
+
+  test('invia una sola richiesta all\'endpoint drafts', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    assert.equal(msw.requests.length, 1);
+    assert.equal(msw.requests[0].url, DRAFTS_URL);
+  });
+
+  test('mappa gli argomenti sui campi della bozza', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    const {body} = msw.requests[0];
+    assert.equal(body.draft_title, 'Il mio titolo');
+    assert.equal(body.draft_subtitle, 'Il mio sottotitolo');
+    assert.deepEqual(body.draft_bylines, [{id: 12345, is_guest: false}]);
+    assert.equal(body.audience, 'everyone');
+    assert.equal(body.write_comment_permissions, 'everyone');
+    assert.equal(body.section_chosen, true);
+    assert.equal(body.draft_section_id, null);
+  });
+
+  // CARATTERIZZAZIONE — l'handler passa una stringa a setBody, quindi getDraft applica
+  // JSON.stringify a una stringa: draft_body arriva a Substack doppiamente serializzato.
+  test('draft_body arriva doppiamente serializzato', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    assert.equal(msw.requests[0].body.draft_body, '"Il corpo"');
+  });
+
+  test('autentica con il token preso dalle env var', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    assert.equal(
+      msw.requests[0].headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+
+  test('legge le env var a runtime, non all\'import del modulo', async () => {
+    const previous = process.env.SUBSTACK_USER_ID;
+    process.env.SUBSTACK_USER_ID = '99999';
+
+    try {
+      await createDraftPostHandler(VALID_ARGS);
+      assert.deepEqual(msw.requests[0].body.draft_bylines, [{id: 99999, is_guest: false}]);
+    } finally {
+      process.env.SUBSTACK_USER_ID = previous;
+    }
+  });
+});
+
+describe('createDraftPostHandler — errori', () => {
+  test('lancia ZodError sugli argomenti invalidi senza fare richieste', async () => {
+    await assert.rejects(
+      () => createDraftPostHandler({title: 'solo il titolo'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('rifiuta un body che non è una stringa', async () => {
+    await assert.rejects(
+      () => createDraftPostHandler({...VALID_ARGS, body: {type: 'doc'}}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propaga gli errori dell\'API Substack', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const error = await createDraftPostHandler(VALID_ARGS).catch((e) => e);
+
+    assert.equal(error.response.status, 500);
+  });
+});
+```
+
+- [ ] **Step 2: Eseguire i test**
+
+Run: `npm test`
+Expected: `# fail 0`, con gli 11 nuovi test dell'handler in verde.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tools/create_draft_post.spec.js
+git commit -m "test: cover create_draft_post handler end to end"
+```
+
+---
+
+## Task 8: Estrarre `createServer()` e testare il layer MCP
+
+Questo task fa TDD sul refactor: prima l'harness e il test che fallisce perché `src/server.js`
+non esiste, poi il modulo che lo fa passare, infine la riduzione di `index.js`.
+
+**Files:**
+- Create: `test/helpers/mcp-harness.js`
+- Create: `src/server.spec.js`
+- Create: `src/server.js`
+- Modify: `src/index.js`
+
+- [ ] **Step 1: Scrivere l'harness MCP**
+
+```js
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
+import {createServer} from '../../src/server.js';
+
+/**
+ * Collega un Client MCP reale al server di produzione tramite una coppia di transport
+ * in memoria. Restituisce il client e una funzione di chiusura.
+ */
+export async function connectMcpClient() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const server = createServer();
+  const client = new Client({name: 'substack-mcp-test-client', version: '1.0.0'}, {capabilities: {}});
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    async close() {
+      await Promise.all([client.close(), server.close()]);
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Scrivere `src/server.spec.js`**
+
+Nota sulle asserzioni: gli errori arrivano al client come `McpError` con messaggio
+prefissato `MCP error -32603: `, quindi si usa `assert.match` e non `assert.equal`.
+
+```js
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {HttpResponse} from 'msw';
+import {connectMcpClient} from '../test/helpers/mcp-harness.js';
+import {createMswServer, DRAFTS_URL} from '../test/helpers/msw-server.js';
+import {setTestEnv} from '../test/helpers/env.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+
+afterEach(() => msw.reset());
+
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const VALID_ARGS = {title: 'Titolo', subtitle: 'Sottotitolo', body: 'Corpo'};
+
+describe('MCP server — list_tools', () => {
+  test('espone create_draft_post con la sua descrizione', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+
+      assert.equal(tools.length, 1);
+      assert.equal(tools[0].name, 'create_draft_post');
+      assert.equal(tools[0].description, 'create a draft post on your Substack account.');
+    } finally {
+      await close();
+    }
+  });
+
+  test('pubblica un inputSchema con i tre campi obbligatori', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      const {inputSchema} = tools[0];
+
+      assert.equal(inputSchema.type, 'object');
+      assert.deepEqual(Object.keys(inputSchema.properties).sort(), ['body', 'subtitle', 'title']);
+      assert.deepEqual([...inputSchema.required].sort(), ['body', 'subtitle', 'title']);
+      assert.equal(inputSchema.properties.title.type, 'string');
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('MCP server — call_tool', () => {
+  test('esegue il tool e restituisce il risultato serializzato', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const result = await client.callTool({name: 'create_draft_post', arguments: VALID_ARGS});
+
+      assert.deepEqual(result.content, [{type: 'text', text: '"OK"'}]);
+    } finally {
+      await close();
+    }
+  });
+
+  test('la chiamata raggiunge l\'API Substack', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      await client.callTool({name: 'create_draft_post', arguments: VALID_ARGS});
+
+      assert.equal(msw.requests.length, 1);
+      assert.equal(msw.requests[0].url, DRAFTS_URL);
+      assert.equal(msw.requests[0].body.draft_title, 'Titolo');
+    } finally {
+      await close();
+    }
+  });
+
+  test('un tool sconosciuto produce un errore', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const error = await client
+        .callTool({name: 'tool_inesistente', arguments: {}})
+        .catch((e) => e);
+
+      assert.match(error.message, /Unknown tool: tool_inesistente/);
+      assert.equal(msw.requests.length, 0);
+    } finally {
+      await close();
+    }
+  });
+
+  test('argomenti invalidi producono un errore Invalid input con i dettagli Zod', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const error = await client
+        .callTool({name: 'create_draft_post', arguments: {title: 'solo il titolo'}})
+        .catch((e) => e);
+
+      assert.match(error.message, /Invalid input:/);
+      assert.match(error.message, /"path":\["subtitle"\]/);
+      assert.equal(msw.requests.length, 0);
+    } finally {
+      await close();
+    }
+  });
+
+  test('un errore dell\'API Substack si propaga al client', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const error = await client
+        .callTool({name: 'create_draft_post', arguments: VALID_ARGS})
+        .catch((e) => e);
+
+      assert.match(error.message, /500/);
+    } finally {
+      await close();
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Eseguire i test per verificare che falliscano**
+
+Run: `npm test`
+Expected: FAIL — `Cannot find module .../src/server.js`
+
+- [ ] **Step 4: Creare `src/server.js`**
+
+Il registry `tools` sostituisce lo `switch`, così la lista e l'esecuzione restano allineate
+per costruzione. La lookup usa `Object.hasOwn` per non risolvere nomi come `constructor`
+sulla catena dei prototipi.
+
+```js
+import {Server} from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {z} from "zod";
+import {zodToJsonSchema} from "zod-to-json-schema";
+import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
+
+export const tools = {
+  create_draft_post: {
+    description: "create a draft post on your Substack account.",
+    schema: createDraftPostSchema,
+    handler: createDraftPostHandler,
+  },
+};
+
+export function createServer() {
+  const server = new Server({
+      name: "Substack MCP",
+      version: "1.0.0"
+    },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        logging: {}
+      },
+    });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: Object.entries(tools).map(([name, {description, schema}]) => ({
+        name,
+        description,
+        inputSchema: zodToJsonSchema(schema),
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const {name, arguments: args} = request.params;
+
+    try {
+      if (!Object.hasOwn(tools, name)) {
+        throw new Error(`Unknown tool: ${name}`);
+      }
+
+      const result = await tools[name].handler(args);
+
+      return {
+        content: [{type: "text", text: JSON.stringify(result, null, 2)}],
+      };
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`Invalid input: ${JSON.stringify(error.errors)}`);
+      }
+      throw error;
+    }
+  });
+
+  return server;
+}
+```
+
+- [ ] **Step 5: Eseguire i test per verificare che passino**
+
+Run: `npm test`
+Expected: `# fail 0`, con gli 8 test di `server.spec.js` in verde.
+
+- [ ] **Step 6: Ridurre `src/index.js` a entrypoint**
+
+Sostituire l'intero contenuto del file con:
+
+```js
+#!/usr/bin/env node
+
+import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
+import {createServer} from "./server.js";
+
+// check envs
+if (!process.env.SUBSTACK_PUBLICATION_URL || !process.env.SUBSTACK_SESSION_TOKEN || !process.env.SUBSTACK_USER_ID) {
+  throw new Error("SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN and SUBSTACK_USER_ID must be set");
+}
+
+const server = createServer();
+
+const transport = new StdioServerTransport();
+server.connect(transport).catch(() => {
+  process.exit(1);
+});
+```
+
+- [ ] **Step 7: Verificare che il check delle env var funzioni ancora**
+
+Run:
+```bash
+env -u SUBSTACK_PUBLICATION_URL -u SUBSTACK_SESSION_TOKEN -u SUBSTACK_USER_ID node src/index.js 2>&1 | head -5
+```
+Expected: l'errore `SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN and SUBSTACK_USER_ID must be set`
+
+- [ ] **Step 8: Verificare che il server parta davvero con le env var presenti**
+
+Il server resta in ascolto su stdio, quindi lo si avvia e lo si termina dopo un secondo:
+nessun output di errore significa che il boot è andato a buon fine.
+
+```bash
+SUBSTACK_PUBLICATION_URL=https://test.substack.com \
+SUBSTACK_SESSION_TOKEN=tok \
+SUBSTACK_USER_ID=1 \
+timeout 1 node src/index.js; echo "exit=$?"
+```
+Expected: nessuno stack trace; `exit=124` (terminato da `timeout`, quindi era vivo).
+
+- [ ] **Step 9: Eseguire l'intera suite**
+
+Run: `npm test`
+Expected: `# fail 0`
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/server.js src/server.spec.js src/index.js test/helpers/mcp-harness.js
+git commit -m "refactor: extract createServer() and cover the MCP layer with tests"
+```
+
+---
+
+## Task 9: CI e verifica finale
+
+**Files:**
+- Create: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Creare il workflow**
+
+Lo stile segue i workflow esistenti del repo: `actions/checkout@v4` e `actions/setup-node@v4`
+con `node-version-file: '.nvmrc'`.
+
+```yaml
+name: Test
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test
+```
+
+- [ ] **Step 2: Verificare che il workflow sia YAML valido**
+
+Run:
+```bash
+node -e "
+const fs = require('fs');
+const text = fs.readFileSync('.github/workflows/test.yml', 'utf8');
+if (text.includes('\t')) throw new Error('YAML non può contenere tab');
+console.log('workflow leggibile,', text.split('\n').length, 'righe');
+"
+```
+Expected: `workflow leggibile, ...`
+
+- [ ] **Step 3: Eseguire il comando esatto che girerà in CI**
+
+Run: `yarn test`
+Expected: `# fail 0`
+
+- [ ] **Step 4: Verificare la coverage**
+
+Run: `npm run test:coverage`
+Expected: il report elenca `src/api/substack/SubstackPost.js`, `src/api/substack/SubstackApi.js`,
+`src/tools/create_draft_post.js` e `src/server.js`, e **non** elenca alcun file `.spec.js`.
+Annotare le percentuali per il riepilogo finale.
+
+- [ ] **Step 5: Verificare che i test non finiscano nel pacchetto npm**
+
+Run: `npm pack --dry-run 2>&1 | grep -c 'spec.js'`
+Expected: `0`
+
+- [ ] **Step 6: Verificare che i test non finiscano nell'immagine Docker**
+
+Se Docker è disponibile in locale:
+```bash
+docker build -t substack-mcp-test . && docker run --rm --entrypoint sh substack-mcp-test -c "find /opt/src -name '*.spec.js' | wc -l"
+```
+Expected: `0`
+
+Se Docker non è disponibile, verificare almeno che `.dockerignore` copra il pattern:
+```bash
+grep -q '\*\*/\*.spec.js' .dockerignore && echo "pattern presente"
+```
+Expected: `pattern presente`
+
+- [ ] **Step 7: Verificare che nessun test raggiunga la rete reale**
+
+Il vincolo è imposto da `onUnhandledRequest: 'error'`: una richiesta non mockata fa fallire
+il test invece di uscire sulla rete. Come controprova empirica, la durata totale deve restare
+nell'ordine del secondo — una chiamata reale a `substack.com` costerebbe latenza visibile o un
+timeout.
+
+```bash
+npm test 2>&1 | grep -E '^# (duration_ms|pass|fail)'
+```
+Expected: `# fail 0` e `# duration_ms` sotto i 5000 ms.
+
+Controprova aggiuntiva: introdurre temporaneamente in un qualsiasi `.spec.js` una chiamata a
+un host non mockato, verificare che il test **fallisca**, poi rimuoverla.
+
+```js
+// da inserire e poi togliere
+test('controprova: la rete è chiusa', async () => {
+  const axios = (await import('axios')).default;
+  await axios.get('https://substack.com/api/v1/whoami');
+});
+```
+Expected: questo test fallisce con un errore di richiesta non gestita. Rimuoverlo dopo la
+verifica.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: run the test suite on push and pull requests"
+```
+
+---
+
+## Verifica di completamento
+
+Al termine di tutti i task devono valere queste condizioni:
+
+- [ ] `npm test` esce con `# fail 0` e 59 test (32 `SubstackPost` + 8 `SubstackApi` +
+      11 `create_draft_post` + 8 `server`)
+- [ ] `npm run test:coverage` produce un report che non contiene file `.spec.js`
+- [ ] `npm pack --dry-run` non contiene file `.spec.js`
+- [ ] `.dockerignore` esiste e contiene `**/*.spec.js`
+- [ ] `src/index.js` contiene solo il wiring dell'entrypoint
+- [ ] `src/server.js` non ha side-effect all'import (non legge env var, non si connette)
+- [ ] `git status` è pulito
+
+Riportare all'autore, come esito finale:
+
+1. Le percentuali di coverage per file.
+2. Le quattro anomalie elencate nella sezione "Anomalie note" della spec, confermando quali
+   sono ora bloccate da un test di caratterizzazione. Restano da valutare come intervento
+   separato.

--- a/docs/superpowers/specs/2026-08-06-test-suite-design.md
+++ b/docs/superpowers/specs/2026-08-06-test-suite-design.md
@@ -102,19 +102,38 @@ costruzione dell'URL: verifichiamo che `new URL('api/v1', publication_url)` prod
 
 ## Struttura dei file
 
+I test sono **colocati accanto al sorgente** e prendono il nome del file che testano, con
+suffisso `.spec.js`. Il test sta vicino a ciò che verifica: si trova subito e non si dimentica
+di aggiornarlo quando il sorgente cambia. Gli helper condivisi, che non testano nulla di
+specifico, restano in `test/helpers/`.
+
 ```
+src/
+  index.js                          # entrypoint, non testato (solo wiring)
+  server.js
+  server.spec.js                    # integration MCP
+  tools/
+    create_draft_post.js
+    create_draft_post.spec.js       # integration handler
+  api/substack/
+    SubstackApi.js
+    SubstackApi.spec.js             # integration HTTP
+    SubstackPost.js
+    SubstackPost.spec.js            # unit, nessuna rete
 test/
   helpers/
-    msw-server.js        # setupServer + handler di default + cattura delle richieste
-    env.js               # set/restore delle env var di test
-    mcp-harness.js       # coppia Client/Server MCP collegata via InMemoryTransport
-  unit/
-    substack-post.test.js
-  integration/
-    substack-api.test.js
-    create-draft-post.test.js
-    mcp-server.test.js
+    msw-server.js                   # setupServer + handler di default + cattura richieste
+    env.js                          # set/restore delle env var di test
+    mcp-harness.js                  # coppia Client/Server MCP via InMemoryTransport
 ```
+
+### Discovery: serve un glob esplicito
+
+I pattern di default di `node --test` coprono `*.test.js`, `*-test.js`, `*_test.js`,
+`test-*.js` e la cartella `test/`, **ma non `*.spec.js`** (verificato su Node 22: discovery di
+default → 0 test trovati). Gli script npm passano quindi il glob esplicito
+`'src/**/*.spec.js'`, che Node 22 espande nativamente — le virgolette servono a impedire
+l'espansione da parte della shell.
 
 ### `helpers/msw-server.js`
 
@@ -190,15 +209,52 @@ Script in `package.json`:
 
 | Script | Comando |
 |---|---|
-| `test` | `node --test test/` |
-| `test:watch` | `node --test --watch test/` |
-| `test:coverage` | `node --test --experimental-test-coverage test/` |
+| `test` | `node --test 'src/**/*.spec.js'` |
+| `test:watch` | `node --test --watch 'src/**/*.spec.js'` |
+| `test:coverage` | `node --test --experimental-test-coverage --test-coverage-exclude='**/*.spec.js' --test-coverage-exclude='test/**' 'src/**/*.spec.js'` |
 
 `devDependencies`: `msw` `2.15.0` (pin esatto, coerente con lo stile delle dependency
 esistenti).
 
-`package.json` acquisisce `"files": ["src"]` così il pacchetto pubblicato su npm non include
-la suite di test.
+## Esclusione dei test dagli artefatti distribuiti
+
+Con i test colocati in `src/` servono due esclusioni esplicite. Entrambe verificate
+empiricamente.
+
+### Pacchetto npm
+
+`package.json` acquisisce:
+
+```json
+"files": ["src", "!src/**/*.spec.js"]
+```
+
+Il campo `files` è una allowlist, quindi `test/` e `docs/` sono già fuori; il pattern di
+negazione toglie i file di test da `src/`. Verificato con `npm pack --dry-run`: nel tarball
+restano solo i sorgenti.
+
+### Immagine Docker
+
+Il `Dockerfile` fa `COPY ./ /opt` senza filtri e **il repo non ha un `.dockerignore`**: oggi
+l'immagine si porta dentro anche `node_modules` locale, `.git`, `.idea` e `docs/`. Aggiungiamo
+un `.dockerignore`:
+
+```
+node_modules
+**/*.spec.js
+test
+docs
+.git
+.github
+.idea
+.vscode
+.env*
+```
+
+Oltre a escludere i test, questo riduce sensibilmente il contesto di build e la dimensione
+dell'immagine. `msw` resta comunque fuori dal runtime anche senza questo accorgimento, perché
+`yarn install --production` non installa le `devDependencies`; il problema erano solo i file
+dei test.
 
 ### CI
 

--- a/docs/superpowers/specs/2026-08-06-test-suite-design.md
+++ b/docs/superpowers/specs/2026-08-06-test-suite-design.md
@@ -1,0 +1,232 @@
+# Test suite per substack-mcp — Design
+
+Data: 2026-08-06
+Stato: approvato
+
+## Obiettivo
+
+Introdurre una suite di test automatici che protegga `substack-mcp` dalle regressioni nel
+tempo. La suite comprende unit test e integration test. Nessun test deve raggiungere un
+servizio esterno reale: ogni chiamata HTTP in uscita è intercettata e mockata, e una
+richiesta non mockata deve far fallire il test.
+
+I test sono di **caratterizzazione**: bloccano il comportamento *attuale* del codice, non
+quello desiderato. Eventuali anomalie riscontrate vengono documentate nei test e riportate
+all'autore, non corrette in questo intervento.
+
+## Vincoli
+
+- Test runner nativo di Node (`node:test` + `node:assert`), nessun framework di test esterno.
+- Node 22 (`.nvmrc` → `v22.15.0`), progetto ESM (`"type": "module"`).
+- Nessun flag sperimentale richiesto per `npm test` (la coverage resta uno script separato).
+- Unica dipendenza di sviluppo aggiunta: `msw` (v2) per l'intercettazione HTTP.
+
+## Stato di partenza
+
+Quattro file sorgente:
+
+- `src/index.js` — bin dell'MCP server: crea il `Server`, valida le env var, registra gli
+  handler `ListTools` / `CallTool`, si collega a `StdioServerTransport`. Tutto a livello di
+  modulo, quindi il file non è importabile da un test senza side-effect.
+- `src/tools/create_draft_post.js` — schema Zod + handler del tool: valida gli argomenti,
+  legge le env var, costruisce `SubstackApi` e `SubstackPost`, invia la bozza, ritorna `'OK'`.
+- `src/api/substack/SubstackApi.js` — client HTTP su axios; `postDraft` fa `POST` su
+  `<publication_url>/api/v1/drafts` con header `Cookie` e `referer`.
+- `src/api/substack/SubstackPost.js` — builder del documento ProseMirror della bozza, con
+  un'ampia superficie di metodi pubblici.
+
+Non esistono test né workflow CI per i test.
+
+## Refactor di produzione
+
+Il comportamento osservabile dell'MCP server resta invariato. Il refactor serve solo a
+rendere il server testabile.
+
+### `src/server.js` (nuovo)
+
+Esporta `createServer()`, che costruisce il `Server` MCP, registra gli handler delle
+richieste e lo restituisce. Nessun side-effect all'import: nessuna lettura di env var,
+nessuna connessione al transport.
+
+La registrazione dei tool diventa una struttura dati invece di uno `switch`:
+
+```js
+const tools = {
+  create_draft_post: {
+    description: "create a draft post on your Substack account.",
+    schema: createDraftPostSchema,
+    handler: createDraftPostHandler,
+  },
+};
+```
+
+`ListToolsRequestSchema` deriva la lista dei tool da questa mappa (nome, descrizione,
+`zodToJsonSchema(schema)`); `CallToolRequestSchema` risolve l'handler per nome. Lista ed
+esecuzione restano così allineate per costruzione, e aggiungere un tool in futuro non
+richiede di toccare il server. La gestione degli errori è invariata: un `z.ZodError` diventa
+`Invalid input: <dettagli>`, gli altri errori sono propagati; un nome di tool sconosciuto
+produce `Unknown tool: <nome>`.
+
+### `src/index.js` (ridotto a entrypoint)
+
+Mantiene shebang, validazione delle env var (`SUBSTACK_PUBLICATION_URL`,
+`SUBSTACK_SESSION_TOKEN`, `SUBSTACK_USER_ID`), chiamata a `createServer()`, creazione dello
+`StdioServerTransport` e connessione con `process.exit(1)` in caso di errore.
+
+## Strategia di mock: MSW
+
+`msw` v2 con `setupServer` da `msw/node` intercetta a livello dei moduli `http`/`https`,
+quindi axios viene esercitato per intero — costruzione dell'URL, serializzazione del body,
+header, gestione dello status — senza che nessun byte lasci il processo.
+
+Configurazione, applicata a tutti i file di test che toccano la rete:
+
+- `server.listen({ onUnhandledRequest: 'error' })` prima dei test. **Questo è il vincolo
+  centrale del design**: qualsiasi richiesta HTTP in uscita non coperta da un handler fa
+  fallire il test. Il requisito "nessuna chiamata esterna reale" diventa così una proprietà
+  verificata dalla suite, non una convenzione.
+- `server.resetHandlers()` dopo ogni test, così un override non filtra nel test successivo.
+- `server.close()` alla fine del file.
+
+Le env var usate nei test sono realistiche, non locali:
+
+| Variabile | Valore nei test |
+|---|---|
+| `SUBSTACK_PUBLICATION_URL` | `https://test.substack.com` |
+| `SUBSTACK_SESSION_TOKEN` | `test-session-token` |
+| `SUBSTACK_USER_ID` | `12345` |
+
+Usare un host realistico invece di `127.0.0.1:<porta>` rende significativa l'asserzione sulla
+costruzione dell'URL: verifichiamo che `new URL('api/v1', publication_url)` produca davvero
+`https://test.substack.com/api/v1/drafts`.
+
+## Struttura dei file
+
+```
+test/
+  helpers/
+    msw-server.js        # setupServer + handler di default + cattura delle richieste
+    env.js               # set/restore delle env var di test
+    mcp-harness.js       # coppia Client/Server MCP collegata via InMemoryTransport
+  unit/
+    substack-post.test.js
+  integration/
+    substack-api.test.js
+    create-draft-post.test.js
+    mcp-server.test.js
+```
+
+### `helpers/msw-server.js`
+
+Espone il `setupServer` configurato con un handler di default per
+`POST https://test.substack.com/api/v1/drafts` che risponde `200` con un payload di bozza
+plausibile, più un helper `captureRequests()` che registra method, URL, header e body JSON di
+ogni richiesta intercettata, per le asserzioni. I singoli test usano `server.use(...)` per
+programmare risposte diverse (4xx, 5xx, payload specifici).
+
+### `helpers/env.js`
+
+Imposta le env var di test elencate sopra e restituisce una funzione di ripristino, così un
+file di test non altera l'ambiente visto dagli altri.
+
+### `helpers/mcp-harness.js`
+
+Collega un `Client` reale dell'SDK MCP al `createServer()` di produzione tramite
+`InMemoryTransport.createLinkedPair()`. Gli integration test parlano quindi il protocollo MCP
+vero, non una sua imitazione.
+
+## Copertura
+
+### `SubstackPost` — unit, nessuna rete
+
+- Costruttore: default di `audience` (`'everyone'`), `write_comment_permissions` che segue
+  `audience` quando non specificato, `draft_bylines` con `user_id` convertito a intero,
+  `subscriber_set_id` che imposta anche `type: 'adhoc_email'`, valori di default di
+  `draft_section_id` e `section_chosen`.
+- Setter: `setTitle`, `setSubtitle`, `setBody`.
+- `getDraft()`: serializza `draft_body` in stringa JSON e mantiene le altre proprietà.
+- Builder di contenuto: `paragraph`, `heading` con `attrs.level`, `bulletList`, `orderedList`,
+  `bold`, `italic`, `horizontalRule`, `paywall`, `shareButton`, `commentButton`,
+  `customButton`, `captionedImage`, `removeLastParagraph`.
+- `youtubeVideo` nelle tre forme di input: URL `youtube.com/watch?v=…`, URL `youtu.be/…`, ID
+  nudo.
+- `marks`: applicazione di mark semplici e di un mark `link` con `attrs.href`.
+- `addComplexText`: ramo stringa e ramo array di chunk.
+- Errori: `setSection` con un nome che non esiste lancia `Section <name> does not exist`.
+
+### `SubstackApi` — integration con MSW
+
+- `postDraft` invia `POST` a `https://test.substack.com/api/v1/drafts`.
+- Header `Cookie` contiene sia `substack.sid=` sia `connect.sid=` con il token.
+- Header `referer` è `<publication_url>/publish/post`.
+- Il body ricevuto corrisponde alla bozza passata.
+- La risposta 2xx viene restituita al chiamante.
+- Comportamento su 4xx e su 5xx (caratterizzazione: axios lancia prima che
+  `handleResponse` possa valutare lo status).
+- `base_url` di default è `https://substack.com/api/v1` quando non specificato.
+
+### `createDraftPostHandler` — integration con MSW
+
+- Input valido: la richiesta intercettata contiene `draft_title`, `draft_subtitle` e
+  `draft_body` attesi; l'handler ritorna `'OK'`.
+- Le env var sono lette a runtime, non all'import del modulo.
+- Input invalido (campo mancante, tipo sbagliato) lancia un `z.ZodError` senza che parta
+  alcuna richiesta HTTP.
+- Un errore HTTP dell'API viene propagato al chiamante.
+
+### MCP server — integration con `InMemoryTransport` + MSW
+
+- `list_tools` espone `create_draft_post` con la descrizione attesa e un `inputSchema` che
+  contiene le proprietà `title`, `subtitle`, `body` tutte richieste.
+- `call_tool` con argomenti validi esegue la chiamata (verificata su MSW) e ritorna
+  `content: [{type: 'text', text: '"OK"'}]`.
+- `call_tool` con un nome sconosciuto produce un errore `Unknown tool: …`.
+- `call_tool` con argomenti invalidi produce un errore che inizia con `Invalid input:`.
+- Un errore dell'API Substack si propaga come errore del tool.
+
+## Tooling
+
+Script in `package.json`:
+
+| Script | Comando |
+|---|---|
+| `test` | `node --test test/` |
+| `test:watch` | `node --test --watch test/` |
+| `test:coverage` | `node --test --experimental-test-coverage test/` |
+
+`devDependencies`: `msw` `2.15.0` (pin esatto, coerente con lo stile delle dependency
+esistenti).
+
+`package.json` acquisisce `"files": ["src"]` così il pacchetto pubblicato su npm non include
+la suite di test.
+
+### CI
+
+`.github/workflows/test.yml`: su `push` e `pull_request`, su `ubuntu-latest`, con
+`actions/setup-node` configurato via `node-version-file: '.nvmrc'`,
+`yarn install --frozen-lockfile` e `yarn test` (il repo usa yarn come package manager, come
+attesta `yarn.lock`).
+
+## Anomalie note
+
+Riscontrate durante l'analisi, **documentate nei test come comportamento corrente e non
+corrette in questo intervento**. Saranno valutate separatamente:
+
+1. `SubstackPost.add()` — il ramo `item.type === 'bullet_list'` chiama
+   `subscribeWithCaption(item.message)`, presumibilmente per copia-incolla dal ramo
+   `subscribeWidget`.
+2. `SubstackApi.handleResponse()` — il controllo su status non-2xx è irraggiungibile, perché
+   axios lancia già di suo sulle risposte non-2xx. Anche il `try/catch` attorno a
+   `return response.data` non può lanciare.
+3. `createDraftPostHandler` — passa `body` (una stringa) a `setBody`, quindi `getDraft()`
+   applica `JSON.stringify` a una stringa e `draft_body` finisce doppiamente serializzato.
+4. `SubstackPost.customSubscribeButton()` e `addHeader()` contengono testo e URL hardcoded
+   specifici di una pubblicazione ("Quickview", "Crypto Daily Recap"), residui di un uso
+   precedente della classe.
+
+## Fuori scope
+
+- Correzione delle anomalie elencate sopra.
+- Test end-to-end che avviano davvero `src/index.js` in un child process.
+- Soglie di coverage obbligatorie in CI (la coverage resta informativa).
+- Nuovi tool MCP o modifiche funzionali al server.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,15 @@
   "bin": {
     "substack-mcp": "src/index.js"
   },
+  "files": [
+    "src",
+    "!src/**/*.spec.js"
+  ],
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "node --test 'src/**/*.spec.js'",
+    "test:watch": "node --test --watch 'src/**/*.spec.js'",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-exclude='**/*.spec.js' --test-coverage-exclude='test/**' 'src/**/*.spec.js'"
   },
   "repository": {
     "type": "git",
@@ -35,5 +42,8 @@
     "axios": "1.9.0",
     "zod": "3.24.4",
     "zod-to-json-schema": "3.24.5"
+  },
+  "devDependencies": {
+    "msw": "2.15.0"
   }
 }

--- a/src/api/substack/SubstackApi.spec.js
+++ b/src/api/substack/SubstackApi.spec.js
@@ -1,0 +1,105 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {HttpResponse} from 'msw';
+import SubstackApi from './SubstackApi.js';
+import {createMswServer, DRAFTS_URL, DRAFT_RESPONSE} from '../../../test/helpers/msw-server.js';
+import {TEST_ENV} from '../../../test/helpers/env.js';
+
+const msw = createMswServer();
+
+before(() => msw.start());
+afterEach(() => msw.reset());
+after(() => msw.stop());
+
+function createApi() {
+  return new SubstackApi({
+    publication_url: TEST_ENV.SUBSTACK_PUBLICATION_URL,
+    auth_token: TEST_ENV.SUBSTACK_SESSION_TOKEN,
+  });
+}
+
+describe('SubstackApi — costruttore', () => {
+  test('deriva publication_url e hostname', () => {
+    const api = createApi();
+
+    assert.equal(api.publication_url, 'https://test.substack.com/api/v1');
+    assert.equal(api.hostname, 'https://test.substack.com');
+  });
+
+  test('base_url ha un default su substack.com', () => {
+    const api = createApi();
+
+    assert.equal(api.base_url, 'https://substack.com/api/v1');
+  });
+
+  test('base_url esplicito vince sul default', () => {
+    const api = new SubstackApi({
+      publication_url: TEST_ENV.SUBSTACK_PUBLICATION_URL,
+      auth_token: 'tok',
+      base_url: 'https://custom.example/api/v9',
+    });
+
+    assert.equal(api.base_url, 'https://custom.example/api/v9');
+  });
+
+  test('costruisce il cookie con entrambi i nomi di sessione', () => {
+    const api = createApi();
+
+    assert.equal(
+      api.auth_cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+});
+
+describe('SubstackApi — postDraft', () => {
+  test('invia POST all\'endpoint drafts con header e body corretti', async () => {
+    const api = createApi();
+
+    const result = await api.postDraft({draft_title: 'Titolo', draft_body: '{}'});
+
+    assert.deepEqual(result, DRAFT_RESPONSE);
+    assert.equal(msw.requests.length, 1);
+
+    const [request] = msw.requests;
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, DRAFTS_URL);
+    assert.equal(
+      request.headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+    assert.equal(request.headers.referer, 'https://test.substack.com/publish/post');
+    assert.deepEqual(request.body, {draft_title: 'Titolo', draft_body: '{}'});
+  });
+
+  test('restituisce il payload della risposta', async () => {
+    msw.server.use(
+      msw.draftsHandler(() => HttpResponse.json({id: 42, custom: true}, {status: 201}))
+    );
+
+    const result = await createApi().postDraft({});
+
+    assert.deepEqual(result, {id: 42, custom: true});
+  });
+
+  // CARATTERIZZAZIONE — axios lancia sulle risposte non-2xx prima che handleResponse
+  // possa valutare lo status, quindi il ramo SubstackAPIException è irraggiungibile.
+  test('su 500 lancia un AxiosError, non un SubstackAPIException', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const error = await createApi().postDraft({}).catch((e) => e);
+
+    assert.equal(error.name, 'AxiosError');
+    assert.equal(error.response.status, 500);
+    assert.doesNotMatch(error.message, /SubstackAPIException/);
+  });
+
+  test('su 401 lancia e registra comunque la richiesta', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('unauthorized', {status: 401})));
+
+    const error = await createApi().postDraft({}).catch((e) => e);
+
+    assert.equal(error.response.status, 401);
+    assert.equal(msw.requests.length, 1);
+  });
+});

--- a/src/api/substack/SubstackPost.spec.js
+++ b/src/api/substack/SubstackPost.spec.js
@@ -101,3 +101,270 @@ describe('SubstackPost — getDraft', () => {
     assert.equal(post.getDraft().draft_body, '"testo semplice"');
   });
 });
+
+describe('SubstackPost — blocchi di contenuto', () => {
+  test('paragraph con testo semplice', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph('Ciao');
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'paragraph', content: [{type: 'text', text: 'Ciao'}]},
+    ]);
+  });
+
+  test('paragraph senza argomenti produce un paragrafo vuoto', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph();
+
+    assert.deepEqual(post.draft_body.content, [{type: 'paragraph'}]);
+  });
+
+  test('heading imposta attrs.level', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.heading({content: 'Titolo', level: 2});
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'heading', content: [{type: 'text', text: 'Titolo'}], attrs: {level: 2}},
+    ]);
+  });
+
+  test('heading usa level 1 come default', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.heading({content: 'Titolo'});
+
+    assert.equal(post.draft_body.content[0].attrs.level, 1);
+  });
+
+  test('horizontalRule e paywall', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.horizontalRule();
+    post.paywall();
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'horizontal_rule'},
+      {type: 'paywall'},
+    ]);
+  });
+
+  test('bulletList costruisce list_item annidati', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.bulletList(['uno', 'due']);
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'bullet_list',
+        content: [
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'uno'}]}]},
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'due'}]}]},
+        ],
+      },
+    ]);
+  });
+
+  test('orderedList aggiunge attrs start/order', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.orderedList(['uno']);
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'ordered_list',
+        attrs: {start: 1, order: 1},
+        content: [
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'uno'}]}]},
+        ],
+      },
+    ]);
+  });
+
+  test('bold e italic producono paragrafi con i mark corrispondenti', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.bold('grassetto');
+    post.italic('corsivo');
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'paragraph', content: [{type: 'text', marks: [{type: 'strong'}], text: 'grassetto'}]},
+      {type: 'paragraph', content: [{type: 'text', marks: [{type: 'em'}], text: 'corsivo'}]},
+    ]);
+  });
+
+  test('shareButton, commentButton e customButton', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.shareButton();
+    post.commentButton();
+    post.customButton({url: 'https://example.com', text: 'Vai'});
+
+    assert.deepEqual(post.draft_body.content, [
+      {type: 'button', attrs: {url: '%%share_url%%', text: 'Share', action: null, class: 'button-wrapper'}},
+      {type: 'button', attrs: {url: '%%half_magic_comments_url%%', text: 'Leave a comment', action: null, class: 'button-wrapper'}},
+      {type: 'button', attrs: {url: 'https://example.com', text: 'Vai', action: null, class: 'button-wrapper'}},
+    ]);
+  });
+
+  test('removeLastParagraph rimuove l\'ultimo blocco', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph('primo');
+    post.paragraph('secondo');
+    post.removeLastParagraph();
+
+    assert.equal(post.draft_body.content.length, 1);
+    assert.deepEqual(post.draft_body.content[0].content, [{type: 'text', text: 'primo'}]);
+  });
+
+  // CARATTERIZZAZIONE — add() passa l'intero item a captionedImage(), quindi item.type
+  // (il tipo del nodo, 'captionedImage') sovrascrive il default `type = null`
+  // dell'attributo omonimo di image2. Il default è irraggiungibile per questa via, che è
+  // anche l'unica praticabile: chiamare captionedImage() direttamente lancia, perché legge
+  // l'ultimo nodo di draft_body.content, che a quel punto non esiste.
+  test('captionedImage annida un nodo image2 e gli attrs.type ereditano il tipo del nodo', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'captionedImage', src: 'https://img.example/a.png'});
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'captionedImage',
+        content: [
+          {
+            type: 'image2',
+            attrs: {
+              src: 'https://img.example/a.png',
+              fullscreen: false,
+              imageSize: 'normal',
+              height: 819,
+              width: 1456,
+              resizeWidth: 728,
+              bytes: null,
+              alt: null,
+              title: null,
+              type: 'captionedImage',
+              href: null,
+              belowTheFold: false,
+              internalRedirect: null,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('SubstackPost — youtubeVideo', () => {
+  const cases = [
+    ['URL youtube.com con parametro v', 'https://www.youtube.com/watch?v=0chZFIZLR_0'],
+    ['URL breve youtu.be', 'https://youtu.be/0chZFIZLR_0?si=-Gp9e_RKG3g1SdVG'],
+    ['ID nudo', '0chZFIZLR_0'],
+  ];
+
+  for (const [label, input] of cases) {
+    test(`estrae il video id da: ${label}`, () => {
+      const post = new SubstackPost({user_id: '1'});
+
+      post.youtubeVideo(input);
+
+      assert.deepEqual(post.draft_body.content, [
+        {type: 'youtube2', attrs: {videoId: '0chZFIZLR_0'}},
+      ]);
+    });
+  }
+});
+
+describe('SubstackPost — testo con mark', () => {
+  test('addComplexText con un array applica i mark per chunk', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph([
+      {content: 'in grassetto', marks: [{type: 'strong'}]},
+      {content: ' e normale'},
+    ]);
+
+    assert.deepEqual(post.draft_body.content[0].content, [
+      {type: 'text', text: 'in grassetto', marks: [{type: 'strong'}]},
+      {type: 'text', text: ' e normale', marks: []},
+    ]);
+  });
+
+  test('un mark link produce attrs.href', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.paragraph([
+      {content: 'clicca qui', marks: [{type: 'link', href: 'https://example.com'}]},
+    ]);
+
+    assert.deepEqual(post.draft_body.content[0].content, [
+      {
+        type: 'text',
+        text: 'clicca qui',
+        marks: [{type: 'link', attrs: {href: 'https://example.com'}}],
+      },
+    ]);
+  });
+});
+
+describe('SubstackPost — setSection', () => {
+  test('imposta draft_section_id quando la sezione esiste', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.setSection('News', [{name: 'Altro', id: 1}, {name: 'News', id: 7}]);
+
+    assert.equal(post.draft_section_id, 7);
+  });
+
+  test('lancia quando la sezione non esiste', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    assert.throws(
+      () => post.setSection('Mancante', [{name: 'News', id: 7}]),
+      /Section Mancante does not exist/
+    );
+  });
+});
+
+describe('SubstackPost — subscribeWidget', () => {
+  test('add con subscribeWidget senza messaggio usa il testo di default', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'subscribeWidget'});
+
+    const [node] = post.draft_body.content;
+    assert.equal(node.type, 'subscribeWidget');
+    assert.deepEqual(node.attrs, {url: '%%checkout_url%%', text: 'Subscribe', language: 'en'});
+    assert.equal(node.content[0].type, 'ctaCaption');
+    assert.match(node.content[0].content[0].text, /^Thanks for reading this newsletter!/);
+    assert.match(node.content[0].content[0].text, /Subscribe for free/);
+  });
+
+  test('add con subscribeWidget e messaggio personalizzato', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'subscribeWidget', message: 'Messaggio mio'});
+
+    assert.equal(post.draft_body.content[0].content[0].content[0].text, 'Messaggio mio');
+  });
+
+  // CARATTERIZZAZIONE — comportamento corrente, probabile copia-incolla dal ramo
+  // subscribeWidget: add() con type 'bullet_list' applica la caption di iscrizione
+  // invece di costruire una lista.
+  test('add con bullet_list applica la caption di iscrizione', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.add({type: 'bullet_list', message: 'Messaggio mio'});
+
+    assert.deepEqual(post.draft_body.content, [
+      {
+        type: 'bullet_list',
+        attrs: {url: '%%checkout_url%%', text: 'Subscribe', language: 'en'},
+        content: [{type: 'ctaCaption', content: [{type: 'text', text: 'Messaggio mio'}]}],
+      },
+    ]);
+  });
+});

--- a/src/api/substack/SubstackPost.spec.js
+++ b/src/api/substack/SubstackPost.spec.js
@@ -1,0 +1,103 @@
+import {test, describe} from 'node:test';
+import assert from 'node:assert/strict';
+import SubstackPost from './SubstackPost.js';
+
+describe('SubstackPost — costruttore', () => {
+  test('applica i default e converte user_id a intero', () => {
+    const post = new SubstackPost({user_id: '12345'});
+
+    assert.equal(post.draft_title, null);
+    assert.equal(post.draft_subtitle, null);
+    assert.deepEqual(post.draft_body, {type: 'doc', content: []});
+    assert.deepEqual(post.draft_bylines, [{id: 12345, is_guest: false}]);
+    assert.equal(post.audience, 'everyone');
+    assert.equal(post.draft_section_id, null);
+    assert.equal(post.section_chosen, true);
+  });
+
+  test('accetta titolo e sottotitolo dal costruttore', () => {
+    const post = new SubstackPost({user_id: '1', title: 'T', subtitle: 'S'});
+
+    assert.equal(post.draft_title, 'T');
+    assert.equal(post.draft_subtitle, 'S');
+  });
+
+  test('write_comment_permissions segue audience quando non specificato', () => {
+    const post = new SubstackPost({user_id: '1', audience: 'only_paid'});
+
+    assert.equal(post.audience, 'only_paid');
+    assert.equal(post.write_comment_permissions, 'only_paid');
+  });
+
+  test('write_comment_permissions esplicito vince su audience', () => {
+    const post = new SubstackPost({
+      user_id: '1',
+      audience: 'only_paid',
+      write_comment_permissions: 'everyone',
+    });
+
+    assert.equal(post.write_comment_permissions, 'everyone');
+  });
+
+  test('senza subscriber_set_id non imposta subscriber_set_id né type', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    assert.equal(post.subscriber_set_id, undefined);
+    assert.equal(post.type, undefined);
+  });
+
+  test('con subscriber_set_id imposta anche type adhoc_email', () => {
+    const post = new SubstackPost({user_id: '1', subscriber_set_id: 77});
+
+    assert.equal(post.subscriber_set_id, 77);
+    assert.equal(post.type, 'adhoc_email');
+  });
+});
+
+describe('SubstackPost — setter', () => {
+  test('setTitle, setSubtitle e setBody aggiornano lo stato', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.setTitle('Nuovo titolo');
+    post.setSubtitle('Nuovo sottotitolo');
+    post.setBody({type: 'doc', content: [{type: 'paragraph'}]});
+
+    assert.equal(post.draft_title, 'Nuovo titolo');
+    assert.equal(post.draft_subtitle, 'Nuovo sottotitolo');
+    assert.deepEqual(post.draft_body, {type: 'doc', content: [{type: 'paragraph'}]});
+  });
+});
+
+describe('SubstackPost — getDraft', () => {
+  test('serializza draft_body in stringa e conserva le altre proprietà', () => {
+    const post = new SubstackPost({user_id: '42', title: 'T', subtitle: 'S'});
+
+    const draft = post.getDraft();
+
+    assert.equal(draft.draft_title, 'T');
+    assert.equal(draft.draft_subtitle, 'S');
+    assert.deepEqual(draft.draft_bylines, [{id: 42, is_guest: false}]);
+    assert.equal(draft.audience, 'everyone');
+    assert.equal(typeof draft.draft_body, 'string');
+    assert.equal(draft.draft_body, '{"type":"doc","content":[]}');
+  });
+
+  test('non muta l\'istanza', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.getDraft();
+
+    assert.deepEqual(post.draft_body, {type: 'doc', content: []});
+  });
+
+  // CARATTERIZZAZIONE — comportamento corrente, probabile anomalia.
+  // createDraftPostHandler passa una stringa a setBody, quindi getDraft applica
+  // JSON.stringify a una stringa e draft_body finisce doppiamente serializzato.
+  test('setBody con una stringa produce un draft_body doppiamente serializzato', () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    post.setBody('testo semplice');
+
+    assert.equal(post.getDraft().draft_body, '"testo semplice"');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,68 +1,14 @@
 #!/usr/bin/env node
 
-import {Server} from "@modelcontextprotocol/sdk/server/index.js";
 import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import {z} from "zod";
-import {zodToJsonSchema} from "zod-to-json-schema";
-import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
-
-// Create an MCP server
-const server = new Server({
-    name: "Substack MCP",
-    version: "1.0.0"
-  },
-  {
-    capabilities: {
-      tools: {},
-      resources: {},
-      logging: {}
-    },
-  });
+import {createServer} from "./server.js";
 
 // check envs
 if (!process.env.SUBSTACK_PUBLICATION_URL || !process.env.SUBSTACK_SESSION_TOKEN || !process.env.SUBSTACK_USER_ID) {
   throw new Error("SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN and SUBSTACK_USER_ID must be set");
 }
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: "create_draft_post",
-        description:
-          "create a draft post on your Substack account.",
-        inputSchema: zodToJsonSchema(createDraftPostSchema),
-      }
-    ],
-  };
-});
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const {name, arguments: args} = request.params;
-
-  try {
-    switch (name) {
-      case "create_draft_post": {
-        const result = await createDraftPostHandler(args);
-        return {
-          content: [{type: "text", text: JSON.stringify(result, null, 2)}],
-        };
-      }
-      default:
-        throw new Error(`Unknown tool: ${name}`);
-    }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new Error(`Invalid input: ${JSON.stringify(error.errors)}`);
-    }
-    throw error;
-  }
-});
-
+const server = createServer();
 
 const transport = new StdioServerTransport();
 server.connect(transport).catch(() => {

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,63 @@
+import {Server} from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {z} from "zod";
+import {zodToJsonSchema} from "zod-to-json-schema";
+import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
+
+export const tools = {
+  create_draft_post: {
+    description: "create a draft post on your Substack account.",
+    schema: createDraftPostSchema,
+    handler: createDraftPostHandler,
+  },
+};
+
+export function createServer() {
+  const server = new Server({
+      name: "Substack MCP",
+      version: "1.0.0"
+    },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        logging: {}
+      },
+    });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: Object.entries(tools).map(([name, {description, schema}]) => ({
+        name,
+        description,
+        inputSchema: zodToJsonSchema(schema),
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const {name, arguments: args} = request.params;
+
+    try {
+      if (!Object.hasOwn(tools, name)) {
+        throw new Error(`Unknown tool: ${name}`);
+      }
+
+      const result = await tools[name].handler(args);
+
+      return {
+        content: [{type: "text", text: JSON.stringify(result, null, 2)}],
+      };
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`Invalid input: ${JSON.stringify(error.errors)}`);
+      }
+      throw error;
+    }
+  });
+
+  return server;
+}

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -1,0 +1,130 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {HttpResponse} from 'msw';
+import {connectMcpClient} from '../test/helpers/mcp-harness.js';
+import {createMswServer, DRAFTS_URL} from '../test/helpers/msw-server.js';
+import {setTestEnv} from '../test/helpers/env.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+
+afterEach(() => msw.reset());
+
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const VALID_ARGS = {title: 'Titolo', subtitle: 'Sottotitolo', body: 'Corpo'};
+
+describe('MCP server — list_tools', () => {
+  test('espone create_draft_post con la sua descrizione', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+
+      assert.equal(tools.length, 1);
+      assert.equal(tools[0].name, 'create_draft_post');
+      assert.equal(tools[0].description, 'create a draft post on your Substack account.');
+    } finally {
+      await close();
+    }
+  });
+
+  test('pubblica un inputSchema con i tre campi obbligatori', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      const {inputSchema} = tools[0];
+
+      assert.equal(inputSchema.type, 'object');
+      assert.deepEqual(Object.keys(inputSchema.properties).sort(), ['body', 'subtitle', 'title']);
+      assert.deepEqual([...inputSchema.required].sort(), ['body', 'subtitle', 'title']);
+      assert.equal(inputSchema.properties.title.type, 'string');
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('MCP server — call_tool', () => {
+  test('esegue il tool e restituisce il risultato serializzato', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const result = await client.callTool({name: 'create_draft_post', arguments: VALID_ARGS});
+
+      assert.deepEqual(result.content, [{type: 'text', text: '"OK"'}]);
+    } finally {
+      await close();
+    }
+  });
+
+  test('la chiamata raggiunge l\'API Substack', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      await client.callTool({name: 'create_draft_post', arguments: VALID_ARGS});
+
+      assert.equal(msw.requests.length, 1);
+      assert.equal(msw.requests[0].url, DRAFTS_URL);
+      assert.equal(msw.requests[0].body.draft_title, 'Titolo');
+    } finally {
+      await close();
+    }
+  });
+
+  test('un tool sconosciuto produce un errore', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const error = await client
+        .callTool({name: 'tool_inesistente', arguments: {}})
+        .catch((e) => e);
+
+      assert.match(error.message, /Unknown tool: tool_inesistente/);
+      assert.equal(msw.requests.length, 0);
+    } finally {
+      await close();
+    }
+  });
+
+  test('argomenti invalidi producono un errore Invalid input con i dettagli Zod', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const error = await client
+        .callTool({name: 'create_draft_post', arguments: {title: 'solo il titolo'}})
+        .catch((e) => e);
+
+      assert.match(error.message, /Invalid input:/);
+      assert.match(error.message, /"path":\["subtitle"\]/);
+      assert.equal(msw.requests.length, 0);
+    } finally {
+      await close();
+    }
+  });
+
+  test('un errore dell\'API Substack si propaga al client', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const error = await client
+        .callTool({name: 'create_draft_post', arguments: VALID_ARGS})
+        .catch((e) => e);
+
+      assert.match(error.message, /500/);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/tools/create_draft_post.spec.js
+++ b/src/tools/create_draft_post.spec.js
@@ -1,0 +1,117 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {createDraftPostHandler, createDraftPostSchema} from './create_draft_post.js';
+import {createMswServer, DRAFTS_URL} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+
+afterEach(() => msw.reset());
+
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const VALID_ARGS = {title: 'Il mio titolo', subtitle: 'Il mio sottotitolo', body: 'Il corpo'};
+
+describe('createDraftPostSchema', () => {
+  test('accetta title, subtitle e body come stringhe', () => {
+    assert.deepEqual(createDraftPostSchema.parse(VALID_ARGS), VALID_ARGS);
+  });
+
+  test('richiede tutti e tre i campi', () => {
+    assert.throws(() => createDraftPostSchema.parse({title: 'solo il titolo'}), z.ZodError);
+  });
+});
+
+describe('createDraftPostHandler — successo', () => {
+  test('restituisce OK', async () => {
+    assert.equal(await createDraftPostHandler(VALID_ARGS), 'OK');
+  });
+
+  test('invia una sola richiesta all\'endpoint drafts', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    assert.equal(msw.requests.length, 1);
+    assert.equal(msw.requests[0].url, DRAFTS_URL);
+  });
+
+  test('mappa gli argomenti sui campi della bozza', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    const {body} = msw.requests[0];
+    assert.equal(body.draft_title, 'Il mio titolo');
+    assert.equal(body.draft_subtitle, 'Il mio sottotitolo');
+    assert.deepEqual(body.draft_bylines, [{id: 12345, is_guest: false}]);
+    assert.equal(body.audience, 'everyone');
+    assert.equal(body.write_comment_permissions, 'everyone');
+    assert.equal(body.section_chosen, true);
+    assert.equal(body.draft_section_id, null);
+  });
+
+  // CARATTERIZZAZIONE — l'handler passa una stringa a setBody, quindi getDraft applica
+  // JSON.stringify a una stringa: draft_body arriva a Substack doppiamente serializzato.
+  test('draft_body arriva doppiamente serializzato', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    assert.equal(msw.requests[0].body.draft_body, '"Il corpo"');
+  });
+
+  test('autentica con il token preso dalle env var', async () => {
+    await createDraftPostHandler(VALID_ARGS);
+
+    assert.equal(
+      msw.requests[0].headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+
+  test('legge le env var a runtime, non all\'import del modulo', async () => {
+    const previous = process.env.SUBSTACK_USER_ID;
+    process.env.SUBSTACK_USER_ID = '99999';
+
+    try {
+      await createDraftPostHandler(VALID_ARGS);
+      assert.deepEqual(msw.requests[0].body.draft_bylines, [{id: 99999, is_guest: false}]);
+    } finally {
+      process.env.SUBSTACK_USER_ID = previous;
+    }
+  });
+});
+
+describe('createDraftPostHandler — errori', () => {
+  test('lancia ZodError sugli argomenti invalidi senza fare richieste', async () => {
+    await assert.rejects(
+      () => createDraftPostHandler({title: 'solo il titolo'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('rifiuta un body che non è una stringa', async () => {
+    await assert.rejects(
+      () => createDraftPostHandler({...VALID_ARGS, body: {type: 'doc'}}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propaga gli errori dell\'API Substack', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const error = await createDraftPostHandler(VALID_ARGS).catch((e) => e);
+
+    assert.equal(error.response.status, 500);
+  });
+});

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -1,0 +1,29 @@
+export const TEST_ENV = {
+  SUBSTACK_PUBLICATION_URL: 'https://test.substack.com',
+  SUBSTACK_SESSION_TOKEN: 'test-session-token',
+  SUBSTACK_USER_ID: '12345',
+};
+
+/**
+ * Imposta le env var di test e restituisce una funzione che ripristina i valori precedenti,
+ * così un file di test non altera l'ambiente visto dagli altri.
+ */
+export function setTestEnv(overrides = {}) {
+  const values = {...TEST_ENV, ...overrides};
+  const saved = {};
+
+  for (const key of Object.keys(values)) {
+    saved[key] = process.env[key];
+    process.env[key] = values[key];
+  }
+
+  return function restoreEnv() {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}

--- a/test/helpers/mcp-harness.js
+++ b/test/helpers/mcp-harness.js
@@ -1,0 +1,26 @@
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
+import {createServer} from '../../src/server.js';
+
+/**
+ * Collega un Client MCP reale al server di produzione tramite una coppia di transport
+ * in memoria. Restituisce il client e una funzione di chiusura.
+ */
+export async function connectMcpClient() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const server = createServer();
+  const client = new Client({name: 'substack-mcp-test-client', version: '1.0.0'}, {capabilities: {}});
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    async close() {
+      await Promise.all([client.close(), server.close()]);
+    },
+  };
+}

--- a/test/helpers/msw-server.js
+++ b/test/helpers/msw-server.js
@@ -1,0 +1,69 @@
+import {setupServer} from 'msw/node';
+import {http, HttpResponse} from 'msw';
+import {TEST_ENV} from './env.js';
+
+export const DRAFTS_URL = `${TEST_ENV.SUBSTACK_PUBLICATION_URL}/api/v1/drafts`;
+
+export const DRAFT_RESPONSE = {
+  id: 167712345,
+  draft_title: 'Test title',
+  draft_subtitle: 'Test subtitle',
+  is_published: false,
+};
+
+/**
+ * Crea il server MSW usato dagli integration test.
+ *
+ * `requests` accumula ogni richiesta intercettata: {method, url, headers, body}.
+ * `draftsHandler(responder)` costruisce un handler per POST /drafts che registra la
+ * richiesta e poi delega la risposta a `responder`. Usalo anche negli override via
+ * `server.use()`, altrimenti quella richiesta non finisce nel registro.
+ */
+export function createMswServer() {
+  const requests = [];
+
+  async function record(request) {
+    const raw = await request.clone().text();
+
+    let body;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      body = raw;
+    }
+
+    requests.push({
+      method: request.method,
+      url: request.url,
+      headers: Object.fromEntries(request.headers.entries()),
+      body,
+    });
+  }
+
+  function draftsHandler(responder) {
+    return http.post(DRAFTS_URL, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
+  const server = setupServer(
+    draftsHandler(() => HttpResponse.json(DRAFT_RESPONSE, {status: 200}))
+  );
+
+  return {
+    server,
+    requests,
+    draftsHandler,
+    start() {
+      server.listen({onUnhandledRequest: 'error'});
+    },
+    reset() {
+      server.resetHandlers();
+      requests.length = 0;
+    },
+    stop() {
+      server.close();
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,42 @@
 # yarn lockfile v1
 
 
+"@inquirer/ansi@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.7.tgz#86de22810cac3ed406ec10f8d66016815b8226b4"
+  integrity sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==
+
+"@inquirer/confirm@^6.0.11":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.1.1.tgz#9c6a7d79c6132b2af57fdb75747f056204e55356"
+  integrity sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
+
+"@inquirer/core@^11.2.1":
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-11.2.1.tgz#54ccd8f7d47852140b6066cbd77d63b2c2b168fd"
+  integrity sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/figures" "^2.0.7"
+    "@inquirer/type" "^4.0.7"
+    cli-width "^4.1.0"
+    fast-wrap-ansi "^0.2.0"
+    mute-stream "^3.0.0"
+    signal-exit "^4.1.0"
+
+"@inquirer/figures@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.7.tgz#f5cc5843732a81304d06a0db4b53cc7dbda15541"
+  integrity sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==
+
+"@inquirer/type@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.7.tgz#9c6f0d857fe6ad549a3a932343b64e76acb34b10"
+  integrity sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==
+
 "@modelcontextprotocol/sdk@1.11.2":
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.11.2.tgz#d81784c140d1a9cc937f61af9f071d8b78befe30"
@@ -18,6 +54,60 @@
     zod "^3.23.8"
     zod-to-json-schema "^3.24.1"
 
+"@mswjs/interceptors@^0.41.3":
+  version "0.41.9"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.41.9.tgz#9d90bbd60d1ddc30dbcbb827a9bb2e470493530d"
+  integrity sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
+
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/deferred-promise@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz#9725acc5afe8ecde690e9e198a094859fdbf2e45"
+  integrity sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
+
+"@types/node@*":
+  version "26.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.2.tgz#da79708f1f9c6294f4cdec8f455a3032b028808a"
+  integrity sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==
+  dependencies:
+    undici-types "~8.3.0"
+
+"@types/set-cookie-parser@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz#ad3a807d6d921db9720621ea3374c5d92020bcbc"
+  integrity sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/statuses@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.6.tgz#66748315cc9a96d63403baa8671b2c124f8633aa"
+  integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
+
 accepts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
@@ -25,6 +115,18 @@ accepts@^2.0.0:
   dependencies:
     mime-types "^3.0.0"
     negotiator "^1.0.0"
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -76,6 +178,32 @@ call-bound@^1.0.2:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -104,6 +232,11 @@ cookie@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cookie@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -153,6 +286,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 encodeurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
@@ -184,6 +322,11 @@ es-set-tostringtag@^2.1.0:
     get-intrinsic "^1.2.6"
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
+
+escalade@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-html@^1.0.3:
   version "1.0.3"
@@ -245,6 +388,25 @@ express@^5.0.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
+fast-string-truncated-width@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz#23afe0da67d752ca0727538f1e6967759728ce49"
+  integrity sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==
+
+fast-string-width@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-string-width/-/fast-string-width-3.0.2.tgz#16dbabb491ce5585b5ecb675b65c165d71688eeb"
+  integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
+  dependencies:
+    fast-string-truncated-width "^3.0.2"
+
+fast-wrap-ansi@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz#95e952a0145bce3f59ad56e179f84c48d4072935"
+  integrity sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==
+  dependencies:
+    fast-string-width "^3.0.2"
+
 finalhandler@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.0.tgz#72306373aa89d05a8242ed569ed86a1bff7c561f"
@@ -287,6 +449,11 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
@@ -316,6 +483,11 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
+graphql@^16.13.2:
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.2.tgz#83faf25869e3df727cc855161db5da85b0e5b2c0"
+  integrity sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==
+
 has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
@@ -334,6 +506,14 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+headers-polyfill@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-5.0.1.tgz#9554eb2892b666db1c7a3380a91b6cfd467a6b19"
+  integrity sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.10"
+    set-cookie-parser "^3.0.1"
 
 http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
@@ -362,6 +542,16 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-promise@^4.0.0:
   version "4.0.0"
@@ -417,6 +607,35 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-2.15.0.tgz#4028ba3d887af8c166d45aa3bf37116f73f21cec"
+  integrity sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==
+  dependencies:
+    "@inquirer/confirm" "^6.0.11"
+    "@mswjs/interceptors" "^0.41.3"
+    "@open-draft/deferred-promise" "^3.0.0"
+    "@types/statuses" "^2.0.6"
+    cookie "^1.1.1"
+    graphql "^16.13.2"
+    headers-polyfill "^5.0.1"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    rettime "^0.11.11"
+    statuses "^2.0.2"
+    strict-event-emitter "^0.5.1"
+    tough-cookie "^6.0.1"
+    type-fest "^5.5.0"
+    until-async "^3.0.2"
+    yargs "^17.7.2"
+
+mute-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-3.0.0.tgz#cd8014dd2acb72e1e91bb67c74f0019e620ba2d1"
+  integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
+
 negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
@@ -446,6 +665,11 @@ once@^1.4.0:
   dependencies:
     wrappy "1"
 
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
 parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -456,10 +680,20 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+
 path-to-regexp@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
   integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 pkce-challenge@^5.0.0:
   version "5.0.0"
@@ -500,6 +734,16 @@ raw-body@^3.0.0:
     http-errors "2.0.0"
     iconv-lite "0.6.3"
     unpipe "1.0.0"
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+rettime@^0.11.11:
+  version "0.11.11"
+  resolved "https://registry.yarnpkg.com/rettime/-/rettime-0.11.11.tgz#fe8fb192e1877bb0080fc1a640cb08eededd7d12"
+  integrity sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==
 
 router@^2.2.0:
   version "2.2.0"
@@ -548,6 +792,11 @@ serve-static@^2.2.0:
     escape-html "^1.0.3"
     parseurl "^1.3.3"
     send "^1.2.0"
+
+set-cookie-parser@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz#f4e490298759d756a68eabcbcd0fc9261ad0fee0"
+  integrity sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -606,15 +855,77 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 statuses@2.0.1, statuses@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+statuses@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
+
+tldts-core@^7.4.10:
+  version "7.4.10"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.4.10.tgz#33b31839bc37e8283f97d8b5741aa665691701f0"
+  integrity sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==
+
+tldts@^7.0.5:
+  version "7.4.10"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.4.10.tgz#c1f2804bb028062ae5345cb0adb129cd50f94471"
+  integrity sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==
+  dependencies:
+    tldts-core "^7.4.10"
+
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tough-cookie@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.2.tgz#7b1f22fcf2daf06c4ff9d53ec1845f44c6627062"
+  integrity sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==
+  dependencies:
+    tldts "^7.0.5"
+
+type-fest@^5.5.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.8.0.tgz#6d517998257c33159db4d4da6f18efa33bd47df3"
+  integrity sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 type-is@^2.0.0, type-is@^2.0.1:
   version "2.0.1"
@@ -625,10 +936,20 @@ type-is@^2.0.0, type-is@^2.0.1:
     media-typer "^1.1.0"
     mime-types "^3.0.0"
 
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
+
 unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+until-async@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/until-async/-/until-async-3.0.2.tgz#447f1531fdd7bb2b4c7a98869bdb1a4c2a23865f"
+  integrity sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -642,10 +963,42 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 zod-to-json-schema@3.24.5, zod-to-json-schema@^3.24.1:
   version "3.24.5"


### PR DESCRIPTION
## Cosa cambia

Introduce una suite di test per proteggere il progetto dalle regressioni. 57 test, unit e integration, con il test runner nativo di Node. **Nessun test raggiunge un servizio esterno reale.**

- **57 test** in 4 file `.spec.js` colocati accanto ai sorgenti
- **MSW** intercetta tutto il traffico HTTP in uscita
- **`createServer()`** estratto in `src/server.js` per rendere testabile il layer MCP
- **CI** su push e pull request
- I test sono esclusi da tarball npm e immagine Docker

Spec e piano: [`docs/superpowers/specs/2026-08-06-test-suite-design.md`](docs/superpowers/specs/2026-08-06-test-suite-design.md), [`docs/superpowers/plans/2026-08-06-test-suite.md`](docs/superpowers/plans/2026-08-06-test-suite.md)

## Perché MSW e non un server locale

`onUnhandledRequest: 'error'` fa fallire il test su **qualsiasi** richiesta HTTP non coperta da un handler. Il requisito "nessuna chiamata esterna reale" diventa una proprietà verificata dalla suite invece di una convenzione che si può violare per distrazione fra sei mesi.

Verificato con una controprova: aggiungendo temporaneamente una `axios.get('https://substack.com/...')` non mockata, il test fallisce con `[MSW] intercepted a request without a matching request handler`.

## Il refactor di `src/index.js`

`src/index.js` eseguiva tutto a livello di modulo (check env + connessione stdio), quindi non era importabile da un test. Ora:

- `src/server.js` esporta `createServer()`, senza side-effect all'import
- `src/index.js` resta il solo entrypoint (16 righe): check env, factory, connessione stdio
- Il registry dei tool sostituisce lo `switch`, così `list_tools` e `call_tool` restano allineati per costruzione

**Il comportamento esterno è invariato.** Verificato eseguendo lo stesso probe JSON-RPC su stdio contro la versione prima e dopo il refactor: output **identico byte per byte**, incluso il caso di tool sconosciuto.

## Test di caratterizzazione

I test bloccano il comportamento **attuale**, non quello desiderato. Alcuni documentano esplicitamente delle anomalie (marcati `CARATTERIZZAZIONE` nel codice) — non sono state corrette qui, per tenere separato "aggiungere rete di sicurezza" da "cambiare comportamento":

1. `SubstackPost.add()` con `bullet_list` applica la caption di iscrizione invece di costruire una lista (probabile copia-incolla dal ramo `subscribeWidget`)
2. `SubstackApi.handleResponse()` ha un ramo non-2xx irraggiungibile: axios lancia prima. **Confermato dalla coverage**: le uniche righe scoperte del file sono esattamente quelle
3. `createDraftPostHandler` passa una stringa a `setBody`, quindi `draft_body` arriva a Substack doppiamente serializzato (`'"testo"'`)
4. `captionedImage` — `add()` passa l'intero `item` al metodo, quindi `item.type` sovrascrive il default `type = null` dell'attributo omonimo di `image2`. Il default è irraggiungibile

## Packaging

Con i test colocati in `src/` servono due esclusioni, entrambe verificate:

- **npm**: `"files": ["src", "!src/**/*.spec.js"]` — confermato con `npm pack --dry-run`
- **Docker**: il repo **non aveva un `.dockerignore`**, quindi `COPY ./ /opt` copiava dentro l'immagine anche `node_modules` locale, `.git`, `.idea` e `docs/`. Ora escluso il necessario; build reale verificata: 0 spec, `msw` assente, e l'immagine risponde ancora correttamente al protocollo MCP

## Note per chi revisiona

- `node --test` **non** scopre i `.spec.js` con i pattern di default, per questo gli script passano il glob esplicito `'src/**/*.spec.js'`
- Gli errori MCP arrivano al client come `McpError` prefissati `MCP error -32603:`, per questo le asserzioni sui messaggi usano `assert.match`
- Coverage: `server.js` e `create_draft_post.js` al 100%, `SubstackApi.js` al 90.70%, `SubstackPost.js` al 49.59% — quest'ultimo perché `addHeader`/`becamePremiumMember`/`addFooter` contengono testi hardcoded specifici di un'altra pubblicazione ("Quickview", "Crypto Daily Recap") e sono stati lasciati fuori scope. Branch coverage complessivo 94%

## Come verificare

```bash
yarn test
yarn test:coverage
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)