### PR TITLE
Replace axios with native fetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ literals (`{a: 1}`, not `{ a: 1 }`).
   arrives as `text: '"OK"'` — quotes included.
 - **`SubstackPost.getDraft()` calls `JSON.stringify` on `draft_body`**, so it must be handed an
   object. Passing a string double-encodes it; this was a real bug (#4).
+- **HTTP goes through native `fetch`** — no HTTP client dependency. `fetch` does not reject on
+  non-2xx, so `SubstackApi.handleResponse` is what turns a failing status into an error
+  (`SubstackAPIException: <status> <statusText>`); it also serializes the body and sets
+  `Content-Type` by hand, which axios used to do implicitly.
 
 ## Verifying the server actually works
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # CLAUDE.md
 
-MCP server exposing Substack automation to LLM clients. Node 22 (`.nvmrc`), ESM, npm.
+MCP server exposing Substack automation to LLM clients. ESM, npm. Development and CI run on
+Node 22 (`.nvmrc`, `Dockerfile`); `engines` declares `>=18`, the floor imposed by native
+`fetch` — do not use APIs newer than that in `src/`.
 
 ## Language
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.11.2",
-        "axios": "1.9.0",
         "zod": "3.24.4",
         "zod-to-json-schema": "3.24.5"
       },
@@ -245,23 +244,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -365,18 +347,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -465,15 +435,6 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -544,21 +505,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -720,62 +666,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -877,21 +767,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1227,12 +1102,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "email": "marcomoauro@hotmail.it"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.11.2",
     "zod": "3.24.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.11.2",
-    "axios": "1.9.0",
     "zod": "3.24.4",
     "zod-to-json-schema": "3.24.5"
   },

--- a/src/api/substack/SubstackApi.js
+++ b/src/api/substack/SubstackApi.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 export default class SubstackApi {
   constructor({
                 email = null,
@@ -14,19 +12,19 @@ export default class SubstackApi {
     this.publication_url = new URL('api/v1', publication_url).toString();
     this.hostname = publication_url
     this.auth_cookie = `substack.sid=${auth_token}; connect.sid=${auth_token};`
-
-    this.session = axios;
   }
 
-  static handleResponse(response) {
-    if (!(response.status >= 200 && response.status < 300)) {
+  static async handleResponse(response) {
+    if (!response.ok) {
       throw new Error(`SubstackAPIException: ${response.status} ${response.statusText}`);
     }
 
+    const text = await response.text();
+
     try {
-      return response.data;
+      return JSON.parse(text);
     } catch (error) {
-      throw new Error(`SubstackRequestException: Invalid Response: ${response.data}`);
+      throw new Error(`SubstackRequestException: Invalid Response: ${text}`);
     }
   }
 
@@ -34,10 +32,11 @@ export default class SubstackApi {
     const url = `${this.publication_url}/drafts`;
 
     const headers = {};
+    headers['Content-Type'] = 'application/json';
     headers['Cookie'] = this.auth_cookie;
     headers['referer'] = `${this.hostname}/publish/post`;
 
-    const response = await this.session.post(url, body, {headers})
+    const response = await fetch(url, {method: 'POST', headers, body: JSON.stringify(body)});
     return SubstackApi.handleResponse(response)
   }
 }

--- a/src/api/substack/SubstackApi.spec.js
+++ b/src/api/substack/SubstackApi.spec.js
@@ -69,6 +69,7 @@ describe('SubstackApi — postDraft', () => {
       'substack.sid=test-session-token; connect.sid=test-session-token;'
     );
     assert.equal(request.headers.referer, 'https://test.substack.com/publish/post');
+    assert.match(request.headers['content-type'], /^application\/json/);
     assert.deepEqual(request.body, {draft_title: 'Title', draft_body: '{}'});
   });
 
@@ -82,16 +83,15 @@ describe('SubstackApi — postDraft', () => {
     assert.deepEqual(result, {id: 42, custom: true});
   });
 
-  // CHARACTERIZATION — axios throws on non-2xx responses before handleResponse gets to
-  // evaluate the status, so the SubstackAPIException branch is unreachable.
-  test('throws an AxiosError on 500, not a SubstackAPIException', async () => {
+  // fetch does not throw on non-2xx, so handleResponse is the one deciding: the
+  // SubstackAPIException branch is now the actual error path. Under axios this test
+  // asserted an AxiosError carrying `response.status` instead.
+  test('throws a SubstackAPIException on 500', async () => {
     msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
 
     const error = await createApi().postDraft({}).catch((e) => e);
 
-    assert.equal(error.name, 'AxiosError');
-    assert.equal(error.response.status, 500);
-    assert.doesNotMatch(error.message, /SubstackAPIException/);
+    assert.match(error.message, /^SubstackAPIException: 500\b/);
   });
 
   test('throws on 401 and still records the request', async () => {
@@ -99,7 +99,15 @@ describe('SubstackApi — postDraft', () => {
 
     const error = await createApi().postDraft({}).catch((e) => e);
 
-    assert.equal(error.response.status, 401);
+    assert.match(error.message, /^SubstackAPIException: 401\b/);
     assert.equal(msw.requests.length, 1);
+  });
+
+  test('throws a SubstackRequestException when a 2xx body is not JSON', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('not json', {status: 200})));
+
+    const error = await createApi().postDraft({}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackRequestException: Invalid Response: not json$/);
   });
 });

--- a/src/tools/create_draft_post.spec.js
+++ b/src/tools/create_draft_post.spec.js
@@ -188,6 +188,6 @@ describe('createDraftPostHandler — errors', () => {
 
     const error = await createDraftPostHandler(VALID_ARGS).catch((e) => e);
 
-    assert.equal(error.response.status, 500);
+    assert.match(error.message, /^SubstackAPIException: 500\b/);
   });
 });


### PR DESCRIPTION
Drops the only HTTP dependency. `SubstackApi` now calls global `fetch`, doing by hand the two
things axios did implicitly: `JSON.stringify` on the request body and
`Content-Type: application/json`. The `this.session = axios` field is gone.

The production tree is now `@modelcontextprotocol/sdk`, `zod` and `zod-to-json-schema` — the
lockfile loses 131 lines, since axios also carried `follow-redirects`, `form-data` and
`proxy-from-env`.

## Behaviour change reviewers should know about

axios rejected on non-2xx **before** `handleResponse` could inspect the status, which made the
`SubstackAPIException` branch unreachable — the suite had a `CHARACTERIZATION` test pinning
exactly that. `fetch` resolves on any status, so `handleResponse` is now the real error path:

| | before | after |
|---|---|---|
| non-2xx | `AxiosError`, `error.response.status === 500` | `Error: SubstackAPIException: 500 Internal Server Error` |
| 2xx, non-JSON body | returned the raw string | `Error: SubstackRequestException: Invalid Response: <body>` |

This is the code finally doing what it was written to do, and the message reaching MCP clients
is more informative, but anything reading `error.response` would break. The two tests asserting
the axios shape were updated and their `CHARACTERIZATION` comment replaced; a new test covers
the non-JSON 2xx case.

## engines

`engines: {node: ">=18"}` is now declared — native `fetch` is a real runtime floor, where axios
had none. Development and CI stay on Node 22 (`.nvmrc`, `Dockerfile`); `engines` is the
published minimum, not the dev target. `CLAUDE.md` was updated to state that distinction.

## Verification

- `npm test` — 66 pass, 0 fail
- stdio probe from `CLAUDE.md` (`initialize` + `tools/list`) — output byte-identical to `main`
- `npm ls --omit=dev` — no axios anywhere in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)