### PR TITLE
Update dependencies, migrate to zod 4 and adopt McpServer.registerTool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ of it. Update the comment in the same commit that changes the behaviour.
 revert the fix, strip the field, loosen the schema — confirm it fails, restore. This caught
 two tests that were passing vacuously: `additionalProperties` was dropped from the published
 schema with nobody noticing, and the schema test survived having every `description` stripped.
-The suite runs in ~200ms, so a mutation costs nothing.
+The whole suite runs in well under a second, so a mutation costs nothing.
 
 ## Style
 
@@ -80,10 +80,12 @@ literals (`{a: 1}`, not `{ a: 1 }`).
 - **Tool failures are results, not rejections.** `McpServer` turns anything a tool throws —
   a validation error, an unknown tool name, a `SubstackAPIException` — into a *successful*
   `CallToolResult` with `isError: true` and the message in `content[0].text`. `client.callTool()`
-  does **not** reject, so `await client.callTool(...).catch(e => e)` silently yields the result
-  object and every assertion on it passes vacuously. Assert `result.isError` and
-  `result.content[0].text` instead. (Protocol-level failures — an unknown *method*, a malformed
-  request — are still `McpError`, prefixed `MCP error -32601: ` and friends.)
+  does **not** reject, so `await client.callTool(...).catch(e => e)` hands you the *result*, not
+  an error: `assert.match(error.message, ...)` then dies with `The "string" argument must be of
+  type string` instead of a useful diff, while anything looser (`assert.ok(error)`) passes while
+  checking nothing. Assert `result.isError` and `result.content[0].text` instead.
+  (Protocol-level failures — an unknown *method*, a malformed request — are still `McpError`,
+  prefixed `MCP error -32601: ` and friends.)
 - **`callTool` results are `JSON.stringify`-ed by the server**, so a handler returning `'OK'`
   arrives as `text: '"OK"'` — quotes included.
 - **`SubstackPost.getDraft()` calls `JSON.stringify` on `draft_body`**, so it must be handed an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ Tests that pin *current* behaviour rather than desired behaviour carry a `CHARAC
 comment explaining why. If one fails, suspect the test before the source — that is the point
 of it. Update the comment in the same commit that changes the behaviour.
 
+**A new test that passes on the first run has proven nothing.** Break the source on purpose —
+revert the fix, strip the field, loosen the schema — confirm it fails, restore. This caught
+two tests that were passing vacuously: `additionalProperties` was dropped from the published
+schema with nobody noticing, and the schema test survived having every `description` stripped.
+The suite runs in ~200ms, so a mutation costs nothing.
+
 ## Style
 
 Two-space indent, semicolons, single quotes in code (imports use double), compact object
@@ -64,6 +70,13 @@ literals (`{a: 1}`, not `{ a: 1 }`).
 - **`node --test` does not discover `*.spec.js`** with its default patterns. The npm scripts
   pass the glob `'src/**/*.spec.js'` explicitly; single quotes matter so Node expands it, not
   the shell.
+- **Check the SDK's own source before asserting how it behaves.** Nearly every gotcha below
+  depends on SDK internals, and it ships readable ESM in
+  `node_modules/@modelcontextprotocol/sdk/dist/esm/`: `server/mcp.js` (registration,
+  validation, published tool definition), `server/zod-json-schema-compat.js` (schema
+  generation), `shared/protocol.js` (handler registration). Reading it is how the
+  `{target: 'draft-7', io: 'input'}` options and the silent `zod-to-json-schema` failure were
+  found; assuming instead once put a false claim in this very file.
 - **Tool failures are results, not rejections.** `McpServer` turns anything a tool throws —
   a validation error, an unknown tool name, a `SubstackAPIException` — into a *successful*
   `CallToolResult` with `isError: true` and the message in `content[0].text`. `client.callTool()`
@@ -118,5 +131,13 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 ```
 
 Note the process exits 0 immediately when stdin is at EOF — that is normal, not a crash, so
-exit status alone tells you nothing. Diff this output before and after a refactor to prove the
-protocol is unchanged.
+exit status alone tells you nothing.
+
+Diff this output before and after a refactor to prove the protocol is unchanged, but normalise
+each line first or key-order churn swamps the real change — `$schema` merely moving position
+reads as a diff:
+
+```bash
+diff <(python3 -m json.tool --sort-keys <<< "$(sed -n '2p' before.txt)") \
+     <(python3 -m json.tool --sort-keys <<< "$(sed -n '2p' after.txt)")
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,25 @@ literals (`{a: 1}`, not `{ a: 1 }`).
   non-2xx, so `SubstackApi.handleResponse` is what turns a failing status into an error
   (`SubstackAPIException: <status> <statusText>`); it also serializes the body and sets
   `Content-Type` by hand, which axios used to do implicitly.
+- **JSON Schema comes from zod itself** — `z.toJSONSchema(schema, {target: 'draft-7', io: 'input'})`,
+  no `zod-to-json-schema` dependency. Those two options are not decoration: they mirror what the
+  SDK's own `server/zod-json-schema-compat.js` passes for tool input schemas, so the published
+  schema stays consistent with anything the SDK generates. `io: 'input'` deliberately omits
+  `additionalProperties: false` — a zod object strips unknown keys rather than rejecting them.
+  Do not reintroduce `zod-to-json-schema`: on a zod 4 schema it returns a bare `{$schema}`
+  **without throwing**, which publishes a parameterless tool to every client.
+- **`ZodError` details live on `.issues`, not `.errors`** (zod 4 renamed it). Reading the old
+  name yields `Invalid input: undefined` and silently strips every detail from the error the
+  client sees.
 
 ## Verifying the server actually works
 
-Tests passing is not proof the binary runs. Drive the real entrypoint over stdio:
+`src/index.spec.js` now automates this: it spawns the real entrypoint as a child process,
+completes the handshake over stdio and asserts the env-var guard. It is the only coverage
+`src/index.js` has, since the file does its work at import time.
+
+Still drive it by hand when changing the transport or the protocol surface — the assertions
+only check what they were told to check:
 
 ```bash
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}}}' \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,12 @@ used in the chat: do not mirror the conversation language into the codebase.
 - `test/helpers/` — shared test helpers only; no tests live here.
 
 Adding a tool means adding a file under `src/tools/` and one entry to the `tools` registry in
-`src/server.js`. `list_tools` derives from that registry, so the two cannot drift apart.
+`src/server.js` — nothing else. `createServer()` loops over the registry calling
+`McpServer.registerTool`, and the SDK derives `tools/list`, argument validation and dispatch
+from what was registered, so there is no second place to update and nothing that can drift.
+Do not add `setRequestHandler` calls for `tools/list` or `tools/call`: registering a tool
+already covers both, and the SDK guards the clash rather than letting it slide — it throws
+`A request handler for tools/call already exists, which would be overridden`.
 
 ## Testing
 
@@ -59,8 +64,13 @@ literals (`{a: 1}`, not `{ a: 1 }`).
 - **`node --test` does not discover `*.spec.js`** with its default patterns. The npm scripts
   pass the glob `'src/**/*.spec.js'` explicitly; single quotes matter so Node expands it, not
   the shell.
-- **MCP errors reach the client as `McpError`** with the message prefixed `MCP error -32603: `.
-  Assert with `assert.match`, never `assert.equal`.
+- **Tool failures are results, not rejections.** `McpServer` turns anything a tool throws —
+  a validation error, an unknown tool name, a `SubstackAPIException` — into a *successful*
+  `CallToolResult` with `isError: true` and the message in `content[0].text`. `client.callTool()`
+  does **not** reject, so `await client.callTool(...).catch(e => e)` silently yields the result
+  object and every assertion on it passes vacuously. Assert `result.isError` and
+  `result.content[0].text` instead. (Protocol-level failures — an unknown *method*, a malformed
+  request — are still `McpError`, prefixed `MCP error -32601: ` and friends.)
 - **`callTool` results are `JSON.stringify`-ed by the server**, so a handler returning `'OK'`
   arrives as `text: '"OK"'` — quotes included.
 - **`SubstackPost.getDraft()` calls `JSON.stringify` on `draft_body`**, so it must be handed an
@@ -69,16 +79,20 @@ literals (`{a: 1}`, not `{ a: 1 }`).
   non-2xx, so `SubstackApi.handleResponse` is what turns a failing status into an error
   (`SubstackAPIException: <status> <statusText>`); it also serializes the body and sets
   `Content-Type` by hand, which axios used to do implicitly.
-- **JSON Schema comes from zod itself** — `z.toJSONSchema(schema, {target: 'draft-7', io: 'input'})`,
-  no `zod-to-json-schema` dependency. Those two options are not decoration: they mirror what the
-  SDK's own `server/zod-json-schema-compat.js` passes for tool input schemas, so the published
-  schema stays consistent with anything the SDK generates. `io: 'input'` deliberately omits
-  `additionalProperties: false` — a zod object strips unknown keys rather than rejecting them.
-  Do not reintroduce `zod-to-json-schema`: on a zod 4 schema it returns a bare `{$schema}`
-  **without throwing**, which publishes a parameterless tool to every client.
-- **`ZodError` details live on `.issues`, not `.errors`** (zod 4 renamed it). Reading the old
-  name yields `Invalid input: undefined` and silently strips every detail from the error the
-  client sees.
+- **The SDK owns JSON Schema generation** — never convert a schema by hand. `registerTool`
+  publishes `inputSchema` itself, via `z.toJSONSchema(schema, {target: 'draft-7', io: 'input'})`
+  under the hood (`server/zod-json-schema-compat.js`). Two traps if you are tempted to go back
+  to the low-level `Server`: `zod-to-json-schema` returns a bare `{$schema}` for a zod 4 schema
+  **without throwing**, publishing a parameterless tool to every client; and `io: 'input'`
+  omits `additionalProperties: false` on purpose, because a zod object strips unknown keys
+  rather than rejecting them.
+- **zod is not optional and not ours to drop.** It is a non-optional `peerDependency` of the
+  SDK, and `registerTool` throws `inputSchema must be a Zod schema or raw shape` for anything
+  else — the SDK's validation *is* zod. npm auto-installs it even if it leaves `package.json`,
+  so removing the direct dependency buys nothing and unpins the version.
+- **`ZodError` details live on `.issues`, not `.errors`** (zod 4 renamed it). Nothing in `src/`
+  reads them today — the SDK formats the message — but `.errors` silently yields `undefined`
+  rather than failing, so it is worth knowing before writing a handler that inspects them.
 
 ## Verifying the server actually works
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,17 @@ literals (`{a: 1}`, not `{ a: 1 }`).
   `Content-Type` by hand, which axios used to do implicitly.
 - **The SDK owns JSON Schema generation** — never convert a schema by hand. `registerTool`
   publishes `inputSchema` itself, via `z.toJSONSchema(schema, {target: 'draft-7', io: 'input'})`
-  under the hood (`server/zod-json-schema-compat.js`). Two traps if you are tempted to go back
-  to the low-level `Server`: `zod-to-json-schema` returns a bare `{$schema}` for a zod 4 schema
-  **without throwing**, publishing a parameterless tool to every client; and `io: 'input'`
-  omits `additionalProperties: false` on purpose, because a zod object strips unknown keys
-  rather than rejecting them.
+  under the hood (`server/zod-json-schema-compat.js`). If you are ever tempted back to the
+  low-level `Server`, know that `zod-to-json-schema` returns a bare `{$schema}` for a zod 4
+  schema **without throwing**, publishing a parameterless tool to every client.
+- **Tool schemas are `z.strictObject`, never `z.object`.** The validation message is the only
+  feedback an LLM gets to repair a malformed call, and a plain `z.object` *strips* unknown keys
+  silently: a model sending `content` instead of `body` is told only that `body` is missing,
+  never that its own key was ignored. `strictObject` adds `Unrecognized key: "content"`, and
+  makes the published `additionalProperties: false` truthful instead of an empty promise.
+  Prefer `z.strictObject({...})` over `.strict()` — zod 4 points at the former.
+  `src/server.spec.js` pins the wording of these messages on purpose: a degraded message
+  breaks nothing by itself, the call still returns, so only an explicit assertion catches it.
 - **zod is not optional and not ours to drop.** It is a non-optional `peerDependency` of the
   SDK, and `registerTool` throws `inputSchema must be a Zod schema or raw shape` for anything
   else — the SDK's validation *is* zod. npm auto-installs it even if it leaves `package.json`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,29 @@
       "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.11.2",
-        "zod": "3.24.4",
-        "zod-to-json-schema": "3.24.5"
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "zod": "4.4.3"
       },
       "bin": {
         "substack-mcp": "src/index.js"
       },
       "devDependencies": {
         "msw": "2.15.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -108,24 +122,43 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.2.tgz",
-      "integrity": "sha512-H9vwztj5OAqHg9GockCQC06k1natgcxWQSRpQcPJf6i5+MWBzfKkRtxGbjQf0X2ihii0ffLZCRGbYV2f2bjNCQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -218,6 +251,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -245,23 +311,40 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -348,15 +431,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -419,9 +503,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -499,9 +583,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -557,18 +641,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -599,10 +684,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -610,7 +699,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -621,6 +710,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -639,6 +734,22 @@
         "fast-string-truncated-width": "^3.0.2"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
@@ -650,9 +761,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -663,7 +774,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/forwarded": {
@@ -775,9 +890,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -797,32 +912,49 @@
         "set-cookie-parser": "^3.0.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -830,6 +962,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -869,6 +1010,27 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -879,12 +1041,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -909,15 +1075,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ms": {
@@ -969,16 +1139,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/msw/node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/mute-stream": {
@@ -1104,12 +1264,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1119,27 +1280,31 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/require-directory": {
@@ -1147,6 +1312,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1176,33 +1350,14 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1211,31 +1366,35 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -1245,6 +1404,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -1282,14 +1445,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1301,13 +1464,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1367,9 +1530,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1482,17 +1645,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/undici-types": {
@@ -1609,21 +1789,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.11.2",
-    "zod": "3.24.4",
-    "zod-to-json-schema": "3.24.5"
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "msw": "2.15.0"

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -31,7 +31,11 @@ function runEntrypoint({env = TEST_ENV, stdin = ''} = {}) {
         timeout: 10_000,
       },
       (error, stdout, stderr) => {
-        resolve({code: error?.code ?? 0, stdout, stderr});
+        // A signal kill — the timeout above firing, say — arrives as `code: null` with
+        // `signal` set. Collapsing that to 0 with `?? 0` would make a hung entrypoint
+        // indistinguishable from a clean exit, defeating every assertion below that reads
+        // the exit code. Report the signal so callers can tell the two apart.
+        resolve({code: error ? error.code : 0, signal: error?.signal ?? null, stdout, stderr});
       }
     );
 
@@ -45,8 +49,9 @@ describe('entrypoint — environment check', () => {
       const env = {...TEST_ENV};
       delete env[missing];
 
-      const {code, stderr} = await runEntrypoint({env});
+      const {code, signal, stderr} = await runEntrypoint({env});
 
+      assert.equal(signal, null, 'the process should exit on its own, not be killed');
       assert.notEqual(code, 0, 'the process should fail');
       assert.match(
         stderr,
@@ -56,8 +61,11 @@ describe('entrypoint — environment check', () => {
   }
 
   test('refuses to start when an env var is present but empty', async () => {
-    const {code, stderr} = await runEntrypoint({env: {...TEST_ENV, SUBSTACK_USER_ID: ''}});
+    const {code, signal, stderr} = await runEntrypoint({
+      env: {...TEST_ENV, SUBSTACK_USER_ID: ''},
+    });
 
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
     assert.notEqual(code, 0, 'the process should fail');
     assert.match(stderr, /must be set/);
   });
@@ -67,8 +75,11 @@ describe('entrypoint — stdio transport', () => {
   // Automates the manual probe documented in CLAUDE.md: a passing unit suite does not prove
   // the binary boots and speaks the protocol over a real stdio transport.
   test('completes the handshake and lists the tools over stdio', async () => {
-    const {stdout, stderr} = await runEntrypoint({stdin: HANDSHAKE});
+    const {stdout, stderr, signal} = await runEntrypoint({stdin: HANDSHAKE});
 
+    // Without this, a server that answered the handshake and then hung would still satisfy
+    // every assertion below — the replies are already in stdout by the time it is killed.
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
     assert.equal(stderr, '', 'nothing should be written to stderr');
 
     const messages = stdout
@@ -96,8 +107,11 @@ describe('entrypoint — stdio transport', () => {
   // The process exits 0 as soon as stdin reaches EOF; that is the documented normal shutdown,
   // not a crash, so exit status alone must never be read as proof the server worked.
   test('exits cleanly when stdin reaches EOF', async () => {
-    const {code} = await runEntrypoint({stdin: ''});
+    const {code, signal} = await runEntrypoint({stdin: ''});
 
+    // `signal` carries the whole point of this test: a hung entrypoint gets SIGTERM-ed by the
+    // helper's timeout, and a killed process must never read as having exited cleanly.
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
     assert.equal(code, 0);
   });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -79,11 +79,10 @@ describe('entrypoint — stdio transport', () => {
     const initialize = messages.find((message) => message.id === 1);
     assert.equal(initialize.result.serverInfo.name, 'Substack MCP');
     assert.equal(initialize.result.protocolVersion, '2024-11-05');
-    assert.deepEqual(Object.keys(initialize.result.capabilities).sort(), [
-      'logging',
-      'resources',
-      'tools',
-    ]);
+    // Only `tools` is advertised. The server used to declare `resources` and `logging` too
+    // while registering no handler for either, so `resources/list` answered -32601 Method
+    // not found; McpServer derives capabilities from what is actually registered.
+    assert.deepEqual(Object.keys(initialize.result.capabilities), ['tools']);
 
     const listTools = messages.find((message) => message.id === 2);
     assert.equal(listTools.result.tools.length, 1);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,0 +1,104 @@
+import {test, describe} from 'node:test';
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import {TEST_ENV} from '../test/helpers/env.js';
+
+const ENTRYPOINT = fileURLToPath(new URL('./index.js', import.meta.url));
+
+const HANDSHAKE = [
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}}}',
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}',
+].join('\n') + '\n';
+
+/**
+ * Runs the real entrypoint as a child process, since index.js does its work at import time
+ * and cannot be exercised in-process. `env` fully replaces the SUBSTACK_* variables, so a
+ * value leaking in from the developer's shell cannot mask a missing-env test.
+ */
+function runEntrypoint({env = TEST_ENV, stdin = ''} = {}) {
+  return new Promise((resolve) => {
+    const child = execFile(
+      process.execPath,
+      [ENTRYPOINT],
+      {
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          ...env,
+        },
+        timeout: 10_000,
+      },
+      (error, stdout, stderr) => {
+        resolve({code: error?.code ?? 0, stdout, stderr});
+      }
+    );
+
+    child.stdin.end(stdin);
+  });
+}
+
+describe('entrypoint — environment check', () => {
+  for (const missing of Object.keys(TEST_ENV)) {
+    test(`refuses to start when ${missing} is missing`, async () => {
+      const env = {...TEST_ENV};
+      delete env[missing];
+
+      const {code, stderr} = await runEntrypoint({env});
+
+      assert.notEqual(code, 0, 'the process should fail');
+      assert.match(
+        stderr,
+        /SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN and SUBSTACK_USER_ID must be set/
+      );
+    });
+  }
+
+  test('refuses to start when an env var is present but empty', async () => {
+    const {code, stderr} = await runEntrypoint({env: {...TEST_ENV, SUBSTACK_USER_ID: ''}});
+
+    assert.notEqual(code, 0, 'the process should fail');
+    assert.match(stderr, /must be set/);
+  });
+});
+
+describe('entrypoint — stdio transport', () => {
+  // Automates the manual probe documented in CLAUDE.md: a passing unit suite does not prove
+  // the binary boots and speaks the protocol over a real stdio transport.
+  test('completes the handshake and lists the tools over stdio', async () => {
+    const {stdout, stderr} = await runEntrypoint({stdin: HANDSHAKE});
+
+    assert.equal(stderr, '', 'nothing should be written to stderr');
+
+    const messages = stdout
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => JSON.parse(line));
+
+    const initialize = messages.find((message) => message.id === 1);
+    assert.equal(initialize.result.serverInfo.name, 'Substack MCP');
+    assert.equal(initialize.result.protocolVersion, '2024-11-05');
+    assert.deepEqual(Object.keys(initialize.result.capabilities).sort(), [
+      'logging',
+      'resources',
+      'tools',
+    ]);
+
+    const listTools = messages.find((message) => message.id === 2);
+    assert.equal(listTools.result.tools.length, 1);
+    assert.equal(listTools.result.tools[0].name, 'create_draft_post');
+    assert.deepEqual(
+      Object.keys(listTools.result.tools[0].inputSchema.properties).sort(),
+      ['body', 'subtitle', 'title']
+    );
+  });
+
+  // The process exits 0 as soon as stdin reaches EOF; that is the documented normal shutdown,
+  // not a crash, so exit status alone must never be read as proof the server worked.
+  test('exits cleanly when stdin reaches EOF', async () => {
+    const {code} = await runEntrypoint({stdin: ''});
+
+    assert.equal(code, 0);
+  });
+});

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,4 @@
-import {Server} from "@modelcontextprotocol/sdk/server/index.js";
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import {z} from "zod";
+import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
 
 export const tools = {
@@ -15,49 +10,18 @@ export const tools = {
 };
 
 export function createServer() {
-  const server = new Server({
-      name: "Substack MCP",
-      version: "1.0.0"
-    },
-    {
-      capabilities: {
-        tools: {},
-        resources: {},
-        logging: {}
-      },
-    });
+  // McpServer derives tools/list from what is registered here and validates every call
+  // against the tool's zod schema before the handler runs, so there is no hand-written
+  // list_tools handler, dispatch table or JSON Schema conversion to keep in sync.
+  // Capabilities are derived too: the server no longer advertises `resources` and
+  // `logging`, which it never implemented.
+  const server = new McpServer({name: "Substack MCP", version: "1.0.0"});
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return {
-      tools: Object.entries(tools).map(([name, {description, schema}]) => ({
-        name,
-        description,
-        // Same options the SDK's own zod-4 compat layer uses for tool input schemas.
-        inputSchema: z.toJSONSchema(schema, {target: "draft-7", io: "input"}),
-      })),
-    };
-  });
-
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const {name, arguments: args} = request.params;
-
-    try {
-      if (!Object.hasOwn(tools, name)) {
-        throw new Error(`Unknown tool: ${name}`);
-      }
-
-      const result = await tools[name].handler(args);
-
-      return {
-        content: [{type: "text", text: JSON.stringify(result, null, 2)}],
-      };
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        throw new Error(`Invalid input: ${JSON.stringify(error.issues)}`);
-      }
-      throw error;
-    }
-  });
+  for (const [name, {description, schema, handler}] of Object.entries(tools)) {
+    server.registerTool(name, {description, inputSchema: schema}, async (args) => ({
+      content: [{type: "text", text: JSON.stringify(await handler(args), null, 2)}],
+    }));
+  }
 
   return server;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,6 @@ import {
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import {z} from "zod";
-import {zodToJsonSchema} from "zod-to-json-schema";
 import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
 
 export const tools = {
@@ -33,7 +32,8 @@ export function createServer() {
       tools: Object.entries(tools).map(([name, {description, schema}]) => ({
         name,
         description,
-        inputSchema: zodToJsonSchema(schema),
+        // Same options the SDK's own zod-4 compat layer uses for tool input schemas.
+        inputSchema: z.toJSONSchema(schema, {target: "draft-7", io: "input"}),
       })),
     };
   });
@@ -53,7 +53,7 @@ export function createServer() {
       };
     } catch (error) {
       if (error instanceof z.ZodError) {
-        throw new Error(`Invalid input: ${JSON.stringify(error.errors)}`);
+        throw new Error(`Invalid input: ${JSON.stringify(error.issues)}`);
       }
       throw error;
     }

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -75,7 +75,7 @@ describe('MCP server — list_tools', () => {
     }
   });
 
-  test('the inputSchema is a draft-07 document generated in input mode', async () => {
+  test('the inputSchema is a draft-07 document that closes the object', async () => {
     const {client, close} = await connectMcpClient();
 
     try {
@@ -83,9 +83,9 @@ describe('MCP server — list_tools', () => {
       const {inputSchema} = tools[0];
 
       assert.equal(inputSchema.$schema, 'http://json-schema.org/draft-07/schema#');
-      // `io: 'input'` deliberately omits additionalProperties: a zod object strips unknown
-      // keys rather than rejecting them, so advertising `false` would misdescribe the tool.
-      assert.equal(Object.hasOwn(inputSchema, 'additionalProperties'), false);
+      // Accurate only because the schema is a strictObject: a plain z.object strips unknown
+      // keys instead of rejecting them, and would publish this as an empty promise.
+      assert.equal(inputSchema.additionalProperties, false);
     } finally {
       await close();
     }
@@ -160,6 +160,64 @@ describe('MCP server — call_tool', () => {
     } finally {
       await close();
     }
+  });
+
+  // The validation message is the whole feedback loop for an LLM: it is what the model reads
+  // to fix a malformed call and retry. These tests treat its content as a contract, not as an
+  // implementation detail, because a degraded message does not fail anything on its own — the
+  // call still returns, the model just cannot work out what to change.
+  describe('the validation message an LLM has to act on', () => {
+    async function callWith(args) {
+      const {client, close} = await connectMcpClient();
+
+      try {
+        const result = await client.callTool({name: 'create_draft_post', arguments: args});
+        assert.equal(result.isError, true);
+        return result.content[0].text;
+      } finally {
+        await close();
+      }
+    }
+
+    test('names every missing field, not just the first', async () => {
+      const text = await callWith({});
+
+      for (const field of ['title', 'subtitle', 'body']) {
+        assert.match(text, new RegExp(`at ${field}\\b`), `should point at ${field}`);
+      }
+    });
+
+    test('reports a wrong type with both what was expected and what arrived', async () => {
+      const text = await callWith({title: 42, subtitle: 'S', body: 'B'});
+
+      assert.match(text, /expected string, received number at title/);
+    });
+
+    test('names an unrecognised key instead of silently dropping it', async () => {
+      // The realistic LLM mistake: `content` instead of `body`. Being told only that `body`
+      // is missing leaves the model unable to see that its own key was the problem.
+      const text = await callWith({title: 'T', subtitle: 'S', content: 'B'});
+
+      assert.match(text, /at body\b/);
+      assert.match(text, /Unrecognized key: "content"/);
+    });
+
+    test('travels as tool output, which is the channel a model can read', async () => {
+      const {client, close} = await connectMcpClient();
+
+      try {
+        const result = await client.callTool({name: 'create_draft_post', arguments: {}});
+
+        // Not a JSON-RPC error: an isError result with the reason in text content. A protocol
+        // error would leave many clients with nothing to hand back to the model.
+        assert.equal(result.isError, true);
+        assert.equal(result.content.length, 1);
+        assert.equal(result.content[0].type, 'text');
+        assert.ok(result.content[0].text.length > 0, 'the reason must not be empty');
+      } finally {
+        await close();
+      }
+    });
   });
 
   test('a Substack API error reaches the client as an isError result', async () => {

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -52,6 +52,44 @@ describe('MCP server — list_tools', () => {
       await close();
     }
   });
+
+  // Regression guard for the zod 3 -> 4 migration: zod-to-json-schema silently returned a
+  // bare `{$schema}` for a zod 4 schema instead of throwing, which would have published a
+  // parameterless tool. Asserting the descriptions — the part an LLM actually reads to fill
+  // the arguments — is what makes a degraded-but-structurally-valid schema fail here.
+  test('every property carries the description the LLM relies on', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      const {properties} = tools[0].inputSchema;
+
+      for (const [name, property] of Object.entries(properties)) {
+        assert.equal(property.type, 'string', `${name} should be a string`);
+        assert.ok(property.description, `${name} should carry a description`);
+      }
+
+      assert.match(properties.body.description, /plain text|JSON string/);
+    } finally {
+      await close();
+    }
+  });
+
+  test('the inputSchema is a draft-07 document generated in input mode', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      const {inputSchema} = tools[0];
+
+      assert.equal(inputSchema.$schema, 'http://json-schema.org/draft-07/schema#');
+      // `io: 'input'` deliberately omits additionalProperties: a zod object strips unknown
+      // keys rather than rejecting them, so advertising `false` would misdescribe the tool.
+      assert.equal(Object.hasOwn(inputSchema, 'additionalProperties'), false);
+    } finally {
+      await close();
+    }
+  });
 });
 
 describe('MCP server — call_tool', () => {
@@ -106,6 +144,13 @@ describe('MCP server — call_tool', () => {
 
       assert.match(error.message, /Invalid input:/);
       assert.match(error.message, /"path":\["subtitle"\]/);
+
+      // zod 4 renamed ZodError.errors to .issues; reading the old name yielded
+      // `Invalid input: undefined`, stripping every detail from the client-facing message.
+      const details = JSON.parse(error.message.replace(/^.*?Invalid input: /, ''));
+      assert.ok(Array.isArray(details) && details.length > 0, 'details should be a non-empty array');
+      assert.deepEqual(details.map((issue) => issue.path.join('.')).sort(), ['body', 'subtitle']);
+
       assert.equal(msw.requests.length, 0);
     } finally {
       await close();

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -119,55 +119,59 @@ describe('MCP server — call_tool', () => {
     }
   });
 
-  test('an unknown tool produces an error', async () => {
+  // McpServer reports tool failures as a successful CallToolResult carrying isError: true,
+  // which is the shape the MCP spec prescribes for execution errors. The three tests below
+  // pinned the previous behaviour, where the hand-written handler threw and the failure
+  // reached the client as a JSON-RPC error instead. `callTool` no longer rejects at all.
+  test('an unknown tool produces an isError result', async () => {
     const {client, close} = await connectMcpClient();
 
     try {
-      const error = await client
-        .callTool({name: 'tool_inesistente', arguments: {}})
-        .catch((e) => e);
+      const result = await client.callTool({name: 'tool_inesistente', arguments: {}});
 
-      assert.match(error.message, /Unknown tool: tool_inesistente/);
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /Tool tool_inesistente not found/);
       assert.equal(msw.requests.length, 0);
     } finally {
       await close();
     }
   });
 
-  test('invalid arguments produce an Invalid input error carrying the Zod details', async () => {
+  test('invalid arguments produce an isError result naming every missing field', async () => {
     const {client, close} = await connectMcpClient();
 
     try {
-      const error = await client
-        .callTool({name: 'create_draft_post', arguments: {title: 'title only'}})
-        .catch((e) => e);
+      const result = await client.callTool({
+        name: 'create_draft_post',
+        arguments: {title: 'title only'},
+      });
 
-      assert.match(error.message, /Invalid input:/);
-      assert.match(error.message, /"path":\["subtitle"\]/);
+      assert.equal(result.isError, true);
 
-      // zod 4 renamed ZodError.errors to .issues; reading the old name yielded
-      // `Invalid input: undefined`, stripping every detail from the client-facing message.
-      const details = JSON.parse(error.message.replace(/^.*?Invalid input: /, ''));
-      assert.ok(Array.isArray(details) && details.length > 0, 'details should be a non-empty array');
-      assert.deepEqual(details.map((issue) => issue.path.join('.')).sort(), ['body', 'subtitle']);
+      const [{text}] = result.content;
+      assert.match(text, /Input validation error/);
+      // Both missing fields must be reported, not just the first one: a client that only
+      // learns about `subtitle` retries and fails again on `body`.
+      assert.match(text, /subtitle/);
+      assert.match(text, /body/);
 
+      // The handler must not run, so no draft is created from invalid input.
       assert.equal(msw.requests.length, 0);
     } finally {
       await close();
     }
   });
 
-  test('a Substack API error propagates to the client', async () => {
+  test('a Substack API error reaches the client as an isError result', async () => {
     msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
 
     const {client, close} = await connectMcpClient();
 
     try {
-      const error = await client
-        .callTool({name: 'create_draft_post', arguments: VALID_ARGS})
-        .catch((e) => e);
+      const result = await client.callTool({name: 'create_draft_post', arguments: VALID_ARGS});
 
-      assert.match(error.message, /500/);
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /SubstackAPIException: 500/);
     } finally {
       await close();
     }

--- a/src/tools/create_draft_post.js
+++ b/src/tools/create_draft_post.js
@@ -3,7 +3,11 @@ import SubstackApi from "../api/substack/SubstackApi.js";
 import SubstackPost from "../api/substack/SubstackPost.js";
 
 
-export const createDraftPostSchema = z.object({
+// strictObject, not object: an unknown key must be reported rather than stripped. The
+// validation message is the only feedback an LLM gets to correct a malformed call, and
+// silently discarding a key it believed it passed is both confusing and unsafe — a model
+// sending `content` instead of `body` would otherwise only be told `body` is missing.
+export const createDraftPostSchema = z.strictObject({
   title: z
     .string()
     .describe(

--- a/src/tools/create_draft_post.js
+++ b/src/tools/create_draft_post.js
@@ -44,6 +44,9 @@ const parseBody = (body) => {
 };
 
 export const createDraftPostHandler = async (args) => {
+  // McpServer already validated against this schema before dispatching, so over MCP this
+  // parse never rejects. It is kept so the handler stays safe when called directly, which
+  // is how its own tests exercise it.
   const validatedArgs = createDraftPostSchema.parse(args);
 
   const {title, subtitle, body} = validatedArgs;


### PR DESCRIPTION
Two related changes. The dependency bump came first; migrating to the SDK's high-level API came out of reviewing what the bump actually touched.

## 1. Dependencies

| Package | From | To |
|---|---|---|
| `@modelcontextprotocol/sdk` | 1.11.2 | **1.30.0** |
| `zod` | 3.24.4 | **4.4.3** |
| `zod-to-json-schema` | 3.24.5 | **removed** |

`msw` was already at the latest (2.15.0). `engines: {node: ">=18"}` is unchanged — the new SDK declares the same floor. Exact pinning preserved, `npm audit` reports 0 vulnerabilities, clearing the 7 advisories #8 left as out of scope.

The SDK bump is inert on its own. zod 4 is a major, and the suite caught two real breakages.

### `zod-to-json-schema` degrades silently on zod 4

Despite declaring `zod: "^3.25.28 || ^4"` as a peer, `zodToJsonSchema()` handed a zod 4 schema returns a bare `{"$schema": "..."}` — **without throwing**. Shipped, that publishes `create_draft_post` with **no parameters at all** to every LLM client. Nothing crashes; the tool just silently stops being callable.

### `ZodError.errors` was renamed to `.issues`

Reading the old name yielded `Invalid input: undefined`, stripping every validation detail from the message reaching the client.

## 2. `McpServer.registerTool`

Fixing the schema conversion meant looking at *why* we convert schemas by hand at all. We didn't need to: `createServer()` used the low-level `Server` API and reimplemented four things the SDK already does — JSON Schema generation, argument validation, dispatch, and ZodError translation.

`createServer()` goes from 46 lines to 13, and `src/server.js` no longer imports zod:

```js
const server = new McpServer({name: "Substack MCP", version: "1.0.0"});

for (const [name, {description, schema, handler}] of Object.entries(tools)) {
  server.registerTool(name, {description, inputSchema: schema}, async (args) => ({
    content: [{type: "text", text: JSON.stringify(await handler(args), null, 2)}],
  }));
}
```

The `tools` registry stays and gets stronger: no hand-written `list_tools` handler beside it, so the two cannot drift. Adding a tool is one registry entry and nothing else.

**zod stays a direct dependency** — the tool files still declare their schemas with it, and it is not removable regardless: non-optional peer of the SDK, `registerTool` throws `inputSchema must be a Zod schema or raw shape` for anything else, and npm auto-installs it even if it leaves `package.json` (verified on a bare project), which would only unpin the version.

## 3. The validation message an LLM has to act on

That message is the only feedback a model gets to repair a malformed call, so I probed every realistic failure mode through a real MCP client. One case was bad.

`z.object` **strips** unknown keys silently, so the most likely LLM mistake — sending `content` instead of `body` — produced only:

```
Invalid input: expected string, received undefined at body
```

True but unhelpful: nothing says `content` was discarded, so the model cannot tell that its own key was the mistake. `z.strictObject` reports both halves:

```
Invalid input: expected string, received undefined at body
Unrecognized key: "content"
```

Silently dropping a key the model believed it passed is also the unsafe direction — a future `{..., publish: true}` would vanish without a word instead of being refused.

Everything else already held up: every missing field is listed (not just the first), type mismatches carry expected *and* received, each issue is suffixed with its dot path, and nothing is truncated.

Independently of wording, the `McpServer` migration improved this channel: validation failures now arrive as **tool output** (`isError: true`, reason in `content[0].text`) rather than a JSON-RPC error — and tool output is what a client can hand back to the model. A protocol error leaves many clients with nothing useful to replay.

A new `describe` block pins the message text as a contract, because a degraded message fails nothing on its own: the call still returns, the model just cannot act on it.

## Behaviour changes on the wire

This is the part worth reviewing. Measured against `main`, not inferred:

| | before | after |
|---|---|---|
| invalid arguments | JSON-RPC error `-32603`, `Invalid input: [{...issues}]` | result, `isError: true`, `-32602 Input validation error: ... at subtitle` |
| unknown tool | JSON-RPC error `-32603 Unknown tool: x` | result, `isError: true`, `Tool x not found` |
| handler throws (Substack 500) | JSON-RPC error `-32603` | result, `isError: true`, `SubstackAPIException: 500 ...` |
| capabilities | `{tools:{}, resources:{}, logging:{}}` | `{tools:{listChanged:true}}` |
| tool definition | — | gains `execution: {taskSupport: 'forbidden'}` |
| `inputSchema` | — | unchanged (`additionalProperties: false` kept, now truthful) |

Tool failures becoming results rather than protocol errors is the shape the MCP spec prescribes for execution errors. Everything else in `inputSchema` is byte-identical: same properties, descriptions, `required`, draft-07 dialect.

Two of these are fixes, not regressions:

- **`resources` and `logging` disappearing.** The server advertised both while registering no handler for either. Verified on `main`: `resources/list` answers `-32601 Method not found`. It was promising capabilities it did not have.
- **`additionalProperties: false` becoming accurate.** It briefly disappeared mid-branch: a plain `z.object` strips unknown keys rather than rejecting them, so advertising `false` was an empty promise. Tool schemas are now `z.strictObject`, which really does reject them — see below.

## Tests

78 pass, 0 fail (was 66 on `main`).

**`src/index.js` had no coverage at all** — absent from the report, 0%. `src/index.spec.js` now spawns the real entrypoint as a child process (the file works at import time, so it cannot be exercised in-process), completing the handshake over stdio and asserting the env-var guard. This automates the manual probe `CLAUDE.md` documented. Now 93.75%; the one uncovered line is `process.exit(1)` on transport failure.

The three tests pinning the old error shape were rewritten. **This matters more than it looks:** `callTool` no longer rejects, so the old `await client.callTool(...).catch(e => e)` idiom yields the *result* object and every assertion on `error.message` would pass vacuously. They assert `result.isError` and `content[0].text` instead.

Two additions to `server.spec.js`. The existing schema test passed even with every `description` stripped — precisely the degradation that matters, since descriptions are what an LLM reads to fill arguments. The other pins the draft-07 dialect and the deliberate absence of `additionalProperties`.

**Nine mutations confirm the tests discriminate rather than merely pass:**

| Mutation | Result |
|---|---|
| `.issues` reverted to `.errors` | 1 fail |
| degraded empty schema | 3 fail |
| descriptions stripped, structure intact | 1 fail — caught **only** by the new test |
| env guard reduced to one variable | 3 fail |
| `inputSchema` dropped from `registerTool` | 8 fail |
| handler errors swallowed | 1 fail |
| `strictObject` reverted to `object` | 2 fail |
| message degraded to a generic string | 1 fail |
| `body` loosened to `.optional()` | 4 fail |

## `CLAUDE.md`

Two gotchas became actively wrong and are replaced: the `McpError -32603` advice (tool errors are no longer protocol errors) and the note telling you to convert schemas by hand. The vacuous-`catch` trap is documented, as is the fact that the SDK *throws* on a duplicate `tools/call` handler rather than silently overriding it.

## Verification

- `npm ci` from an empty `node_modules/`
- `npm test` — 78/78; `server.js` at 100% line/branch/function
- `npm pack --dry-run` — no `.spec.js` in the tarball; `.dockerignore` covers the new file
- stdio probe against the real binary: capabilities, `tools/list` and the validation-error path all as tabulated

## Note

I'd originally suggested splitting the `McpServer` migration into its own PR, so the dependency bump could be reverted independently of a wire-visible behaviour change. @marcomoauro asked to keep them together — flagging it here so reviewers know the two are coupled in one revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
