### PR TITLE
Add structured logging across the server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ used in the chat: do not mirror the conversation language into the codebase.
 | `npm run test:coverage` | Coverage report, spec files excluded |
 | `npm pack --dry-run` | Verify what ships to npm |
 
+`npm test` prints ~860 lines of TAP for a suite that runs in under a second. Pipe it through
+`grep -E '^# (pass|fail)'` for just the tally, and `grep -E '^not ok'` to find what broke.
+
 ## Layout
 
 - `src/index.js` — entrypoint only: env check, `createServer()`, stdio transport. Keep it thin.
@@ -27,6 +30,7 @@ used in the chat: do not mirror the conversation language into the codebase.
   import time**: no env reads, no transport connection. Tests depend on this.
 - `src/tools/<name>.js` — one file per MCP tool, exporting a zod schema and a handler.
 - `src/api/substack/` — `SubstackApi` (HTTP) and `SubstackPost` (ProseMirror document builder).
+- `src/logger.js` — the only place that writes a log line. No dependencies, no state.
 - `test/helpers/` — shared test helpers only; no tests live here.
 
 Adding a tool means adding a file under `src/tools/` and one entry to the `tools` registry in
@@ -36,6 +40,43 @@ from what was registered, so there is no second place to update and nothing that
 Do not add `setRequestHandler` calls for `tools/list` or `tools/call`: registering a tool
 already covers both, and the SDK guards the clash rather than letting it slide — it throws
 `A request handler for tools/call already exists, which would be overridden`.
+
+## Logging
+
+**Everything must be logged well enough to debug a session from the log alone**, because the
+caller is an LLM and the failure is usually in what it sent, not in this code. Every new tool,
+method or branch that a call can take gets a line: the arguments it received, the decision it
+made, the outcome. `src/logger.js` is the only writer — never `console.log`.
+
+- **stdout belongs to the JSON-RPC transport.** One byte written there corrupts the protocol
+  and the client disconnects, which is why the logger writes to stderr and why
+  `src/index.spec.js` asserts that stdout parses as JSON-RPC and stderr as log lines. MCP hosts
+  collect the server's stderr into their own log files; that is where these lines get read.
+- One JSON object per line: `{"ts","level","msg",…fields}`. `msg` is a dotted event name
+  (`tool.call.start`, `substack.response`), not a sentence — it is what you grep for.
+- Levels are `silent < error < warn < info < debug`, from `SUBSTACK_MCP_LOG_LEVEL`, default
+  `info`, read **at call time** (nothing in `src/` may read the environment at import time).
+  `info` is the story of a call — tool in, request out, response, result. `debug` adds the
+  payloads and the document-building steps. An unknown value falls back to `info` rather than
+  muting the server.
+- **Secrets are redacted by key name**, recursively: `/token|cookie|password|secret|auth|session|^sid$/i`
+  becomes `***`. So pass whole objects (`{headers}`, `{args}`, `{draft}`) and let the logger
+  handle it, rather than picking fields by hand at each call site. `sid` is anchored on purpose;
+  as a substring it would also blank out `considerations`. Post content is *not* truncated —
+  it is usually the thing being debugged.
+- The logger never throws: `Error` values are expanded to `{name, message, stack}` (raw, they
+  serialize to `{}`), cycles become `[Circular]`, and an unserializable payload degrades to a
+  `log_error` note.
+- **A rejected tool call cannot be logged from inside the handler.** `McpServer` validates
+  arguments itself and answers `Input validation error` before the handler runs, so
+  `logOutgoingMessages(transport)` wraps `transport.send` to catch it — `warn` for anything
+  carrying `error` or `isError`, `debug` for the rest of the traffic. That line is the most
+  useful one in the file when a model cannot get a call right.
+- Tool failures are logged **and rethrown**: `McpServer` still converts them into an `isError`
+  result. Swallowing one would change the protocol behaviour.
+- `setTestEnv()` forces `SUBSTACK_MCP_LOG_LEVEL=silent`, so the in-process suites do not print
+  a line per tool call over the reporter. Assert on logs with `test/helpers/capture-logs.js`,
+  which sets the level and captures stderr for the duration of a call.
 
 ## Testing
 
@@ -48,15 +89,26 @@ unmocked request fails the test instead of reaching the network. Never disable t
 overrides with `msw.draftsHandler(...)` rather than a bare `http.post`, otherwise the request
 is not recorded in `msw.requests`.
 
+The exception is `src/index.spec.js`, which spawns the entrypoint as a child process: MSW runs
+in the test process and cannot intercept anything there. To exercise a failing request, point
+`SUBSTACK_PUBLICATION_URL` at `http://127.0.0.1:1` — the request gets logged, then fails with
+ECONNREFUSED without a packet leaving the machine.
+
 Tests that pin *current* behaviour rather than desired behaviour carry a `CHARACTERIZATION`
 comment explaining why. If one fails, suspect the test before the source — that is the point
 of it. Update the comment in the same commit that changes the behaviour.
 
 **A new test that passes on the first run has proven nothing.** Break the source on purpose —
 revert the fix, strip the field, loosen the schema — confirm it fails, restore. This caught
-two tests that were passing vacuously: `additionalProperties` was dropped from the published
-schema with nobody noticing, and the schema test survived having every `description` stripped.
-The whole suite runs in well under a second, so a mutation costs nothing.
+three tests that were passing vacuously: `additionalProperties` was dropped from the published
+schema with nobody noticing, the schema test survived having every `description` stripped, and
+"never writes the session token to the log" passed with redaction disabled, because the
+handshake it drove never logs a request header in the first place — it now drives a real tool
+call against a closed local port. Renaming the log line under test is the cheapest mutation for
+a logging assertion. **Check the mutation actually landed** before trusting a green run: a
+`sed`/`perl` regex that fails to match leaves the file untouched and reads exactly like a test
+that asserts nothing. Grep the file for a marker first. The whole suite runs in well under a
+second, so a mutation costs nothing.
 
 ## Style
 
@@ -111,9 +163,10 @@ literals (`{a: 1}`, not `{ a: 1 }`).
   SDK, and `registerTool` throws `inputSchema must be a Zod schema or raw shape` for anything
   else — the SDK's validation *is* zod. npm auto-installs it even if it leaves `package.json`,
   so removing the direct dependency buys nothing and unpins the version.
-- **`ZodError` details live on `.issues`, not `.errors`** (zod 4 renamed it). Nothing in `src/`
-  reads them today — the SDK formats the message — but `.errors` silently yields `undefined`
-  rather than failing, so it is worth knowing before writing a handler that inspects them.
+- **`ZodError` details live on `.issues`, not `.errors`** (zod 4 renamed it). The only reader in
+  `src/` is the `create_draft_post.args.invalid` log — the SDK formats the message it sends to
+  the client — and `.errors` silently yields `undefined` rather than failing, so a handler that
+  inspects them logs nothing and reports no error.
 
 ## Verifying the server actually works
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,13 @@ made, the outcome. `src/logger.js` is the only writer — never `console.log`.
   muting the server.
 - **Secrets are redacted by key name**, recursively: `/token|cookie|password|secret|auth|session|^sid$/i`
   becomes `***`. So pass whole objects (`{headers}`, `{args}`, `{draft}`) and let the logger
-  handle it, rather than picking fields by hand at each call site. `sid` is anchored on purpose;
-  as a substring it would also blank out `considerations`. Post content is *not* truncated —
-  it is usually the thing being debugged.
+  handle it, rather than picking fields by hand at each call site. Post content is *not*
+  truncated — it is usually the thing being debugged.
+- **Two carve-outs keep the pattern from eating the diagnosis.** `sid` is anchored (`^sid$`)
+  because as a substring it also matches `considerations`. And a **boolean** under a secret key
+  survives: one bit cannot leak a credential, while redacting it turns the useful part of the
+  line into `***` — `has_auth_token: Boolean(auth_token)` logged as `"***"`, stating only that
+  the field exists, is a bug this repo has already shipped once.
 - The logger never throws: `Error` values are expanded to `{name, message, stack}` (raw, they
   serialize to `{}`), cycles become `[Circular]`, and an unserializable payload degrades to a
   `log_error` note.
@@ -74,9 +78,11 @@ made, the outcome. `src/logger.js` is the only writer — never `console.log`.
   useful one in the file when a model cannot get a call right.
 - Tool failures are logged **and rethrown**: `McpServer` still converts them into an `isError`
   result. Swallowing one would change the protocol behaviour.
-- `setTestEnv()` forces `SUBSTACK_MCP_LOG_LEVEL=silent`, so the in-process suites do not print
-  a line per tool call over the reporter. Assert on logs with `test/helpers/capture-logs.js`,
-  which sets the level and captures stderr for the duration of a call.
+- `setTestEnv()` forces `SUBSTACK_MCP_LOG_LEVEL=silent`. **Call it from every spec whose subject
+  logs**, including one that reads no env var of its own — `SubstackPost.spec.js` needs it purely
+  for this, and the two `src/api/substack` suites once printed 14 log lines over the reporter for
+  want of it. Assert on logs with `test/helpers/capture-logs.js`, which sets the level and
+  captures stderr for the duration of a call.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ This option requires Docker to be installed on your system.
 
 2. Replace `<SUBSTACK_PUBLICATION_URL>`, `<YOUR_SESSION_TOKEN>` and `<YOUR_USER_ID>` with your credentials.
 
+### 🪵 Logs
+
+The server logs what it does as one JSON object per line, on **stderr** — MCP clients collect it
+into their own log file (on macOS, Claude Desktop writes it to
+`~/Library/Logs/Claude/mcp-server-substack-api.log`). It is the fastest way to see what your LLM
+actually sent when a call does not do what you expected:
+
+```json
+{"ts":"2026-08-07T10:12:03.114Z","level":"info","msg":"tool.call.start","tool":"create_draft_post","args":{"title":"My title","subtitle":"My subtitle","body":"…"}}
+{"ts":"2026-08-07T10:12:03.402Z","level":"info","msg":"substack.response","status":200,"duration_ms":287}
+{"ts":"2026-08-07T10:12:03.403Z","level":"info","msg":"create_draft_post.created","draft_id":167712345}
+```
+
+Set the optional `SUBSTACK_MCP_LOG_LEVEL` env var alongside your credentials to change how much
+is written:
+
+| Value | What you get |
+|---|---|
+| `silent` | nothing |
+| `error` | failed calls only |
+| `warn` | the above, plus calls the server rejected (bad arguments) |
+| `info` *(default)* | the above, plus every tool call, request and response |
+| `debug` | the above, plus full payloads and every JSON-RPC message |
+
+Your session token is never written to the log, at any level.
+
 ## 💻 Popular Clients that supports MCPs
 
 > For a complete list of MCP clients and their feature support, visit the [official MCP clients page](https://modelcontextprotocol.io/clients).

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ is written:
 |---|---|
 | `silent` | nothing |
 | `error` | failed calls only |
-| `warn` | the above, plus calls the server rejected (bad arguments) |
+| `warn` | the above, plus every answer the client received as an error — including calls rejected for bad arguments before they ran |
 | `info` *(default)* | the above, plus every tool call, request and response |
 | `debug` | the above, plus full payloads and every JSON-RPC message |
 

--- a/src/api/substack/SubstackApi.js
+++ b/src/api/substack/SubstackApi.js
@@ -1,3 +1,5 @@
+import {logger} from "../../logger.js";
+
 export default class SubstackApi {
   constructor({
                 email = null,
@@ -12,20 +14,42 @@ export default class SubstackApi {
     this.publication_url = new URL('api/v1', publication_url).toString();
     this.hostname = publication_url
     this.auth_cookie = `substack.sid=${auth_token}; connect.sid=${auth_token};`
+
+    logger.debug('substack_api.created', {
+      base_url: this.base_url,
+      publication_url: this.publication_url,
+      hostname: this.hostname,
+      // The token itself never gets logged; whether one arrived at all is the diagnosis.
+      has_auth_token: Boolean(auth_token),
+    });
   }
 
   static async handleResponse(response) {
     if (!response.ok) {
+      // Substack explains the refusal in the body, and the thrown message carries only the
+      // status. Reading it here is what makes a 400 debuggable at all.
+      const body = await response.text().catch(() => '<unreadable body>');
+      logger.error('substack.response.error', {
+        status: response.status,
+        statusText: response.statusText,
+        body,
+      });
+
       throw new Error(`SubstackAPIException: ${response.status} ${response.statusText}`);
     }
 
     const text = await response.text();
+    let parsed;
 
     try {
-      return JSON.parse(text);
+      parsed = JSON.parse(text);
     } catch (error) {
+      logger.error('substack.response.invalid', {status: response.status, body: text});
       throw new Error(`SubstackRequestException: Invalid Response: ${text}`);
     }
+
+    logger.debug('substack.response.body', {status: response.status, body: parsed});
+    return parsed;
   }
 
   async postDraft(body) {
@@ -36,7 +60,33 @@ export default class SubstackApi {
     headers['Cookie'] = this.auth_cookie;
     headers['referer'] = `${this.hostname}/publish/post`;
 
-    const response = await fetch(url, {method: 'POST', headers, body: JSON.stringify(body)});
+    const startedAt = Date.now();
+    // `headers` carries the session cookie: the logger redacts it by key name.
+    logger.info('substack.request', {method: 'POST', url, headers, body});
+
+    let response;
+
+    try {
+      response = await fetch(url, {method: 'POST', headers, body: JSON.stringify(body)});
+    } catch (error) {
+      // fetch only rejects on a transport failure — DNS, TLS, connection reset. A non-2xx
+      // answer resolves, and is handled by handleResponse below.
+      logger.error('substack.request.failed', {
+        method: 'POST',
+        url,
+        duration_ms: Date.now() - startedAt,
+        error,
+      });
+      throw error;
+    }
+
+    logger.info('substack.response', {
+      method: 'POST',
+      url,
+      status: response.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return SubstackApi.handleResponse(response)
   }
 }

--- a/src/api/substack/SubstackApi.spec.js
+++ b/src/api/substack/SubstackApi.spec.js
@@ -3,13 +3,23 @@ import assert from 'node:assert/strict';
 import {HttpResponse} from 'msw';
 import SubstackApi from './SubstackApi.js';
 import {createMswServer, DRAFTS_URL, DRAFT_RESPONSE} from '../../../test/helpers/msw-server.js';
-import {TEST_ENV} from '../../../test/helpers/env.js';
+import {TEST_ENV, setTestEnv} from '../../../test/helpers/env.js';
+import {captureLogs} from '../../../test/helpers/capture-logs.js';
 
 const msw = createMswServer();
+let restoreEnv;
 
-before(() => msw.start());
+// setTestEnv is here for its SUBSTACK_MCP_LOG_LEVEL=silent: this file reads no env var, but
+// every method it exercises logs, and the lines would otherwise land in the reporter output.
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
 afterEach(() => msw.reset());
-after(() => msw.stop());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
 
 function createApi() {
   return new SubstackApi({
@@ -111,3 +121,42 @@ describe('SubstackApi — postDraft', () => {
     assert.match(error.message, /^SubstackRequestException: Invalid Response: not json$/);
   });
 });
+
+describe('SubstackApi — logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  // `has_auth_token` matches the redaction pattern twice over (`auth`, `token`) and used to be
+  // logged as `***`, which said only that the field existed. Booleans are now exempt.
+  test('the constructor reports whether a token arrived, without logging it', async () => {
+    const lines = await captureLogs(() => createApi());
+
+    const created = find(lines, 'substack_api.created');
+    assert.equal(created.has_auth_token, true);
+    assert.equal(created.publication_url, 'https://test.substack.com/api/v1');
+    assert.doesNotMatch(JSON.stringify(created), new RegExp(TEST_ENV.SUBSTACK_SESSION_TOKEN));
+  });
+
+  test('a successful response is logged with its parsed body', async () => {
+    const lines = await captureLogs(() => createApi().postDraft({draft_title: 'Title'}));
+
+    const body = find(lines, 'substack.response.body');
+    assert.equal(body.status, 200);
+    assert.deepEqual(body.body, DRAFT_RESPONSE);
+  });
+
+  test('a 2xx body that is not JSON is logged before the exception', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('not json', {status: 200})));
+
+    const lines = await captureLogs(() => createApi().postDraft({}).catch(() => {}));
+
+    const invalid = find(lines, 'substack.response.invalid');
+    assert.equal(invalid.status, 200);
+    assert.equal(invalid.body, 'not json');
+  });
+});
+// `substack.request.failed` is covered in src/index.spec.js instead: a fetch to a closed port
+// here would be flagged by MSW as an unhandled request, since it intercepts the whole process.

--- a/src/api/substack/SubstackPost.js
+++ b/src/api/substack/SubstackPost.js
@@ -1,8 +1,9 @@
 import {logger} from "../../logger.js";
 
-// Only the constructor and the methods on the current code path log, all at `debug`. The
-// fluent helpers below (`text`, `marks`, `add`, …) run once per chunk of a document and would
-// bury every other line at the volume of a real post.
+// Logging covers the constructor and the entry points a caller drives directly — the setters
+// and `getDraft` — at `debug`, plus `setSection`'s rejection at `error`. The fluent helpers
+// (`text`, `marks`, `add`, …) stay silent: they run once per chunk of a document and would bury
+// every other line at the volume of a real post.
 export default class SubstackPost {
   constructor({title = null, subtitle = null, user_id, audience = null, write_comment_permissions = null, subscriber_set_id = null }) {
     this.draft_title = title;

--- a/src/api/substack/SubstackPost.js
+++ b/src/api/substack/SubstackPost.js
@@ -1,3 +1,8 @@
+import {logger} from "../../logger.js";
+
+// Only the constructor and the methods on the current code path log, all at `debug`. The
+// fluent helpers below (`text`, `marks`, `add`, …) run once per chunk of a document and would
+// bury every other line at the volume of a real post.
 export default class SubstackPost {
   constructor({title = null, subtitle = null, user_id, audience = null, write_comment_permissions = null, subscriber_set_id = null }) {
     this.draft_title = title;
@@ -19,24 +24,38 @@ export default class SubstackPost {
       this.type = 'adhoc_email'
     }
 
+    logger.debug('draft.created', {
+      draft_title: this.draft_title,
+      draft_subtitle: this.draft_subtitle,
+      draft_bylines: this.draft_bylines,
+      audience: this.audience,
+      write_comment_permissions: this.write_comment_permissions,
+      type: this.type ?? null,
+    });
   }
 
   setBody(body) {
+    logger.debug('draft.setBody', {body});
     this.draft_body = body;
   }
 
   setTitle(title) {
+    logger.debug('draft.setTitle', {title});
     this.draft_title = title;
   }
 
   setSubtitle(subtitle) {
+    logger.debug('draft.setSubtitle', {subtitle});
     this.draft_subtitle = subtitle;
   }
 
   setSection(name, sections) {
+    logger.debug('draft.setSection', {name, sections});
+
     const section = sections.find(s => s.name === name);
 
     if (!section) {
+      logger.error('draft.setSection.unknown', {name, available: sections.map(s => s.name)});
       throw new Error(`Section ${name} does not exist`);
     }
 
@@ -322,7 +341,10 @@ export default class SubstackPost {
 
   getDraft() {
     const {draft_body, ...rest} = this;
-    return {...rest, draft_body: JSON.stringify(draft_body)};
+    const draft = {...rest, draft_body: JSON.stringify(draft_body)};
+
+    logger.debug('draft.getDraft', {draft});
+    return draft;
   }
 
   subscribeWithCaption(message = null) {

--- a/src/api/substack/SubstackPost.spec.js
+++ b/src/api/substack/SubstackPost.spec.js
@@ -1,6 +1,20 @@
-import {test, describe} from 'node:test';
+import {test, describe, before, after} from 'node:test';
 import assert from 'node:assert/strict';
 import SubstackPost from './SubstackPost.js';
+import {setTestEnv} from '../../../test/helpers/env.js';
+import {captureLogs} from '../../../test/helpers/capture-logs.js';
+
+let restoreEnv;
+
+// setTestEnv is here for its SUBSTACK_MCP_LOG_LEVEL=silent: this file reads no env var, but the
+// constructor and every setter log, and the lines would otherwise land in the reporter output.
+before(() => {
+  restoreEnv = setTestEnv();
+});
+
+after(() => {
+  restoreEnv();
+});
 
 describe('SubstackPost — constructor', () => {
   test('applies the defaults and coerces user_id to an integer', () => {
@@ -99,6 +113,65 @@ describe('SubstackPost — getDraft', () => {
     post.setBody('testo semplice');
 
     assert.equal(post.getDraft().draft_body, '"testo semplice"');
+  });
+});
+
+describe('SubstackPost — logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('the constructor records the fields it derived', async () => {
+    const lines = await captureLogs(() => new SubstackPost({user_id: '42', title: 'T'}));
+
+    const created = find(lines, 'draft.created');
+    assert.equal(created.draft_title, 'T');
+    assert.deepEqual(created.draft_bylines, [{id: 42, is_guest: false}]);
+    assert.equal(created.audience, 'everyone');
+  });
+
+  test('each setter records what it was given', async () => {
+    const post = new SubstackPost({user_id: '1'});
+
+    const lines = await captureLogs(() => {
+      post.setTitle('New title');
+      post.setSubtitle('New subtitle');
+      post.setBody({type: 'doc', content: [{type: 'paragraph'}]});
+    });
+
+    assert.equal(find(lines, 'draft.setTitle').title, 'New title');
+    assert.equal(find(lines, 'draft.setSubtitle').subtitle, 'New subtitle');
+    assert.deepEqual(find(lines, 'draft.setBody').body.content, [{type: 'paragraph'}]);
+  });
+
+  test('getDraft records the payload that is about to be sent', async () => {
+    const post = new SubstackPost({user_id: '1', title: 'T'});
+
+    const lines = await captureLogs(() => post.getDraft());
+
+    const {draft} = find(lines, 'draft.getDraft');
+    assert.equal(draft.draft_title, 'T');
+    assert.equal(draft.draft_body, '{"type":"doc","content":[]}');
+  });
+
+  test('a section is recorded, and an unknown one names the available sections', async () => {
+    const post = new SubstackPost({user_id: '1'});
+    const sections = [{name: 'News', id: 7}];
+
+    const lines = await captureLogs(() => {
+      post.setSection('News', sections);
+      assert.throws(() => post.setSection('Missing', sections));
+    });
+
+    assert.equal(find(lines, 'draft.setSection').name, 'News');
+
+    // The thrown message names only what was asked for; the log is where a caller can see what
+    // it should have asked for instead.
+    const unknown = find(lines, 'draft.setSection.unknown');
+    assert.equal(unknown.name, 'Missing');
+    assert.deepEqual(unknown.available, ['News']);
   });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,33 @@
 
 import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
 import {createServer} from "./server.js";
+import {logger, logOutgoingMessages} from "./logger.js";
 
 // check envs
-if (!process.env.SUBSTACK_PUBLICATION_URL || !process.env.SUBSTACK_SESSION_TOKEN || !process.env.SUBSTACK_USER_ID) {
+const REQUIRED_ENV = ["SUBSTACK_PUBLICATION_URL", "SUBSTACK_SESSION_TOKEN", "SUBSTACK_USER_ID"];
+const missingEnv = REQUIRED_ENV.filter((name) => !process.env[name]);
+
+if (missingEnv.length > 0) {
+  // Which variable is missing is the whole diagnosis, and the thrown message cannot say —
+  // clients surface it verbatim and its wording is pinned by the tests.
+  logger.error("server.env.missing", {missing: missingEnv});
   throw new Error("SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN and SUBSTACK_USER_ID must be set");
 }
 
+logger.info("server.starting", {
+  publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+  user_id: process.env.SUBSTACK_USER_ID,
+  log_level: process.env.SUBSTACK_MCP_LOG_LEVEL || "info",
+  node: process.version,
+});
+
 const server = createServer();
 
-const transport = new StdioServerTransport();
-server.connect(transport).catch(() => {
-  process.exit(1);
-});
+const transport = logOutgoingMessages(new StdioServerTransport());
+server.connect(transport).then(
+  () => logger.info("server.ready", {transport: "stdio"}),
+  (error) => {
+    logger.error("server.connect.failed", {error});
+    process.exit(1);
+  }
+);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -12,6 +12,16 @@ const HANDSHAKE = [
   '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}',
 ].join('\n') + '\n';
 
+const CALL_TOOL = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 3,
+  method: 'tools/call',
+  params: {
+    name: 'create_draft_post',
+    arguments: {title: 'A title', subtitle: 'A subtitle', body: 'A body'},
+  },
+}) + '\n';
+
 /**
  * Runs the real entrypoint as a child process, since index.js does its work at import time
  * and cannot be exercised in-process. `env` fully replaces the SUBSTACK_* variables, so a
@@ -43,6 +53,17 @@ function runEntrypoint({env = TEST_ENV, stdin = ''} = {}) {
   });
 }
 
+/**
+ * Parses the structured log lines out of the child's stderr. Anything that is not JSON — a
+ * stack trace, a Node warning — is dropped, so the callers below assert on the log itself.
+ */
+function logLines(stderr) {
+  return stderr
+    .split('\n')
+    .filter((line) => line.trim().startsWith('{'))
+    .map((line) => JSON.parse(line));
+}
+
 describe('entrypoint — environment check', () => {
   for (const missing of Object.keys(TEST_ENV)) {
     test(`refuses to start when ${missing} is missing`, async () => {
@@ -57,6 +78,11 @@ describe('entrypoint — environment check', () => {
         stderr,
         /SUBSTACK_PUBLICATION_URL, SUBSTACK_SESSION_TOKEN and SUBSTACK_USER_ID must be set/
       );
+
+      // The thrown message lists all three variables whatever is wrong; only the log says
+      // which one is actually missing, which is the whole point of logging it.
+      const logged = logLines(stderr).find((line) => line.msg === 'server.env.missing');
+      assert.deepEqual(logged.missing, [missing]);
     });
   }
 
@@ -80,7 +106,13 @@ describe('entrypoint — stdio transport', () => {
     // Without this, a server that answered the handshake and then hung would still satisfy
     // every assertion below — the replies are already in stdout by the time it is killed.
     assert.equal(signal, null, 'the process should exit on its own, not be killed');
-    assert.equal(stderr, '', 'nothing should be written to stderr');
+
+    // stderr now carries the structured log. What must hold is that it carries *only* that:
+    // a stray console.log or a warning printed on the wrong stream is how the transport gets
+    // corrupted, and JSON.parse below is the only thing standing between the two.
+    for (const line of stderr.split('\n').filter((line) => line.trim() !== '')) {
+      assert.doesNotThrow(() => JSON.parse(line), `stderr should only carry log lines: ${line}`);
+    }
 
     const messages = stdout
       .split('\n')
@@ -113,5 +145,88 @@ describe('entrypoint — stdio transport', () => {
     // helper's timeout, and a killed process must never read as having exited cleanly.
     assert.equal(signal, null, 'the process should exit on its own, not be killed');
     assert.equal(code, 0);
+  });
+});
+
+describe('entrypoint — logging', () => {
+  test('reports the startup on stderr, leaving stdout to the protocol', async () => {
+    const {stdout, stderr} = await runEntrypoint({stdin: HANDSHAKE});
+
+    const messages = logLines(stderr);
+    const starting = messages.find((line) => line.msg === 'server.starting');
+    const registered = messages.find((line) => line.msg === 'tool.registered');
+    const ready = messages.find((line) => line.msg === 'server.ready');
+
+    assert.equal(starting.publication_url, TEST_ENV.SUBSTACK_PUBLICATION_URL);
+    assert.equal(starting.user_id, TEST_ENV.SUBSTACK_USER_ID);
+    assert.equal(registered.tool, 'create_draft_post');
+    assert.equal(ready.transport, 'stdio');
+
+    // Everything on stdout must still parse as JSON-RPC: no log line may have leaked there.
+    for (const line of stdout.split('\n').filter((line) => line.trim() !== '')) {
+      assert.equal(JSON.parse(line).jsonrpc, '2.0');
+    }
+  });
+
+  // The token only ever reaches a log line through the Cookie header of an outgoing request,
+  // so the handshake alone cannot prove it is redacted — asserting on it there passes whether
+  // redaction works or not. This drives a real tool call instead, at debug level, and points
+  // the publication at a closed local port: the request is logged before fetch is called, then
+  // fails with ECONNREFUSED without a packet leaving the machine. MSW cannot help here, it
+  // cannot instrument a child process.
+  test('never writes the session token to the log, not even in a request header', async () => {
+    const {stderr} = await runEntrypoint({
+      env: {
+        ...TEST_ENV,
+        SUBSTACK_PUBLICATION_URL: 'http://127.0.0.1:1',
+        SUBSTACK_MCP_LOG_LEVEL: 'debug',
+      },
+      stdin: HANDSHAKE + CALL_TOOL,
+    });
+
+    const request = logLines(stderr).find((line) => line.msg === 'substack.request');
+
+    assert.ok(request, 'the request must be logged, or this test asserts nothing');
+    assert.equal(request.headers.Cookie, '***');
+    assert.doesNotMatch(stderr, new RegExp(TEST_ENV.SUBSTACK_SESSION_TOKEN));
+  });
+
+  test('logs the failure of a tool call, with the reason the client is given', async () => {
+    const {stderr} = await runEntrypoint({
+      env: {
+        ...TEST_ENV,
+        SUBSTACK_PUBLICATION_URL: 'http://127.0.0.1:1',
+        SUBSTACK_MCP_LOG_LEVEL: 'debug',
+      },
+      stdin: HANDSHAKE + CALL_TOOL,
+    });
+
+    const lines = logLines(stderr);
+    const start = lines.find((line) => line.msg === 'tool.call.start');
+    const failed = lines.find((line) => line.msg === 'substack.request.failed');
+    const error = lines.find((line) => line.msg === 'tool.call.error');
+
+    assert.equal(start.tool, 'create_draft_post');
+    assert.equal(start.args.title, 'A title');
+    assert.equal(typeof failed.duration_ms, 'number');
+    // The stack is the part the client never sees: it exists only in the log.
+    assert.match(error.error.stack, /SubstackApi/);
+  });
+
+  test('SUBSTACK_MCP_LOG_LEVEL=silent produces no output while the server still works', async () => {
+    const {stdout, stderr} = await runEntrypoint({
+      env: {...TEST_ENV, SUBSTACK_MCP_LOG_LEVEL: 'silent'},
+      stdin: HANDSHAKE,
+    });
+
+    assert.equal(stderr, '');
+
+    const listTools = stdout
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => JSON.parse(line))
+      .find((message) => message.id === 2);
+
+    assert.equal(listTools.result.tools[0].name, 'create_draft_post');
   });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -150,7 +150,12 @@ describe('entrypoint — stdio transport', () => {
 
 describe('entrypoint — logging', () => {
   test('reports the startup on stderr, leaving stdout to the protocol', async () => {
-    const {stdout, stderr} = await runEntrypoint({stdin: HANDSHAKE});
+    const {stdout, stderr, signal} = await runEntrypoint({stdin: HANDSHAKE});
+
+    // Every test reading runEntrypoint asserts this: the helper SIGTERMs a hung child after
+    // 10s, and by then the expected output is already captured, so a log assertion alone would
+    // pass on a server that logged correctly and then hung.
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
 
     const messages = logLines(stderr);
     const starting = messages.find((line) => line.msg === 'server.starting');
@@ -175,7 +180,7 @@ describe('entrypoint — logging', () => {
   // fails with ECONNREFUSED without a packet leaving the machine. MSW cannot help here, it
   // cannot instrument a child process.
   test('never writes the session token to the log, not even in a request header', async () => {
-    const {stderr} = await runEntrypoint({
+    const {stderr, signal} = await runEntrypoint({
       env: {
         ...TEST_ENV,
         SUBSTACK_PUBLICATION_URL: 'http://127.0.0.1:1',
@@ -183,6 +188,8 @@ describe('entrypoint — logging', () => {
       },
       stdin: HANDSHAKE + CALL_TOOL,
     });
+
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
 
     const request = logLines(stderr).find((line) => line.msg === 'substack.request');
 
@@ -192,7 +199,7 @@ describe('entrypoint — logging', () => {
   });
 
   test('logs the failure of a tool call, with the reason the client is given', async () => {
-    const {stderr} = await runEntrypoint({
+    const {stderr, signal} = await runEntrypoint({
       env: {
         ...TEST_ENV,
         SUBSTACK_PUBLICATION_URL: 'http://127.0.0.1:1',
@@ -200,6 +207,8 @@ describe('entrypoint — logging', () => {
       },
       stdin: HANDSHAKE + CALL_TOOL,
     });
+
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
 
     const lines = logLines(stderr);
     const start = lines.find((line) => line.msg === 'tool.call.start');
@@ -214,11 +223,12 @@ describe('entrypoint — logging', () => {
   });
 
   test('SUBSTACK_MCP_LOG_LEVEL=silent produces no output while the server still works', async () => {
-    const {stdout, stderr} = await runEntrypoint({
+    const {stdout, stderr, signal} = await runEntrypoint({
       env: {...TEST_ENV, SUBSTACK_MCP_LOG_LEVEL: 'silent'},
       stdin: HANDSHAKE,
     });
 
+    assert.equal(signal, null, 'the process should exit on its own, not be killed');
     assert.equal(stderr, '');
 
     const listTools = stdout

--- a/src/logger.js
+++ b/src/logger.js
@@ -54,7 +54,10 @@ function redact(value, seen = new WeakSet()) {
     : Object.fromEntries(
       Object.entries(value).map(([key, item]) => [
         key,
-        SECRET_KEY.test(key) ? REDACTED : redact(item, seen),
+        // A boolean under a secret key is kept: one bit cannot leak a credential, and the
+        // diagnostic flags worth logging are named after the secret they describe. Redacting
+        // `has_auth_token` would silently turn the only useful part of the line into `***`.
+        SECRET_KEY.test(key) && typeof item !== 'boolean' ? REDACTED : redact(item, seen),
       ])
     );
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,116 @@
+// Structured logging for the whole server, in one place.
+//
+// Everything goes to **stderr**, never stdout: on a stdio transport stdout carries the
+// JSON-RPC stream, and a single byte written there corrupts the protocol and drops the
+// client. MCP hosts (Claude Desktop, Claude Code, Cursor) collect the server's stderr into
+// their own log files, which is where these lines are meant to be read.
+//
+// One JSON object per line, so a log file can be filtered with grep and parsed with jq:
+//   {"ts":"2026-08-07T10:12:03.114Z","level":"info","msg":"tool.call.start","tool":"…"}
+
+const LEVELS = {silent: 0, error: 1, warn: 2, info: 3, debug: 4};
+
+const DEFAULT_LEVEL = 'info';
+
+// Keys whose value must never reach a log file. Matched on the key, not the value, so a
+// token nested anywhere in a payload is redacted without every call site remembering to.
+// `sid` is anchored on purpose: as a substring it would also redact `consider`, `aside` and
+// anything else that happens to contain it. `session` covers `session_id` and `session_token`.
+const SECRET_KEY = /token|cookie|password|secret|auth|session|^sid$/i;
+
+const REDACTED = '***';
+
+// Read at call time, not at import: SUBSTACK_MCP_LOG_LEVEL may be set after this module is
+// imported (tests do exactly that), and no module here may read the environment at import
+// time. An unknown value falls back to the default rather than silencing the server.
+function currentLevel() {
+  const configured = (process.env.SUBSTACK_MCP_LOG_LEVEL || '').trim().toLowerCase();
+  return LEVELS[configured] ?? LEVELS[DEFAULT_LEVEL];
+}
+
+/**
+ * Copies `value`, replacing secrets with `***`. Errors become plain objects — JSON.stringify
+ * renders an Error as `{}`, which is how a stack trace silently disappears from a log. Cycles
+ * are cut with `[Circular]`; `seen` is unwound on the way out so that a value merely repeated
+ * across siblings is still logged in full.
+ */
+function redact(value, seen = new WeakSet()) {
+  if (value instanceof Error) {
+    return {name: value.name, message: value.message, stack: value.stack};
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+
+  seen.add(value);
+
+  const redacted = Array.isArray(value)
+    ? value.map((item) => redact(item, seen))
+    : Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        SECRET_KEY.test(key) ? REDACTED : redact(item, seen),
+      ])
+    );
+
+  seen.delete(value);
+  return redacted;
+}
+
+function emit(level, msg, fields) {
+  if (LEVELS[level] > currentLevel()) {
+    return;
+  }
+
+  const ts = new Date().toISOString();
+  let line;
+
+  try {
+    line = JSON.stringify({ts, level, msg, ...redact(fields ?? {})});
+  } catch (error) {
+    // A logger that throws is worse than no logger at all: it would fail the tool call it was
+    // only supposed to describe. BigInt and getters that throw still get here past `redact`.
+    line = JSON.stringify({ts, level, msg, log_error: `unserializable fields: ${error.message}`});
+  }
+
+  process.stderr.write(`${line}\n`);
+}
+
+export const logger = {
+  error: (msg, fields) => emit('error', msg, fields),
+  warn: (msg, fields) => emit('warn', msg, fields),
+  info: (msg, fields) => emit('info', msg, fields),
+  debug: (msg, fields) => emit('debug', msg, fields),
+};
+
+/**
+ * Logs every message the server sends, by wrapping `transport.send` in place.
+ *
+ * This is the only way to see a rejected tool call: `McpServer` validates arguments against
+ * the tool schema itself and answers with an `Input validation error` before the registered
+ * handler runs, so nothing inside the handler can report it. That rejection is the single
+ * most useful line when an LLM cannot get a call right, hence `warn` for failures and
+ * `debug` for the rest of the traffic.
+ */
+export function logOutgoingMessages(transport) {
+  const send = transport.send.bind(transport);
+
+  transport.send = async (message, options) => {
+    if (message?.error) {
+      logger.warn('protocol.error', {id: message.id, error: message.error});
+    } else if (message?.result?.isError) {
+      logger.warn('tool.result.error', {id: message.id, content: message.result.content});
+    } else {
+      logger.debug('protocol.send', {message});
+    }
+
+    return send(message, options);
+  };
+
+  return transport;
+}

--- a/src/logger.spec.js
+++ b/src/logger.spec.js
@@ -1,0 +1,337 @@
+import {test, describe, beforeEach, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {logger, logOutgoingMessages} from './logger.js';
+
+let savedLevel;
+
+beforeEach(() => {
+  savedLevel = process.env.SUBSTACK_MCP_LOG_LEVEL;
+});
+
+afterEach(() => {
+  if (savedLevel === undefined) {
+    delete process.env.SUBSTACK_MCP_LOG_LEVEL;
+  } else {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = savedLevel;
+  }
+});
+
+/**
+ * Captures what the logger writes to stderr, and asserts nothing reaches stdout — on a stdio
+ * transport stdout belongs to the JSON-RPC stream.
+ */
+function capture(run) {
+  const stderr = [];
+  const stdout = [];
+  const originalStderr = process.stderr.write;
+  const originalStdout = process.stdout.write;
+
+  process.stderr.write = (chunk) => {
+    stderr.push(String(chunk));
+    return true;
+  };
+  process.stdout.write = (chunk) => {
+    stdout.push(String(chunk));
+    return true;
+  };
+
+  try {
+    run();
+  } finally {
+    process.stderr.write = originalStderr;
+    process.stdout.write = originalStdout;
+  }
+
+  return {stderr, stdout};
+}
+
+function logLines(run) {
+  const {stderr, stdout} = capture(run);
+
+  assert.deepEqual(stdout, [], 'the logger must never write to stdout');
+
+  return stderr
+    .join('')
+    .split('\n')
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line));
+}
+
+describe('logger — levels', () => {
+  test('info is the default: error, warn and info pass, debug does not', () => {
+    delete process.env.SUBSTACK_MCP_LOG_LEVEL;
+
+    const lines = logLines(() => {
+      logger.error('an error');
+      logger.warn('a warning');
+      logger.info('an info');
+      logger.debug('a debug');
+    });
+
+    assert.deepEqual(lines.map((line) => line.msg), ['an error', 'a warning', 'an info']);
+  });
+
+  test('debug lets everything through', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'debug';
+
+    const lines = logLines(() => {
+      logger.error('an error');
+      logger.debug('a debug');
+    });
+
+    assert.deepEqual(lines.map((line) => line.level), ['error', 'debug']);
+  });
+
+  test('silent writes nothing at all', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'silent';
+
+    const lines = logLines(() => {
+      logger.error('an error');
+      logger.warn('a warning');
+      logger.info('an info');
+      logger.debug('a debug');
+    });
+
+    assert.deepEqual(lines, []);
+  });
+
+  test('error only silences everything below it', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'error';
+
+    const lines = logLines(() => {
+      logger.error('an error');
+      logger.warn('a warning');
+      logger.info('an info');
+    });
+
+    assert.deepEqual(lines.map((line) => line.msg), ['an error']);
+  });
+
+  test('the value is read per call, not at import', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'silent';
+
+    const lines = logLines(() => {
+      logger.info('suppressed');
+      process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+      logger.info('emitted');
+    });
+
+    assert.deepEqual(lines.map((line) => line.msg), ['emitted']);
+  });
+
+  test('an unknown level falls back to info rather than muting the server', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'verbose';
+
+    const lines = logLines(() => {
+      logger.info('an info');
+      logger.debug('a debug');
+    });
+
+    assert.deepEqual(lines.map((line) => line.msg), ['an info']);
+  });
+
+  test('the level is matched case-insensitively and trimmed', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = '  DEBUG  ';
+
+    const lines = logLines(() => logger.debug('a debug'));
+
+    assert.equal(lines.length, 1);
+  });
+});
+
+describe('logger — line format', () => {
+  test('emits one JSON line per call, carrying ts, level, msg and the fields', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const {stderr} = capture(() => logger.info('tool.call.start', {tool: 'create_draft_post'}));
+
+    assert.equal(stderr.length, 1);
+    assert.ok(stderr[0].endsWith('\n'), 'the line must be newline-terminated');
+
+    const line = JSON.parse(stderr[0]);
+    assert.equal(line.level, 'info');
+    assert.equal(line.msg, 'tool.call.start');
+    assert.equal(line.tool, 'create_draft_post');
+    // A timestamp is what makes two lines comparable when reading a log after the fact.
+    assert.equal(new Date(line.ts).toISOString(), line.ts);
+  });
+
+  test('works with no fields at all', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const [line] = logLines(() => logger.info('server.ready'));
+
+    assert.deepEqual(Object.keys(line).sort(), ['level', 'msg', 'ts']);
+  });
+});
+
+describe('logger — redaction', () => {
+  test('replaces secrets by key name, however deeply nested', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const [line] = logLines(() => logger.info('substack.request', {
+      url: 'https://test.substack.com/api/v1/drafts',
+      auth_token: 'super-secret',
+      headers: {Cookie: 'substack.sid=super-secret;', 'Content-Type': 'application/json'},
+      nested: [{password: 'hunter2'}, {session_id: 'abc'}, {sid: 'xyz'}],
+    }));
+
+    assert.equal(line.url, 'https://test.substack.com/api/v1/drafts');
+    assert.equal(line.auth_token, '***');
+    assert.equal(line.headers.Cookie, '***');
+    assert.equal(line.headers['Content-Type'], 'application/json');
+    assert.equal(line.nested[0].password, '***');
+    assert.equal(line.nested[1].session_id, '***');
+    assert.equal(line.nested[2].sid, '***');
+
+    // The point of redacting by key: the value must not survive anywhere in the line.
+    assert.doesNotMatch(JSON.stringify(line), /super-secret|hunter2|xyz/);
+  });
+
+  // The counterpart of the anchored `sid` alternative: matching it as a substring would blank
+  // out ordinary fields, and a log full of `***` is as useless as no log.
+  test('does not redact keys that merely contain a secret word as a substring', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const [line] = logLines(() => logger.info('draft.built', {
+      considerations: 'kept',
+      subtitle: 'kept',
+      draft_section_id: 42,
+    }));
+
+    assert.equal(line.considerations, 'kept');
+    assert.equal(line.subtitle, 'kept');
+    assert.equal(line.draft_section_id, 42);
+  });
+
+  test('leaves the post content untouched — that is what is being debugged', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const body = 'A'.repeat(5000);
+    const [line] = logLines(() => logger.info('tool.call.start', {args: {title: 'T', body}}));
+
+    assert.equal(line.args.body, body);
+  });
+});
+
+describe('logger — resilience', () => {
+  test('renders an Error with its message and stack instead of {}', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const [line] = logLines(() => logger.error('tool.call.error', {
+      error: new Error('SubstackAPIException: 500 Internal Server Error'),
+    }));
+
+    assert.equal(line.error.name, 'Error');
+    assert.equal(line.error.message, 'SubstackAPIException: 500 Internal Server Error');
+    assert.match(line.error.stack, /logger\.spec\.js/);
+  });
+
+  test('a circular payload is logged rather than throwing', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const draft = {title: 'T'};
+    draft.self = draft;
+
+    const [line] = logLines(() => logger.info('draft.built', {draft}));
+
+    assert.equal(line.draft.title, 'T');
+    assert.equal(line.draft.self, '[Circular]');
+  });
+
+  test('a value repeated across siblings is not mistaken for a cycle', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const shared = {type: 'text'};
+    const [line] = logLines(() => logger.info('draft.built', {content: [shared, shared]}));
+
+    assert.deepEqual(line.content, [{type: 'text'}, {type: 'text'}]);
+  });
+
+  test('an unserializable field degrades to a note, and never throws', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const [line] = logLines(() => logger.info('tool.call.start', {args: {id: 10n}}));
+
+    assert.equal(line.msg, 'tool.call.start');
+    assert.match(line.log_error, /unserializable fields/);
+  });
+});
+
+describe('logOutgoingMessages', () => {
+  function fakeTransport() {
+    const sent = [];
+    return {
+      sent,
+      send(message, options) {
+        sent.push({message, options});
+        return Promise.resolve('sent');
+      },
+    };
+  }
+
+  test('logs a rejected tool call at warn — the SDK answers those without the handler running', async () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const transport = logOutgoingMessages(fakeTransport());
+    const message = {
+      jsonrpc: '2.0',
+      id: 2,
+      result: {isError: true, content: [{type: 'text', text: 'Input validation error: …'}]},
+    };
+
+    const lines = logLines(() => transport.send(message));
+
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].level, 'warn');
+    assert.equal(lines[0].msg, 'tool.result.error');
+    assert.equal(lines[0].id, 2);
+    assert.match(lines[0].content[0].text, /Input validation error/);
+  });
+
+  test('logs a JSON-RPC error at warn', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const transport = logOutgoingMessages(fakeTransport());
+
+    const lines = logLines(() => transport.send({
+      jsonrpc: '2.0',
+      id: 3,
+      error: {code: -32601, message: 'Method not found'},
+    }));
+
+    assert.deepEqual(lines.map((line) => [line.level, line.msg]), [['warn', 'protocol.error']]);
+    assert.equal(lines[0].error.code, -32601);
+  });
+
+  test('successful traffic is debug-only, so info stays readable', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'info';
+
+    const transport = logOutgoingMessages(fakeTransport());
+    const lines = logLines(() => transport.send({jsonrpc: '2.0', id: 1, result: {tools: []}}));
+
+    assert.deepEqual(lines, []);
+  });
+
+  test('successful traffic is logged at debug', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'debug';
+
+    const transport = logOutgoingMessages(fakeTransport());
+    const lines = logLines(() => transport.send({jsonrpc: '2.0', id: 1, result: {tools: []}}));
+
+    assert.deepEqual(lines.map((line) => line.msg), ['protocol.send']);
+  });
+
+  test('still delivers the message, with its options and return value intact', async () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'silent';
+
+    const transport = fakeTransport();
+    logOutgoingMessages(transport);
+
+    const message = {jsonrpc: '2.0', id: 1, result: {}};
+    const returned = await transport.send(message, {relatedRequestId: 7});
+
+    assert.equal(returned, 'sent');
+    assert.deepEqual(transport.sent, [{message, options: {relatedRequestId: 7}}]);
+  });
+});

--- a/src/logger.spec.js
+++ b/src/logger.spec.js
@@ -17,8 +17,9 @@ afterEach(() => {
 });
 
 /**
- * Captures what the logger writes to stderr, and asserts nothing reaches stdout — on a stdio
- * transport stdout belongs to the JSON-RPC stream.
+ * Records what the logger writes to each stream and returns both. It asserts nothing itself —
+ * `logLines` below is what checks that stdout stayed empty, since on a stdio transport stdout
+ * belongs to the JSON-RPC stream. Use `logLines` unless a test needs the raw chunks.
  */
 function capture(run) {
   const stderr = [];
@@ -186,6 +187,23 @@ describe('logger — redaction', () => {
 
     // The point of redacting by key: the value must not survive anywhere in the line.
     assert.doesNotMatch(JSON.stringify(line), /super-secret|hunter2|xyz/);
+  });
+
+  // `has_auth_token` matches the pattern twice over, and redacting it produced
+  // `"has_auth_token":"***"` — a line stating only that the field exists. A boolean cannot
+  // carry a credential, so it survives; anything else under the same key does not.
+  test('keeps a boolean flag named after a secret, but not a string value', () => {
+    process.env.SUBSTACK_MCP_LOG_LEVEL = 'debug';
+
+    const [line] = logLines(() => logger.debug('substack_api.created', {
+      has_auth_token: true,
+      has_password: false,
+      auth_token: 'super-secret',
+    }));
+
+    assert.equal(line.has_auth_token, true);
+    assert.equal(line.has_password, false);
+    assert.equal(line.auth_token, '***');
   });
 
   // The counterpart of the anchored `sid` alternative: matching it as a substring would blank

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
+import {logger} from "./logger.js";
 
 export const tools = {
   create_draft_post: {
@@ -18,9 +19,25 @@ export function createServer() {
   const server = new McpServer({name: "Substack MCP", version: "1.0.0"});
 
   for (const [name, {description, schema, handler}] of Object.entries(tools)) {
-    server.registerTool(name, {description, inputSchema: schema}, async (args) => ({
-      content: [{type: "text", text: JSON.stringify(await handler(args), null, 2)}],
-    }));
+    server.registerTool(name, {description, inputSchema: schema}, async (args) => {
+      const startedAt = Date.now();
+      logger.info("tool.call.start", {tool: name, args});
+
+      try {
+        const result = await handler(args);
+        logger.info("tool.call.success", {tool: name, duration_ms: Date.now() - startedAt, result});
+
+        return {content: [{type: "text", text: JSON.stringify(result, null, 2)}]};
+      } catch (error) {
+        // Logged and rethrown, not swallowed: McpServer still turns it into a CallToolResult
+        // with isError: true, which is the shape the spec prescribes. Without this the stack
+        // trace surfaces nowhere — the client only ever sees the message.
+        logger.error("tool.call.error", {tool: name, duration_ms: Date.now() - startedAt, error});
+        throw error;
+      }
+    });
+
+    logger.info("tool.registered", {tool: name, description});
   }
 
   return server;

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -4,6 +4,7 @@ import {HttpResponse} from 'msw';
 import {connectMcpClient} from '../test/helpers/mcp-harness.js';
 import {createMswServer, DRAFTS_URL} from '../test/helpers/msw-server.js';
 import {setTestEnv} from '../test/helpers/env.js';
+import {captureLogs} from '../test/helpers/capture-logs.js';
 
 const msw = createMswServer();
 let restoreEnv;
@@ -217,6 +218,55 @@ describe('MCP server — call_tool', () => {
       } finally {
         await close();
       }
+    });
+  });
+
+  describe('what the log says about a call', () => {
+    function find(lines, msg) {
+      const line = lines.find((entry) => entry.msg === msg);
+      assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+      return line;
+    }
+
+    async function callAndCaptureLogs(args) {
+      const {client, close} = await connectMcpClient();
+
+      try {
+        return await captureLogs(() => client.callTool({name: 'create_draft_post', arguments: args}));
+      } finally {
+        await close();
+      }
+    }
+
+    test('a successful call is bracketed by start and success, with its duration', async () => {
+      const lines = await callAndCaptureLogs(VALID_ARGS);
+
+      const start = find(lines, 'tool.call.start');
+      assert.equal(start.tool, 'create_draft_post');
+      assert.deepEqual(start.args, VALID_ARGS);
+
+      const success = find(lines, 'tool.call.success');
+      assert.equal(success.tool, 'create_draft_post');
+      assert.equal(success.result, 'OK');
+      assert.equal(typeof success.duration_ms, 'number');
+    });
+
+    test('a failing call logs the error and no success line', async () => {
+      msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+      const lines = await callAndCaptureLogs(VALID_ARGS);
+
+      assert.match(find(lines, 'tool.call.error').error.message, /SubstackAPIException: 500/);
+      assert.equal(lines.find((entry) => entry.msg === 'tool.call.success'), undefined);
+    });
+
+    // McpServer answers a malformed call itself, so nothing inside the tool runs or logs. This
+    // is the gap logOutgoingMessages() closes at the transport, which this harness does not
+    // wrap — the rejection line itself is asserted in src/logger.spec.js.
+    test('a call rejected before the handler runs logs nothing from the tool', async () => {
+      const lines = await callAndCaptureLogs({title: 'title only'});
+
+      assert.deepEqual(lines.map((entry) => entry.msg), []);
     });
   });
 

--- a/src/tools/create_draft_post.js
+++ b/src/tools/create_draft_post.js
@@ -1,6 +1,7 @@
 import {z} from "zod";
 import SubstackApi from "../api/substack/SubstackApi.js";
 import SubstackPost from "../api/substack/SubstackPost.js";
+import {logger} from "../logger.js";
 
 
 // strictObject, not object: an unknown key must be reported rather than stripped. The
@@ -29,13 +30,18 @@ const parseBody = (body) => {
   try {
     const doc = JSON.parse(body);
     if (doc && doc.type === 'doc') {
+      logger.debug('draft.body.parsed', {format: 'prosemirror', nodes: doc.content?.length ?? 0});
       return doc;
     }
+
+    // Valid JSON that is not a document: it goes through as text, and a model that believed
+    // it was sending a document would have no other way to find out.
+    logger.debug('draft.body.json_is_not_a_document', {parsed: doc});
   } catch (error) {
     // not JSON, treat as plain text
   }
 
-  return {
+  const doc = {
     type: 'doc',
     content: body
       .split(/\n+/)
@@ -45,13 +51,27 @@ const parseBody = (body) => {
         content: [{type: 'text', text: paragraph}],
       })),
   };
+
+  logger.debug('draft.body.parsed', {format: 'text', nodes: doc.content.length, chars: body.length});
+  return doc;
 };
 
 export const createDraftPostHandler = async (args) => {
+  logger.debug('create_draft_post.start', {args});
+
   // McpServer already validated against this schema before dispatching, so over MCP this
   // parse never rejects. It is kept so the handler stays safe when called directly, which
   // is how its own tests exercise it.
-  const validatedArgs = createDraftPostSchema.parse(args);
+  let validatedArgs;
+
+  try {
+    validatedArgs = createDraftPostSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined
+    // instead of failing. Reached only on a direct call — over MCP the SDK rejects first.
+    logger.error('create_draft_post.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
 
   const {title, subtitle, body} = validatedArgs;
 
@@ -66,7 +86,15 @@ export const createDraftPostHandler = async (args) => {
   substack_post.setSubtitle(subtitle)
   substack_post.setBody(parseBody(body))
 
-  await substack_api.postDraft(substack_post.getDraft())
+  const draft = substack_post.getDraft();
+  logger.debug('create_draft_post.draft.built', {draft});
+
+  const response = await substack_api.postDraft(draft)
+
+  logger.info('create_draft_post.created', {
+    draft_id: response?.id ?? null,
+    is_published: response?.is_published ?? null,
+  });
 
   return 'OK'
 }

--- a/src/tools/create_draft_post.spec.js
+++ b/src/tools/create_draft_post.spec.js
@@ -172,6 +172,32 @@ describe('createDraftPostHandler — logging', () => {
     return line;
   }
 
+  test('records the arguments it received and the draft it built from them', async () => {
+    const lines = await captureLogs(() => createDraftPostHandler(VALID_ARGS));
+
+    assert.deepEqual(find(lines, 'create_draft_post.start').args, VALID_ARGS);
+
+    const {draft} = find(lines, 'create_draft_post.draft.built');
+    assert.equal(draft.draft_title, 'My title');
+    assert.equal(draft.draft_subtitle, 'My subtitle');
+    // The serialized document, which is the field the Substack editor actually rejects.
+    assert.equal(draft.draft_body, JSON.stringify({
+      type: 'doc',
+      content: [{type: 'paragraph', content: [{type: 'text', text: 'The body'}]}],
+    }));
+  });
+
+  // Over MCP the SDK rejects first, so this line only appears on a direct call — which is how
+  // anything embedding the handler outside the server would use it.
+  test('records the validation issues when the arguments are rejected', async () => {
+    const lines = await captureLogs(
+      () => createDraftPostHandler({title: 'title only'}).catch(() => {})
+    );
+
+    const invalid = find(lines, 'create_draft_post.args.invalid');
+    assert.deepEqual(invalid.issues.map((issue) => issue.path.join('.')).sort(), ['body', 'subtitle']);
+  });
+
   test('records how the body was interpreted', async () => {
     const lines = await captureLogs(() => createDraftPostHandler(VALID_ARGS));
 

--- a/src/tools/create_draft_post.spec.js
+++ b/src/tools/create_draft_post.spec.js
@@ -5,6 +5,7 @@ import {HttpResponse} from 'msw';
 import {createDraftPostHandler, createDraftPostSchema} from './create_draft_post.js';
 import {createMswServer, DRAFTS_URL} from '../../test/helpers/msw-server.js';
 import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
 
 const msw = createMswServer();
 let restoreEnv;
@@ -161,6 +162,75 @@ describe('createDraftPostHandler — body conversion', () => {
 
   test('an empty string produces a document with no content', async () => {
     assert.deepEqual(await sendAndDecode(''), {type: 'doc', content: []});
+  });
+});
+
+describe('createDraftPostHandler — logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('records how the body was interpreted', async () => {
+    const lines = await captureLogs(() => createDraftPostHandler(VALID_ARGS));
+
+    const parsed = find(lines, 'draft.body.parsed');
+    assert.equal(parsed.format, 'text');
+    assert.equal(parsed.nodes, 1);
+  });
+
+  test('distinguishes a document that arrived as JSON from text', async () => {
+    const body = JSON.stringify({type: 'doc', content: [{type: 'paragraph'}, {type: 'paragraph'}]});
+    const lines = await captureLogs(() => createDraftPostHandler({...VALID_ARGS, body}));
+
+    const parsed = find(lines, 'draft.body.parsed');
+    assert.equal(parsed.format, 'prosemirror');
+    assert.equal(parsed.nodes, 2);
+  });
+
+  // The reason a model's document silently became two paragraphs of literal JSON. Nothing else
+  // reports it: the draft is created either way and the tool answers OK.
+  test('flags JSON that was not a document, so a silent downgrade is visible', async () => {
+    const lines = await captureLogs(() => createDraftPostHandler({...VALID_ARGS, body: '{"a":1}'}));
+
+    assert.deepEqual(find(lines, 'draft.body.json_is_not_a_document').parsed, {a: 1});
+  });
+
+  test('records the outgoing request with the session cookie redacted', async () => {
+    const lines = await captureLogs(() => createDraftPostHandler(VALID_ARGS));
+
+    const request = find(lines, 'substack.request');
+    assert.equal(request.url, DRAFTS_URL);
+    assert.equal(request.method, 'POST');
+    assert.equal(request.headers.Cookie, '***');
+    assert.equal(request.body.draft_title, 'My title');
+
+    const response = find(lines, 'substack.response');
+    assert.equal(response.status, 200);
+    assert.equal(typeof response.duration_ms, 'number');
+
+    assert.equal(find(lines, 'create_draft_post.created').draft_id, 167712345);
+  });
+
+  // The thrown message carries only the status. Substack explains the refusal in the body, and
+  // this is the only place it survives.
+  test('records the body of a failed response, which the error message drops', async () => {
+    msw.server.use(msw.draftsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const lines = await captureLogs(
+      () => createDraftPostHandler(VALID_ARGS).catch(() => {})
+    );
+
+    const failure = find(lines, 'substack.response.error');
+    assert.equal(failure.status, 500);
+    assert.equal(failure.body, 'boom');
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => createDraftPostHandler(VALID_ARGS), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
   });
 });
 

--- a/test/helpers/capture-logs.js
+++ b/test/helpers/capture-logs.js
@@ -1,0 +1,39 @@
+/**
+ * Runs `run` with logging forced to `level` and returns the log lines it produced, parsed.
+ *
+ * The logger writes straight to stderr, so this replaces `process.stderr.write` for the
+ * duration of the call and restores it afterwards — including when `run` throws, otherwise a
+ * single failing assertion would swallow the output of every test that follows.
+ *
+ * `src/logger.spec.js` keeps its own capture: it also has to prove nothing reaches stdout,
+ * which is the logger's own contract rather than something its callers can assert.
+ */
+export async function captureLogs(run, {level = 'debug'} = {}) {
+  const saved = process.env.SUBSTACK_MCP_LOG_LEVEL;
+  process.env.SUBSTACK_MCP_LOG_LEVEL = level;
+
+  const chunks = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+
+  try {
+    await run();
+  } finally {
+    process.stderr.write = originalWrite;
+
+    if (saved === undefined) {
+      delete process.env.SUBSTACK_MCP_LOG_LEVEL;
+    } else {
+      process.env.SUBSTACK_MCP_LOG_LEVEL = saved;
+    }
+  }
+
+  return chunks
+    .join('')
+    .split('\n')
+    .filter((line) => line !== '')
+    .map((line) => JSON.parse(line));
+}

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -7,9 +7,14 @@ export const TEST_ENV = {
 /**
  * Sets the test env vars and returns a function restoring the previous values, so that one
  * test file does not alter the environment the others see.
+ *
+ * Logging is silenced by default: the in-process suites would otherwise print a line per tool
+ * call over the test reporter's output. It is not part of TEST_ENV because index.spec.js
+ * iterates over that object's keys to build one missing-variable test each, and the log level
+ * is optional — the server must start without it. Pass an override to inspect the logs.
  */
 export function setTestEnv(overrides = {}) {
-  const values = {...TEST_ENV, ...overrides};
+  const values = {...TEST_ENV, SUBSTACK_MCP_LOG_LEVEL: 'silent', ...overrides};
   const saved = {};
 
   for (const key of Object.keys(values)) {


### PR DESCRIPTION
## Why

The caller of this server is an LLM, and when a tool call does not do what was expected the fault
is usually in what the model sent rather than in this code. Nothing was recorded anywhere, so
there was nothing to look at: a failed call reached the client as a one-line message and the
stack, the arguments and the request all vanished.

## What changed

`src/logger.js` is the only writer, with no dependencies. One JSON object per line, on
**stderr** — never stdout, which on a stdio transport carries the JSON-RPC stream and is
corrupted by a single stray byte. MCP hosts collect the server's stderr into their own log files,
which is where these lines are meant to be read.

```json
{"ts":"2026-08-07T10:12:03.114Z","level":"info","msg":"tool.call.start","tool":"create_draft_post","args":{"title":"My title","body":"…"}}
{"ts":"2026-08-07T10:12:03.402Z","level":"info","msg":"substack.response","status":200,"duration_ms":287}
```

- Levels `silent < error < warn < info < debug`, from the new optional `SUBSTACK_MCP_LOG_LEVEL`
  (default `info`), read **at call time** so no module reads the environment at import.
- Secrets redacted recursively by key name, so call sites pass whole objects (`{headers}`,
  `{args}`, `{draft}`) instead of picking fields by hand. Post content is not truncated — it is
  usually the thing being debugged.
- The logger never throws: `Error` values expand to `{name, message, stack}` (raw, they serialize
  to `{}` and the stack silently disappears), cycles become `[Circular]`, an unserializable
  payload degrades to a `log_error` note.
- Covered: startup and *which* env var is missing, every tool call with arguments, duration and
  result, how the body was interpreted, the outgoing request and its response, and every failure
  path. `SubstackPost` logs its constructor and the setters on the active path at `debug`; the
  fluent helpers (`text`, `marks`, `add`) run once per chunk and would bury everything else.

## Two things worth a reviewer's attention

**`logOutgoingMessages(transport)` wraps `transport.send`.** A rejected tool call cannot be
logged from inside the handler: `McpServer` validates arguments itself and answers
`Input validation error` before the handler runs. That line is the most useful one in the file
when a model cannot get a call right, hence `warn` for anything carrying `error`/`isError` and
`debug` for the rest of the traffic.

**`SubstackApi.handleResponse` now reads the body of a non-2xx response** before throwing. The
thrown message carries only the status, while Substack explains the refusal in the body. This is
the one behaviour change; the error message itself is unchanged, and the extra `await` is only on
the failure path.

## Testing

109 tests, green, `src/logger.js` at 100% coverage. Every new assertion was verified by breaking
the source on purpose, as CLAUDE.md requires — 20 mutations, each one failing the suite. That
exercise found real problems rather than confirming the happy path:

- **`never writes the session token to the log` passed with redaction disabled.** The handshake it
  drove never logs a request header, so the assertion was empty. It now drives a real `tools/call`
  with the publication pointed at `http://127.0.0.1:1`: the request is logged before `fetch`, which
  then fails with ECONNREFUSED without a packet leaving the machine. MSW cannot help — it runs in
  the test process and `index.spec.js` spawns a child.
- **No test covered the tool or API log lines**: renaming `draft.body.parsed` failed nothing. Fixed
  with a new block in `create_draft_post.spec.js` and the shared `test/helpers/capture-logs.js`.
- **`session_id` was not being redacted** — `sid` is not a substring of it. The pattern is now
  `/token|cookie|password|secret|auth|session|^sid$/i`, with `sid` anchored so it does not blank
  out `considerations`.

`src/index.spec.js` used to assert `stderr === ''`. It now asserts that stdout parses as JSON-RPC
and stderr as log lines, which is the standing guard against the `console.log` that would break
the transport.

## Docs

`CLAUDE.md` gains a **Logging** section stating the convention — everything must be logged well
enough to debug a session from the log alone — plus the stdout/stderr rule, the format, the
redaction contract and the MSW exception. Also corrects a claim that had gone stale: `.issues` now
has a reader in `src/`. `README.md` documents `SUBSTACK_MCP_LOG_LEVEL` with a table of levels and
where to find the log file on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
