### PR TITLE
Add subscriber filtering and three read-only tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,8 @@ the tally, `grep -E '^(not ok|✖)'` for what broke.
 - `src/server.js` — `createServer()` factory plus the `tools` registry. **No side effects at
   import time**: no env reads, no transport connection. Tests depend on this.
 - `src/tools/<name>.js` — one file per MCP tool, exporting a zod schema and a handler.
-- `src/api/substack/` — `SubstackApi` (HTTP) and `SubstackPost` (ProseMirror document builder).
+- `src/api/substack/` — `SubstackApi` (HTTP), `SubstackPost` (ProseMirror document builder) and
+  `SubscriberQuery` (the subscriber filter DSL).
 - `src/logger.js` — the only place that writes a log line. No dependencies, no state.
 - `test/helpers/` — shared test helpers only; no tests live here.
 
@@ -56,6 +57,45 @@ from what was registered, so there is no second place to update and nothing that
 Do not add `setRequestHandler` calls for `tools/list` or `tools/call`: registering a tool
 already covers both, and the SDK guards the clash rather than letting it slide — it throws
 `A request handler for tools/call already exists, which would be overridden`.
+
+## Substack's private API
+
+There is no public documentation for any of this. Every endpoint below was read off the publisher
+dashboard's own traffic and its `reactPublish.*.js` bundle, then confirmed against the live API —
+so **check behaviour against a real request before trusting a claim about it**, including the
+claims here. An official, key-authenticated Publisher API exists (`publisher_api_enabled`,
+`/api/v1/publisher_api/api_key`) but is gated: the key endpoint answers **403** on a publication
+that does not have it. If it ever opens up it is a better foundation than a session cookie.
+
+**`POST /api/v1/subscriber-stats` is the whole subscriber surface** — list, filter, sort and search
+in one call. `src/api/substack/SubscriberQuery.js` owns the translation, and the reasons it exists
+rather than passing arguments straight through:
+
+- A filter is a **flat key** inside `filters`: column name with an operator suffix glued on
+  (`num_comments_gt`). Multiple keys are ANDed. **No OR, no nesting** — an OR needs separate calls.
+- **The suffix depends on the column's type**, and the API answers every mismatch with a bare 400
+  that names neither the column nor the alternatives. `is not` is `_not` on `subscription_type`,
+  `_distinct_from` on an Int or `group_membership`, and `_string_not` on a String. `_lte` is
+  Int-only; the DateTime equivalent is `_is_on_or_before`, not `_lte`. So the tool exposes operators
+  named by intent and derives the suffix, which makes an illegal pair unrepresentable rather than a
+  round trip away.
+- **`search` goes inside `filters`.** At the top level it is ignored *silently* and the response
+  comes back unfiltered — which reads as "search matched everything", not as an error.
+- **Sorting is two different keys**: `order_by` ascending, `order_by_desc_nulls_last` descending.
+- **The API validates enum values too**, so `subscription_type: 'premium'` is a 400. The valid sets
+  are `paid|free|founding|comp|gift|free_trial|iap` and `none|member|admin`.
+- `count` is the total matching the filters regardless of `limit`, which makes `limit: 1` a cheap
+  way to size a segment.
+- **A request-level `columnView` is ignored.** The returned fields come from the publication's saved
+  Display settings, so the engagement columns are *filterable but not readable* — the tool's
+  description says so, because a caller filtering on opens and then not finding them would
+  reasonably conclude the data is missing rather than unrequestable.
+
+**`GET /api/v1/post_management/{drafts,published,scheduled}`** lists posts. `order_by` is **not
+optional**: `scheduled` answers 400 without it, which is why `src/tools/list_posts.js` keeps a
+default per status rather than letting the server choose. Free-text search is `query`, and a null
+one must never be serialized — `query=null` searches for the literal string. `GET /api/v1/drafts/:id`
+returns a single draft whole.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,80 @@ A Model Context Protocol (MCP) Server for [Substack](https://substack.com) enabl
 **Returns**: "OK" if the post was created successfully.
 </details>
 
+<details>
+<summary><strong>list_subscribers</strong> - List and filter your subscribers</summary>
+
+Exposes the same filtering the Subscribers dashboard offers: 48 columns, 18 operators, free-text
+search, sorting and pagination.
+
+**Inputs**:
+- `filters` (array, optional): conditions combined with **AND**, each `{column, operator, value}`
+- `search` (string, optional): free text matched against subscriber name and email
+- `sort_by` (string, optional): any filterable column
+- `sort_direction` (`asc` | `desc`, optional): defaults to `desc`
+- `limit` (number, optional): 1–100, defaults to 25
+- `offset` (number, optional): for paging
+
+Which operators a column accepts depends on its type:
+
+| Type | Operators |
+|---|---|
+| `Int` | `is` `is_not` `gt` `gte` `lt` `lte` |
+| `String` | `is` `is_not` `is_any_of` `contains` `starts_with` `ends_with` `includes_none` |
+| `DateTime` | `is_on` `is_after` `is_on_or_after` `is_before` `is_on_or_before` |
+| `Array` (`tag_ids`, `emails_enabled`) | `includes_any` `includes_all` `includes_none` |
+| `subscription_type`, `group_membership` | `is` `is_not` `is_any_of` |
+
+The columns cover subscriber identity (name, email, country, state, group membership),
+subscription (type, start/expiry/cancel dates, revenue, Stripe plan, attribution), email
+engagement (opens and unique opens over 7d/30d/6mo, links clicked, sections) and site engagement
+(post views, unique posts seen, comments, shares, days active, activity rating). The full list
+with types reaches the client in the tool's JSON Schema, so a model does not have to guess names.
+
+**Returns**: `{count, returned, limit, offset, subscribers}`. `count` is the total matching the
+filters regardless of `limit`, so a call with `limit: 1` is a cheap way to size a segment.
+
+> **Note**: engagement columns can be *filtered* on but are not part of the returned records —
+> Substack takes the fields it returns from the publication's saved Display settings and ignores a
+> per-request column list. Use `count` with different thresholds to learn about them.
+
+There is no OR and no nesting: anything needing OR has to be issued as separate calls.
+</details>
+
+<details>
+<summary><strong>list_posts</strong> - List drafts, published or scheduled posts</summary>
+
+**Inputs**:
+- `status` (`drafts` | `published` | `scheduled`): which list to read
+- `search` (string, optional): free text matched against title and content
+- `limit` (number, optional): 1–100, defaults to 25
+- `offset` (number, optional): for paging
+- `sort_direction` (`asc` | `desc`, optional): drafts and published posts are newest-first,
+  scheduled posts soonest-first
+
+**Returns**: `{status, total, returned, limit, offset, posts}`, each post summarised — use
+`get_draft` for the full content of an unpublished one.
+</details>
+
+<details>
+<summary><strong>get_draft</strong> - Read one draft in full</summary>
+
+**Inputs**:
+- `draft_id` (number): the id returned by `list_posts` or `create_draft_post`
+
+**Returns**: the draft as Substack stores it, body and audience/email settings included.
+</details>
+
+<details>
+<summary><strong>get_publication_stats</strong> - Read the headline stats</summary>
+
+**Inputs**: none.
+
+**Returns**: total and recent subscribers, email and app subscribers, ARR, site views and the
+30-day email open rate, each with its change where Substack reports one. If one of the underlying
+endpoints fails the rest are still returned, and the failure is named under `errors`.
+</details>
+
 ### 📋 Requirements
 
 - Substack tokens, follow my [guide](https://implementing.substack.com/p/mcp-server-for-substack) to obtain them:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) Server for [Substack](https://substack.com) enabl
 - `subtitle` (string): Subtitle of the post
 - `body` (string): Body of the post
 
-**Returns**: "OK" if the post was created successfully.
+**Returns**: `{draft_id, is_published}`. Pass `draft_id` to `get_draft` to read the draft back.
 </details>
 
 <details>
@@ -77,7 +77,7 @@ There is no OR and no nesting: anything needing OR has to be issued as separate 
 <summary><strong>get_draft</strong> - Read one draft in full</summary>
 
 **Inputs**:
-- `draft_id` (number): the id returned by `list_posts`
+- `draft_id` (number): the id returned by `list_posts` or `create_draft_post`
 
 **Returns**: the draft as Substack stores it, body and audience/email settings included.
 </details>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There is no OR and no nesting: anything needing OR has to be issued as separate 
 <summary><strong>get_draft</strong> - Read one draft in full</summary>
 
 **Inputs**:
-- `draft_id` (number): the id returned by `list_posts` or `create_draft_post`
+- `draft_id` (number): the id returned by `list_posts`
 
 **Returns**: the draft as Substack stores it, body and audience/email settings included.
 </details>

--- a/src/api/substack/SubscriberQuery.js
+++ b/src/api/substack/SubscriberQuery.js
@@ -1,0 +1,255 @@
+import {logger} from "../../logger.js";
+
+/**
+ * Translates a structured filter list into the payload `POST /api/v1/subscriber-stats` expects.
+ *
+ * Substack encodes a filter as a single flat key inside `filters`: the column name with an
+ * operator suffix glued onto it (`num_comments_gt`, `user_email_address_similar_to`). Multiple
+ * keys are ANDed; there is no OR and no nesting. Sorting and free-text search are two more keys
+ * in the same object rather than separate parameters.
+ *
+ * That encoding is hostile to a caller that has to construct it blind, because the suffix
+ * depends on the column's type and the API answers every mistake with a bare 400: "is not" is
+ * `_distinct_from`, `_not` or `_string_not` depending on the column, and `_lte` works on an Int
+ * while the DateTime equivalent is `_is_on_or_before`. So the operators exposed here are named
+ * by intent (`is_not`, `is_before`) and the suffix is derived from the column's type, which
+ * makes an illegal combination impossible to express rather than a round-trip away.
+ *
+ * The column table and the operator matrix were both read out of the publisher bundle and then
+ * confirmed empirically: all 48 columns were probed against the live API with the discriminating
+ * suffixes, and the resulting classification is what the tables below encode.
+ */
+
+// type -> {operator name: suffix appended to the column}. The empty string is a real suffix:
+// on an Int or enum column "is" sends the column name alone.
+export const OPERATORS_BY_TYPE = {
+  Int: {
+    is: '',
+    is_not: '_distinct_from',
+    gt: '_gt',
+    gte: '_gte',
+    lt: '_lt',
+    lte: '_lte',
+  },
+  String: {
+    is: '_string_is',
+    is_not: '_string_not',
+    is_any_of: '_in',
+    contains: '_similar_to',
+    starts_with: '_starts_with',
+    ends_with: '_ends_with',
+    includes_none: '_includes_none',
+  },
+  DateTime: {
+    is_on: '_is_on',
+    is_after: '_gt',
+    is_on_or_after: '_gte',
+    is_before: '_lt',
+    is_on_or_before: '_is_on_or_before',
+  },
+  Array: {
+    includes_any: '_includes_any',
+    includes_all: '_includes_all',
+    includes_none: '_includes_none',
+  },
+  subscription_type: {
+    is: '',
+    is_not: '_not',
+    is_any_of: '_in',
+  },
+  group_membership: {
+    is: '',
+    is_not: '_distinct_from',
+    is_any_of: '_in',
+  },
+};
+
+// The operators whose value is a list. Passing a scalar to one of these, or a list to any other,
+// is a 400 from the API and a refusal here.
+const LIST_OPERATORS = new Set(['is_any_of', 'includes_any', 'includes_all', 'includes_none']);
+
+const SUBSCRIPTION_TYPES = ['paid', 'free', 'founding', 'comp', 'gift', 'free_trial', 'iap'];
+const GROUP_MEMBERSHIPS = ['none', 'member', 'admin'];
+
+/**
+ * The 48 filterable columns, keyed by the name the API expects. `label` is the wording the
+ * Substack UI shows for the same column, which is how a caller working from the dashboard will
+ * refer to it. `values` restricts an enum column.
+ */
+export const SUBSCRIBER_COLUMNS = {
+  // Subscriber identity
+  user_name: {type: 'String', label: 'Name'},
+  user_email_address: {type: 'String', label: 'Email'},
+  country: {type: 'String', label: 'Country'},
+  state: {type: 'String', label: 'State/Province'},
+  group_membership: {type: 'group_membership', label: 'Group membership', values: GROUP_MEMBERSHIPS},
+
+  // Subscription
+  subscription_type: {type: 'subscription_type', label: 'Type', values: SUBSCRIPTION_TYPES},
+  subscription_created_at: {type: 'DateTime', label: 'Start date'},
+  subscription_expires_at: {type: 'DateTime', label: 'Expiration date'},
+  first_payment_at: {type: 'DateTime', label: 'First paid date'},
+  last_subscribed_at: {type: 'DateTime', label: 'Paid upgrade date'},
+  unsubscribed_at: {type: 'DateTime', label: 'Cancel date'},
+  subscription_interval: {type: 'String', label: 'Subscription interval'},
+  stripe_plan_name: {type: 'String', label: 'Stripe plan'},
+  free_attribution: {type: 'String', label: 'Subscription source (free)'},
+  paid_attribution: {type: 'String', label: 'Subscription source (paid)'},
+  is_subscribed: {type: 'Int', label: 'Can see paid content'},
+  bestseller_tier: {type: 'Int', label: 'Bestseller'},
+  total_revenue_generated: {type: 'Int', label: 'Revenue'},
+  num_subs_gifted: {type: 'Int', label: 'Subscriptions gifted'},
+  bundle_id: {type: 'Int', label: 'Bundle'},
+  is_bundle_parent: {type: 'Int', label: 'Bundle origin'},
+
+  // Email engagement
+  num_emails_received: {type: 'Int', label: 'Emails received (6mo)'},
+  num_emails_dropped: {type: 'Int', label: 'Emails dropped (6mo)'},
+  num_email_opens: {type: 'Int', label: 'Emails opened (6mo)'},
+  num_email_opens_last_7d: {type: 'Int', label: 'Emails opened (7d)'},
+  num_email_opens_last_30d: {type: 'Int', label: 'Emails opened (30d)'},
+  num_unique_email_posts_seen: {type: 'Int', label: 'Unique emails seen (6mo)'},
+  num_unique_email_posts_seen_last_7d: {type: 'Int', label: 'Unique emails seen (7d)'},
+  num_unique_email_posts_seen_last_30d: {type: 'Int', label: 'Unique emails seen (30d)'},
+  last_opened_at: {type: 'DateTime', label: 'Last email open'},
+  links_clicked: {type: 'Int', label: 'Links clicked'},
+  last_clicked_at: {type: 'DateTime', label: 'Last clicked at'},
+  emails_enabled: {type: 'Array', label: 'Sections'},
+
+  // Site engagement
+  num_web_post_views: {type: 'Int', label: 'Post views'},
+  num_web_post_views_last_7d: {type: 'Int', label: 'Post views (7d)'},
+  num_web_post_views_last_30d: {type: 'Int', label: 'Post views (30d)'},
+  num_unique_web_posts_seen: {type: 'Int', label: 'Unique posts seen'},
+  num_unique_web_posts_seen_last_7d: {type: 'Int', label: 'Unique posts seen (7d)'},
+  num_unique_web_posts_seen_last_30d: {type: 'Int', label: 'Unique posts seen (30d)'},
+  num_comments: {type: 'Int', label: 'Comments'},
+  num_comments_last_7d: {type: 'Int', label: 'Comments (7d)'},
+  num_comments_last_30d: {type: 'Int', label: 'Comments (30d)'},
+  num_shares: {type: 'Int', label: 'Shares'},
+  num_shares_last_7d: {type: 'Int', label: 'Shares (7d)'},
+  num_shares_last_30d: {type: 'Int', label: 'Shares (30d)'},
+  days_active_last_30d: {type: 'Int', label: 'Days active (30d)'},
+  activity_rating: {type: 'Int', label: 'Activity'},
+
+  // Tags
+  tag_ids: {type: 'Array', label: 'Tags'},
+};
+
+export const SUBSCRIBER_COLUMN_NAMES = Object.keys(SUBSCRIBER_COLUMNS);
+
+function describeColumn(column) {
+  const {type, label} = SUBSCRIBER_COLUMNS[column];
+  return `${column} (${label}, ${type})`;
+}
+
+function resolveSuffix(column, operator) {
+  const definition = SUBSCRIBER_COLUMNS[column];
+
+  if (!definition) {
+    throw new Error(
+      `Unknown column "${column}". Valid columns: ${SUBSCRIBER_COLUMN_NAMES.join(', ')}`
+    );
+  }
+
+  const operators = OPERATORS_BY_TYPE[definition.type];
+  const suffix = operators[operator];
+
+  // A missing key and a key holding the empty string are both falsy, so the presence check has
+  // to be explicit: "is" legitimately maps to ''.
+  if (suffix === undefined) {
+    throw new Error(
+      `Operator "${operator}" does not apply to ${describeColumn(column)}. ` +
+      `Valid operators for it: ${Object.keys(operators).join(', ')}`
+    );
+  }
+
+  return suffix;
+}
+
+function validateValue(column, operator, value) {
+  const {values} = SUBSCRIBER_COLUMNS[column];
+  const expectsList = LIST_OPERATORS.has(operator);
+
+  if (expectsList && !Array.isArray(value)) {
+    throw new Error(`Operator "${operator}" on ${describeColumn(column)} needs an array of values.`);
+  }
+
+  if (!expectsList && Array.isArray(value)) {
+    throw new Error(
+      `Operator "${operator}" on ${describeColumn(column)} takes a single value, not an array.`
+    );
+  }
+
+  if (!values) return;
+
+  // Enum values are validated by the API too, and rejecting one costs a round trip that tells
+  // the caller only "400". Listing the alternatives here is the difference between a repairable
+  // call and a guess.
+  for (const candidate of Array.isArray(value) ? value : [value]) {
+    if (!values.includes(candidate)) {
+      throw new Error(
+        `"${candidate}" is not a valid value for ${describeColumn(column)}. ` +
+        `Valid values: ${values.join(', ')}`
+      );
+    }
+  }
+}
+
+/**
+ * Builds the request body for the subscribers endpoint.
+ *
+ * `filters` is a list of {column, operator, value}. `search` is free text matched against name
+ * and email. `sort_by` names any column, `sort_direction` is 'asc' or 'desc' (default 'desc').
+ */
+export function buildSubscriberQuery({
+  filters = [],
+  search = null,
+  sort_by = null,
+  sort_direction = 'desc',
+  limit = 25,
+  offset = 0,
+} = {}) {
+  const built = {};
+
+  for (const {column, operator, value} of filters) {
+    const suffix = resolveSuffix(column, operator);
+    validateValue(column, operator, value);
+
+    const key = `${column}${suffix}`;
+
+    // Two filters that reduce to the same key would silently collapse into one, dropping a
+    // condition the caller asked for. Refusing is the only way that stays visible.
+    if (Object.prototype.hasOwnProperty.call(built, key)) {
+      throw new Error(
+        `Duplicate filter: ${describeColumn(column)} already has an "${operator}" condition. ` +
+        `Use a single condition per column and operator.`
+      );
+    }
+
+    built[key] = value;
+    logger.debug('subscriber_query.filter', {column, operator, key, value});
+  }
+
+  // Verified against the live API: a top-level `search` is ignored and the response comes back
+  // unfiltered. It only takes effect inside `filters`.
+  if (search !== null && search !== '') {
+    built.search = search;
+  }
+
+  if (sort_by !== null) {
+    if (!SUBSCRIBER_COLUMNS[sort_by]) {
+      throw new Error(
+        `Unknown column "${sort_by}" for sort_by. Valid columns: ${SUBSCRIBER_COLUMN_NAMES.join(', ')}`
+      );
+    }
+
+    const key = sort_direction === 'asc' ? 'order_by' : 'order_by_desc_nulls_last';
+    built[key] = sort_by;
+  }
+
+  const query = {filters: built, limit, offset};
+  logger.debug('subscriber_query.built', {query});
+
+  return query;
+}

--- a/src/api/substack/SubscriberQuery.spec.js
+++ b/src/api/substack/SubscriberQuery.spec.js
@@ -6,6 +6,7 @@ import {
   OPERATORS_BY_TYPE,
 } from './SubscriberQuery.js';
 import {setTestEnv} from '../../../test/helpers/env.js';
+import {captureLogs} from '../../../test/helpers/capture-logs.js';
 
 // The module logs, so the level has to be silenced or the lines land on the reporter.
 let restoreEnv;
@@ -249,6 +250,27 @@ describe('buildSubscriberQuery — search and sort', () => {
       search: 'gmail',
       order_by_desc_nulls_last: 'subscription_created_at',
     });
+  });
+});
+
+describe('buildSubscriberQuery — logging', () => {
+  // The assembled payload is what the API answers 400 about, and the structured arguments alone
+  // do not show it: the whole point of this module is that the two look nothing alike.
+  test('records the payload it assembled', async () => {
+    const lines = await captureLogs(() => buildSubscriberQuery({
+      filters: [{column: 'subscription_type', operator: 'is', value: 'free'}],
+      limit: 10,
+    }));
+
+    const built = lines.find((entry) => entry.msg === 'subscriber_query.built');
+    assert.ok(built, `expected a subscriber_query.built log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    assert.deepEqual(built.query, {filters: {subscription_type: 'free'}, limit: 10, offset: 0});
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => buildSubscriberQuery({}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
   });
 });
 

--- a/src/api/substack/SubscriberQuery.spec.js
+++ b/src/api/substack/SubscriberQuery.spec.js
@@ -1,0 +1,322 @@
+import {test, describe, before, after} from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildSubscriberQuery,
+  SUBSCRIBER_COLUMNS,
+  OPERATORS_BY_TYPE,
+} from './SubscriberQuery.js';
+import {setTestEnv} from '../../../test/helpers/env.js';
+
+// The module logs, so the level has to be silenced or the lines land on the reporter.
+let restoreEnv;
+before(() => {
+  restoreEnv = setTestEnv();
+});
+after(() => restoreEnv());
+
+const filtersOf = (input) => buildSubscriberQuery(input).filters;
+
+describe('SUBSCRIBER_COLUMNS', () => {
+  // The count is the whole point of the reconnaissance: 48 columns were enumerated from the
+  // publisher bundle and every one of them was confirmed against the live API. A column
+  // silently disappearing from the table is a capability silently disappearing from the tool.
+  test('covers all 48 filterable columns', () => {
+    assert.equal(Object.keys(SUBSCRIBER_COLUMNS).length, 48);
+  });
+
+  test('gives every column a type that has an operator set', () => {
+    for (const [column, {type}] of Object.entries(SUBSCRIBER_COLUMNS)) {
+      assert.ok(OPERATORS_BY_TYPE[type], `${column} has unknown type ${type}`);
+    }
+  });
+
+  test('gives every column a human label', () => {
+    for (const [column, {label}] of Object.entries(SUBSCRIBER_COLUMNS)) {
+      assert.equal(typeof label, 'string', `${column} has no label`);
+      assert.ok(label.length > 0, `${column} has an empty label`);
+    }
+  });
+});
+
+describe('buildSubscriberQuery — pagination', () => {
+  test('defaults to the first page', () => {
+    assert.deepEqual(buildSubscriberQuery({}), {filters: {}, limit: 25, offset: 0});
+  });
+
+  test('passes limit and offset through', () => {
+    const query = buildSubscriberQuery({limit: 100, offset: 250});
+
+    assert.equal(query.limit, 100);
+    assert.equal(query.offset, 250);
+  });
+});
+
+describe('buildSubscriberQuery — operator suffixes', () => {
+  test('Int "is" uses the empty suffix', () => {
+    assert.deepEqual(
+      filtersOf({filters: [{column: 'num_comments', operator: 'is', value: 3}]}),
+      {num_comments: 3}
+    );
+  });
+
+  test('Int "is_not" uses _distinct_from', () => {
+    assert.deepEqual(
+      filtersOf({filters: [{column: 'num_comments', operator: 'is_not', value: 0}]}),
+      {num_comments_distinct_from: 0}
+    );
+  });
+
+  test('Int comparisons map onto _gt _gte _lt _lte', () => {
+    const built = filtersOf({
+      filters: [
+        {column: 'num_email_opens_last_30d', operator: 'gt', value: 1},
+        {column: 'num_email_opens_last_7d', operator: 'gte', value: 2},
+        {column: 'num_comments', operator: 'lt', value: 3},
+        {column: 'num_shares', operator: 'lte', value: 4},
+      ],
+    });
+
+    assert.deepEqual(built, {
+      num_email_opens_last_30d_gt: 1,
+      num_email_opens_last_7d_gte: 2,
+      num_comments_lt: 3,
+      num_shares_lte: 4,
+    });
+  });
+
+  // String "is" is _string_is, not the empty suffix — the empty suffix on a String column is
+  // one of the combinations the API answers with a 400.
+  test('String operators use the string-specific suffixes', () => {
+    const built = filtersOf({
+      filters: [
+        {column: 'user_email_address', operator: 'is', value: 'a@b.c'},
+        {column: 'user_name', operator: 'is_not', value: 'Bob'},
+        {column: 'country', operator: 'contains', value: 'IT'},
+        {column: 'state', operator: 'starts_with', value: 'Lom'},
+        {column: 'stripe_plan_name', operator: 'ends_with', value: 'ly'},
+      ],
+    });
+
+    assert.deepEqual(built, {
+      user_email_address_string_is: 'a@b.c',
+      user_name_string_not: 'Bob',
+      country_similar_to: 'IT',
+      state_starts_with: 'Lom',
+      stripe_plan_name_ends_with: 'ly',
+    });
+  });
+
+  // The asymmetry worth pinning: on a DateTime "is before" is _lt, but "is on or before" is
+  // _is_on_or_before rather than the _lte an Int would use.
+  test('DateTime operators map onto the date-specific suffixes', () => {
+    const built = filtersOf({
+      filters: [
+        {column: 'subscription_created_at', operator: 'is_after', value: '2026-01-01'},
+        {column: 'last_opened_at', operator: 'is_on_or_after', value: '2026-01-02'},
+        {column: 'last_clicked_at', operator: 'is_before', value: '2026-01-03'},
+        {column: 'first_payment_at', operator: 'is_on', value: '2026-01-04'},
+        {column: 'unsubscribed_at', operator: 'is_on_or_before', value: '2026-01-05'},
+      ],
+    });
+
+    assert.deepEqual(built, {
+      subscription_created_at_gt: '2026-01-01',
+      last_opened_at_gte: '2026-01-02',
+      last_clicked_at_lt: '2026-01-03',
+      first_payment_at_is_on: '2026-01-04',
+      unsubscribed_at_is_on_or_before: '2026-01-05',
+    });
+  });
+
+  test('array columns use the includes_* suffixes', () => {
+    const built = filtersOf({
+      filters: [
+        {column: 'tag_ids', operator: 'includes_any', value: [1, 2]},
+        {column: 'emails_enabled', operator: 'includes_none', value: ['3']},
+      ],
+    });
+
+    assert.deepEqual(built, {tag_ids_includes_any: [1, 2], emails_enabled_includes_none: ['3']});
+  });
+
+  // Two enum columns, two different "is not" suffixes. subscription_type is the only column in
+  // the whole table that uses _not.
+  test('subscription_type "is_not" uses _not while group_membership uses _distinct_from', () => {
+    assert.deepEqual(
+      filtersOf({filters: [{column: 'subscription_type', operator: 'is_not', value: 'free'}]}),
+      {subscription_type_not: 'free'}
+    );
+
+    assert.deepEqual(
+      filtersOf({filters: [{column: 'group_membership', operator: 'is_not', value: 'none'}]}),
+      {group_membership_distinct_from: 'none'}
+    );
+  });
+
+  test('"is_any_of" uses _in', () => {
+    assert.deepEqual(
+      filtersOf({filters: [{column: 'subscription_type', operator: 'is_any_of', value: ['free', 'paid']}]}),
+      {subscription_type_in: ['free', 'paid']}
+    );
+  });
+});
+
+describe('buildSubscriberQuery — combining', () => {
+  test('several filters become several keys, which the API ANDs', () => {
+    const built = filtersOf({
+      filters: [
+        {column: 'subscription_type', operator: 'is', value: 'paid'},
+        {column: 'num_email_opens_last_30d', operator: 'gt', value: 2},
+      ],
+    });
+
+    assert.deepEqual(built, {subscription_type: 'paid', num_email_opens_last_30d_gt: 2});
+  });
+
+  test('the same column can carry two different operators', () => {
+    const built = filtersOf({
+      filters: [
+        {column: 'subscription_created_at', operator: 'is_after', value: '2026-01-01'},
+        {column: 'subscription_created_at', operator: 'is_before', value: '2026-06-01'},
+      ],
+    });
+
+    assert.deepEqual(built, {
+      subscription_created_at_gt: '2026-01-01',
+      subscription_created_at_lt: '2026-06-01',
+    });
+  });
+
+  // Two identical column+operator pairs collapse onto one key, so one of the two conditions
+  // would vanish. Silently dropping half of what the caller asked for is worse than refusing.
+  test('rejects the same column and operator twice instead of dropping one', () => {
+    assert.throws(
+      () => filtersOf({
+        filters: [
+          {column: 'num_comments', operator: 'gt', value: 1},
+          {column: 'num_comments', operator: 'gt', value: 5},
+        ],
+      }),
+      /duplicate/i
+    );
+  });
+});
+
+describe('buildSubscriberQuery — search and sort', () => {
+  // Verified against the live API: a top-level `search` is ignored and returns the unfiltered
+  // count, so it has to travel inside `filters` alongside the columns.
+  test('search travels inside filters, not next to limit', () => {
+    const query = buildSubscriberQuery({search: 'gmail'});
+
+    assert.deepEqual(query.filters, {search: 'gmail'});
+    assert.equal(query.search, undefined);
+  });
+
+  test('descending sort uses order_by_desc_nulls_last', () => {
+    assert.deepEqual(
+      filtersOf({sort_by: 'subscription_created_at', sort_direction: 'desc'}),
+      {order_by_desc_nulls_last: 'subscription_created_at'}
+    );
+  });
+
+  test('ascending sort uses order_by', () => {
+    assert.deepEqual(
+      filtersOf({sort_by: 'total_revenue_generated', sort_direction: 'asc'}),
+      {order_by: 'total_revenue_generated'}
+    );
+  });
+
+  test('sort defaults to descending', () => {
+    assert.deepEqual(
+      filtersOf({sort_by: 'subscription_created_at'}),
+      {order_by_desc_nulls_last: 'subscription_created_at'}
+    );
+  });
+
+  test('sorting by an unknown column is refused', () => {
+    assert.throws(() => filtersOf({sort_by: 'nope'}), /unknown column.*nope/i);
+  });
+
+  test('search, sort and filters coexist', () => {
+    const built = filtersOf({
+      search: 'gmail',
+      sort_by: 'subscription_created_at',
+      filters: [{column: 'subscription_type', operator: 'is', value: 'free'}],
+    });
+
+    assert.deepEqual(built, {
+      subscription_type: 'free',
+      search: 'gmail',
+      order_by_desc_nulls_last: 'subscription_created_at',
+    });
+  });
+});
+
+describe('buildSubscriberQuery — validation', () => {
+  // The API answers 400 with no usable explanation for all three of these. Catching them here
+  // is what turns a dead end into a message a model can act on.
+  test('an unknown column is refused and named', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'subscriber_email', operator: 'is', value: 'x'}]}),
+      /unknown column.*subscriber_email/i
+    );
+  });
+
+  test('an operator the column type does not accept is refused', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'user_email_address', operator: 'gt', value: 1}]}),
+      /gt/
+    );
+  });
+
+  test('the refusal lists the operators that would have worked', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'subscription_created_at', operator: 'lte', value: 'x'}]}),
+      /is_on_or_before/
+    );
+  });
+
+  test('an invalid enum value is refused and the allowed values listed', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'subscription_type', operator: 'is', value: 'premium'}]}),
+      /premium.*free_trial|free_trial.*premium/s
+    );
+  });
+
+  test('a valid enum value passes', () => {
+    for (const value of ['paid', 'free', 'founding', 'comp', 'gift', 'free_trial', 'iap']) {
+      assert.deepEqual(
+        filtersOf({filters: [{column: 'subscription_type', operator: 'is', value}]}),
+        {[`subscription_type`]: value}
+      );
+    }
+  });
+
+  test('is_any_of requires an array', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'subscription_type', operator: 'is_any_of', value: 'free'}]}),
+      /array/i
+    );
+  });
+
+  test('includes_any requires an array', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'tag_ids', operator: 'includes_any', value: 1}]}),
+      /array/i
+    );
+  });
+
+  test('a scalar operator rejects an array', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'num_comments', operator: 'gt', value: [1]}]}),
+      /array/i
+    );
+  });
+
+  test('enum values inside is_any_of are validated too', () => {
+    assert.throws(
+      () => filtersOf({filters: [{column: 'subscription_type', operator: 'is_any_of', value: ['free', 'premium']}]}),
+      /premium/
+    );
+  });
+});

--- a/src/api/substack/SubstackApi.js
+++ b/src/api/substack/SubstackApi.js
@@ -52,27 +52,44 @@ export default class SubstackApi {
     return parsed;
   }
 
-  async postDraft(body) {
-    const url = `${this.publication_url}/drafts`;
+  /**
+   * Issues one authenticated request against the publication API and returns the parsed body.
+   *
+   * `path` is relative to `/api/v1` (`/drafts`, `/subscriber-stats`). `params` become the query
+   * string, with null and undefined entries dropped rather than serialized — a `query=null` in
+   * the URL is a search for the literal string "null", which silently returns nothing.
+   */
+  async request({method, path, body = null, params = null, referer = '/publish/posts'}) {
+    const target = new URL(`${this.publication_url}${path}`);
+
+    for (const [key, value] of Object.entries(params ?? {})) {
+      if (value !== null && value !== undefined) target.searchParams.set(key, value);
+    }
+
+    const url = target.toString();
 
     const headers = {};
-    headers['Content-Type'] = 'application/json';
+    if (body !== null) headers['Content-Type'] = 'application/json';
     headers['Cookie'] = this.auth_cookie;
-    headers['referer'] = `${this.hostname}/publish/post`;
+    headers['referer'] = `${this.hostname}${referer}`;
 
     const startedAt = Date.now();
     // `headers` carries the session cookie: the logger redacts it by key name.
-    logger.info('substack.request', {method: 'POST', url, headers, body});
+    logger.info('substack.request', {method, url, headers, body});
 
     let response;
 
     try {
-      response = await fetch(url, {method: 'POST', headers, body: JSON.stringify(body)});
+      response = await fetch(url, {
+        method,
+        headers,
+        ...(body === null ? {} : {body: JSON.stringify(body)}),
+      });
     } catch (error) {
       // fetch only rejects on a transport failure — DNS, TLS, connection reset. A non-2xx
       // answer resolves, and is handled by handleResponse below.
       logger.error('substack.request.failed', {
-        method: 'POST',
+        method,
         url,
         duration_ms: Date.now() - startedAt,
         error,
@@ -81,12 +98,47 @@ export default class SubstackApi {
     }
 
     logger.info('substack.response', {
-      method: 'POST',
+      method,
       url,
       status: response.status,
       duration_ms: Date.now() - startedAt,
     });
 
     return SubstackApi.handleResponse(response)
+  }
+
+  async postDraft(body) {
+    return this.request({method: 'POST', path: '/drafts', body, referer: '/publish/post'});
+  }
+
+  /**
+   * Lists subscribers. `query` is the whole request body — filters, sorting and free-text search
+   * all live inside its `filters` object; see SubscriberQuery.js for how it is assembled.
+   */
+  async getSubscribers(query) {
+    return this.request({
+      method: 'POST',
+      path: '/subscriber-stats',
+      body: query,
+      referer: '/publish/subscribers',
+    });
+  }
+
+  /**
+   * Lists posts for one status: 'drafts', 'published' or 'scheduled'. `order_by` is not optional
+   * on the API side for every status — 'scheduled' answers 400 without it — so the caller is
+   * expected to always pass one.
+   */
+  async getPosts({status, limit, offset, order_by, order_direction, query = null}) {
+    return this.request({
+      method: 'GET',
+      path: `/post_management/${status}`,
+      params: {offset, limit, order_by, order_direction, query},
+      referer: '/publish/posts',
+    });
+  }
+
+  async getDraft(draft_id) {
+    return this.request({method: 'GET', path: `/drafts/${draft_id}`, referer: '/publish/post'});
   }
 }

--- a/src/api/substack/SubstackApi.spec.js
+++ b/src/api/substack/SubstackApi.spec.js
@@ -2,7 +2,16 @@ import {test, describe, before, after, afterEach} from 'node:test';
 import assert from 'node:assert/strict';
 import {HttpResponse} from 'msw';
 import SubstackApi from './SubstackApi.js';
-import {createMswServer, DRAFTS_URL, DRAFT_RESPONSE} from '../../../test/helpers/msw-server.js';
+import {
+  createMswServer,
+  DRAFTS_URL,
+  DRAFT_RESPONSE,
+  SUBSCRIBER_STATS_URL,
+  SUBSCRIBER_STATS_RESPONSE,
+  POSTS_RESPONSE,
+  DRAFT_DETAIL_RESPONSE,
+  DASHBOARD_SUMMARY_RESPONSE,
+} from '../../../test/helpers/msw-server.js';
 import {TEST_ENV, setTestEnv} from '../../../test/helpers/env.js';
 import {captureLogs} from '../../../test/helpers/capture-logs.js';
 
@@ -119,6 +128,123 @@ describe('SubstackApi — postDraft', () => {
     const error = await createApi().postDraft({}).catch((e) => e);
 
     assert.match(error.message, /^SubstackRequestException: Invalid Response: not json$/);
+  });
+});
+
+describe('SubstackApi — getSubscribers', () => {
+  test('POSTs the query to the subscriber-stats endpoint', async () => {
+    const query = {filters: {subscription_type: 'free'}, limit: 25, offset: 0};
+
+    const result = await createApi().getSubscribers(query);
+
+    assert.deepEqual(result, SUBSCRIBER_STATS_RESPONSE);
+    assert.equal(msw.requests.length, 1);
+
+    const [request] = msw.requests;
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, SUBSCRIBER_STATS_URL);
+    assert.deepEqual(request.body, query);
+  });
+
+  test('authenticates with the session cookie', async () => {
+    await createApi().getSubscribers({filters: {}, limit: 1, offset: 0});
+
+    assert.equal(
+      msw.requests[0].headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+
+  test('throws a SubstackAPIException when the API rejects the filters', async () => {
+    msw.server.use(
+      msw.subscriberStatsHandler(() => new HttpResponse('bad filter', {status: 400}))
+    );
+
+    const error = await createApi().getSubscribers({filters: {}}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+  });
+});
+
+describe('SubstackApi — getPosts', () => {
+  test('GETs the requested status with pagination and sort in the query string', async () => {
+    const result = await createApi().getPosts({
+      status: 'published',
+      limit: 25,
+      offset: 50,
+      order_by: 'post_date',
+      order_direction: 'desc',
+    });
+
+    assert.deepEqual(result, POSTS_RESPONSE);
+
+    const url = new URL(msw.requests[0].url);
+    assert.equal(msw.requests[0].method, 'GET');
+    assert.equal(url.pathname, '/api/v1/post_management/published');
+    assert.equal(url.searchParams.get('limit'), '25');
+    assert.equal(url.searchParams.get('offset'), '50');
+    assert.equal(url.searchParams.get('order_by'), 'post_date');
+    assert.equal(url.searchParams.get('order_direction'), 'desc');
+  });
+
+  test('includes the search term as `query` when one is given', async () => {
+    await createApi().getPosts({
+      status: 'drafts',
+      limit: 25,
+      offset: 0,
+      order_by: 'draft_updated_at',
+      order_direction: 'desc',
+      query: 'mcp',
+    });
+
+    assert.equal(new URL(msw.requests[0].url).searchParams.get('query'), 'mcp');
+  });
+
+  // An empty `query=` is what the dashboard sends, but a null one must not become the string
+  // "null" in the URL — that would search for a post named null and return nothing.
+  test('omits `query` entirely when no search term is given', async () => {
+    await createApi().getPosts({
+      status: 'drafts',
+      limit: 25,
+      offset: 0,
+      order_by: 'draft_updated_at',
+      order_direction: 'desc',
+    });
+
+    assert.equal(new URL(msw.requests[0].url).searchParams.has('query'), false);
+  });
+});
+
+describe('SubstackApi — getDraft', () => {
+  test('GETs the draft by id', async () => {
+    const result = await createApi().getDraft(167712345);
+
+    assert.deepEqual(result, DRAFT_DETAIL_RESPONSE);
+    assert.equal(msw.requests[0].method, 'GET');
+    assert.equal(new URL(msw.requests[0].url).pathname, '/api/v1/drafts/167712345');
+  });
+
+  test('throws a SubstackAPIException on 404', async () => {
+    msw.server.use(msw.draftDetailHandler(() => new HttpResponse('nope', {status: 404})));
+
+    const error = await createApi().getDraft(999).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 404\b/);
+  });
+});
+
+describe('SubstackApi — request', () => {
+  test('performs a bare GET against a publication path', async () => {
+    const result = await createApi().request({method: 'GET', path: '/publish-dashboard/summary'});
+
+    assert.deepEqual(result, DASHBOARD_SUMMARY_RESPONSE);
+    assert.equal(new URL(msw.requests[0].url).pathname, '/api/v1/publish-dashboard/summary');
+  });
+
+  test('sends no body on a GET', async () => {
+    await createApi().request({method: 'GET', path: '/publish-dashboard/summary'});
+
+    assert.equal(msw.requests[0].body, '');
   });
 });
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -128,12 +128,24 @@ describe('entrypoint — stdio transport', () => {
     assert.deepEqual(Object.keys(initialize.result.capabilities), ['tools']);
 
     const listTools = messages.find((message) => message.id === 2);
-    assert.equal(listTools.result.tools.length, 1);
-    assert.equal(listTools.result.tools[0].name, 'create_draft_post');
+    const byName = Object.fromEntries(listTools.result.tools.map((tool) => [tool.name, tool]));
+
+    assert.deepEqual(Object.keys(byName).sort(), [
+      'create_draft_post',
+      'get_draft',
+      'get_publication_stats',
+      'list_posts',
+      'list_subscribers',
+    ]);
+
     assert.deepEqual(
-      Object.keys(listTools.result.tools[0].inputSchema.properties).sort(),
+      Object.keys(byName.create_draft_post.inputSchema.properties).sort(),
       ['body', 'subtitle', 'title']
     );
+
+    // The whole point of listing over a real transport rather than in-process: the 48-value
+    // column enum has to survive JSON-RPC serialization to be of any use to a client.
+    assert.equal(byName.list_subscribers.inputSchema.properties.filters.items.properties.column.enum.length, 48);
   });
 
   // The process exits 0 as soon as stdin reaches EOF; that is the documented normal shutdown,

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,9 @@
 import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
+import {listSubscribersSchema, listSubscribersHandler} from "./tools/list_subscribers.js";
+import {listPostsSchema, listPostsHandler} from "./tools/list_posts.js";
+import {getDraftSchema, getDraftHandler} from "./tools/get_draft.js";
+import {getPublicationStatsSchema, getPublicationStatsHandler} from "./tools/get_publication_stats.js";
 import {logger} from "./logger.js";
 
 export const tools = {
@@ -7,6 +11,45 @@ export const tools = {
     description: "create a draft post on your Substack account.",
     schema: createDraftPostSchema,
     handler: createDraftPostHandler,
+  },
+  list_subscribers: {
+    // The engagement caveat belongs in the description rather than a comment: the columns are
+    // filterable but never come back in the response, because the API takes the fields it returns
+    // from the publication's saved Display settings and ignores a per-request column list. A
+    // caller filtering on opens and then looking for them in the result would otherwise conclude
+    // the data is missing. `count` is the way to read them — filter and look at how many match.
+    description:
+      "List and filter the subscribers of your Substack publication. Supports the same 48 columns " +
+      "and operators as the Subscribers dashboard, combined with AND, plus free-text search, " +
+      "sorting and pagination. Returns `count`, the total matching the filters regardless of " +
+      "`limit`, so a call with limit 1 is a cheap way to size a segment. Engagement columns " +
+      "(email opens, post views, comments, shares, activity rating) can be filtered on but are " +
+      "not included in the returned subscriber records — use `count` with different thresholds to " +
+      "learn about them.",
+    schema: listSubscribersSchema,
+    handler: listSubscribersHandler,
+  },
+  list_posts: {
+    description:
+      "List the posts of your Substack publication: drafts, published posts or scheduled posts. " +
+      "Supports free-text search, pagination and sort direction. Each post is returned as a " +
+      "summary; use get_draft for the full content of an unpublished one.",
+    schema: listPostsSchema,
+    handler: listPostsHandler,
+  },
+  get_draft: {
+    description:
+      "Read one draft post of your Substack publication in full, including its body and its " +
+      "audience and email settings. Take the id from list_posts.",
+    schema: getDraftSchema,
+    handler: getDraftHandler,
+  },
+  get_publication_stats: {
+    description:
+      "Read the headline stats of your Substack publication: total and recent subscribers, ARR, " +
+      "site views, and the 30-day email open rate. Takes no arguments.",
+    schema: getPublicationStatsSchema,
+    handler: getPublicationStatsHandler,
   },
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -40,7 +40,7 @@ export const tools = {
   get_draft: {
     description:
       "Read one draft post of your Substack publication in full, including its body and its " +
-      "audience and email settings. Take the id from list_posts.",
+      "audience and email settings. Take the id from list_posts or create_draft_post.",
     schema: getDraftSchema,
     handler: getDraftHandler,
   },

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -122,7 +122,10 @@ describe('MCP server — call_tool', () => {
     try {
       const result = await client.callTool({name: 'create_draft_post', arguments: VALID_ARGS});
 
-      assert.deepEqual(result.content, [{type: 'text', text: '"OK"'}]);
+      // Serialized by the server, so the id arrives as JSON text rather than an object.
+      assert.deepEqual(result.content, [
+        {type: 'text', text: JSON.stringify({draft_id: 167712345, is_published: false}, null, 2)},
+      ]);
     } finally {
       await close();
     }
@@ -269,7 +272,7 @@ describe('MCP server — call_tool', () => {
 
       const success = find(lines, 'tool.call.success');
       assert.equal(success.tool, 'create_draft_post');
-      assert.equal(success.result, 'OK');
+      assert.deepEqual(success.result, {draft_id: 167712345, is_published: false});
       assert.equal(typeof success.duration_ms, 'number');
     });
 

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -24,72 +24,94 @@ after(() => {
 const VALID_ARGS = {title: 'Title', subtitle: 'Subtitle', body: 'Body'};
 
 describe('MCP server — list_tools', () => {
-  test('exposes create_draft_post with its description', async () => {
+  // Indexed by name rather than position: the registry is an object, and asserting on tools[0]
+  // makes every one of these tests depend on the declaration order of an unrelated tool.
+  async function listToolsByName() {
     const {client, close} = await connectMcpClient();
 
     try {
       const {tools} = await client.listTools();
-
-      assert.equal(tools.length, 1);
-      assert.equal(tools[0].name, 'create_draft_post');
-      assert.equal(tools[0].description, 'create a draft post on your Substack account.');
+      return Object.fromEntries(tools.map((tool) => [tool.name, tool]));
     } finally {
       await close();
     }
+  }
+
+  const EXPECTED_TOOLS = [
+    'create_draft_post',
+    'get_draft',
+    'get_publication_stats',
+    'list_posts',
+    'list_subscribers',
+  ];
+
+  test('exposes exactly the registered tools', async () => {
+    const tools = await listToolsByName();
+
+    assert.deepEqual(Object.keys(tools).sort(), EXPECTED_TOOLS);
   });
 
-  test('publishes an inputSchema with the three required fields', async () => {
-    const {client, close} = await connectMcpClient();
+  test('every tool carries a description', async () => {
+    const tools = await listToolsByName();
 
-    try {
-      const {tools} = await client.listTools();
-      const {inputSchema} = tools[0];
-
-      assert.equal(inputSchema.type, 'object');
-      assert.deepEqual(Object.keys(inputSchema.properties).sort(), ['body', 'subtitle', 'title']);
-      assert.deepEqual([...inputSchema.required].sort(), ['body', 'subtitle', 'title']);
-      assert.equal(inputSchema.properties.title.type, 'string');
-    } finally {
-      await close();
+    for (const name of EXPECTED_TOOLS) {
+      assert.ok(tools[name].description, `${name} should carry a description`);
     }
+
+    assert.equal(tools.create_draft_post.description, 'create a draft post on your Substack account.');
+  });
+
+  test('create_draft_post publishes an inputSchema with the three required fields', async () => {
+    const {inputSchema} = (await listToolsByName()).create_draft_post;
+
+    assert.equal(inputSchema.type, 'object');
+    assert.deepEqual(Object.keys(inputSchema.properties).sort(), ['body', 'subtitle', 'title']);
+    assert.deepEqual([...inputSchema.required].sort(), ['body', 'subtitle', 'title']);
+    assert.equal(inputSchema.properties.title.type, 'string');
   });
 
   // Regression guard for the zod 3 -> 4 migration: zod-to-json-schema silently returned a
   // bare `{$schema}` for a zod 4 schema instead of throwing, which would have published a
   // parameterless tool. Asserting the descriptions — the part an LLM actually reads to fill
   // the arguments — is what makes a degraded-but-structurally-valid schema fail here.
-  test('every property carries the description the LLM relies on', async () => {
-    const {client, close} = await connectMcpClient();
+  test('every property of every tool carries the description the LLM relies on', async () => {
+    const tools = await listToolsByName();
 
-    try {
-      const {tools} = await client.listTools();
-      const {properties} = tools[0].inputSchema;
-
-      for (const [name, property] of Object.entries(properties)) {
-        assert.equal(property.type, 'string', `${name} should be a string`);
-        assert.ok(property.description, `${name} should carry a description`);
+    for (const name of EXPECTED_TOOLS) {
+      for (const [property, definition] of Object.entries(tools[name].inputSchema.properties ?? {})) {
+        assert.ok(definition.description, `${name}.${property} should carry a description`);
       }
+    }
 
-      assert.match(properties.body.description, /plain text|JSON string/);
-    } finally {
-      await close();
+    const {properties} = tools.create_draft_post.inputSchema;
+    assert.match(properties.body.description, /plain text|JSON string/);
+  });
+
+  test('every inputSchema is a draft-07 document that closes the object', async () => {
+    const tools = await listToolsByName();
+
+    for (const name of EXPECTED_TOOLS) {
+      const {inputSchema} = tools[name];
+
+      assert.equal(inputSchema.$schema, 'http://json-schema.org/draft-07/schema#', name);
+      // Accurate only because the schemas are strictObjects: a plain z.object strips unknown
+      // keys instead of rejecting them, and would publish this as an empty promise.
+      assert.equal(inputSchema.additionalProperties, false, name);
     }
   });
 
-  test('the inputSchema is a draft-07 document that closes the object', async () => {
-    const {client, close} = await connectMcpClient();
+  // The 48 column names reach the model only through this enum. If the schema ever published
+  // `column` as a bare string the tool would still work for a caller that already knows the
+  // names, and be unusable for one that does not.
+  test('list_subscribers publishes the filterable columns as an enum', async () => {
+    const {inputSchema} = (await listToolsByName()).list_subscribers;
+    const {column, operator} = inputSchema.properties.filters.items.properties;
 
-    try {
-      const {tools} = await client.listTools();
-      const {inputSchema} = tools[0];
-
-      assert.equal(inputSchema.$schema, 'http://json-schema.org/draft-07/schema#');
-      // Accurate only because the schema is a strictObject: a plain z.object strips unknown
-      // keys instead of rejecting them, and would publish this as an empty promise.
-      assert.equal(inputSchema.additionalProperties, false);
-    } finally {
-      await close();
-    }
+    assert.equal(column.enum.length, 48);
+    assert.ok(column.enum.includes('num_email_opens_last_30d'));
+    assert.ok(column.enum.includes('subscription_type'));
+    assert.ok(operator.enum.includes('is_any_of'));
+    assert.ok(operator.enum.includes('is_on_or_before'));
   });
 });
 

--- a/src/tools/create_draft_post.js
+++ b/src/tools/create_draft_post.js
@@ -96,5 +96,12 @@ export const createDraftPostHandler = async (args) => {
     is_published: response?.is_published ?? null,
   });
 
-  return 'OK'
+  // The id, not 'OK': it is what get_draft needs, and returning it is the only way the model can
+  // reach the draft it just created — the log line above goes to stderr, where the model cannot
+  // see it. `?? null` rather than leaving it undefined, which JSON.stringify would drop from the
+  // result, reporting success while silently carrying no id at all.
+  return {
+    draft_id: response?.id ?? null,
+    is_published: response?.is_published ?? false,
+  }
 }

--- a/src/tools/create_draft_post.spec.js
+++ b/src/tools/create_draft_post.spec.js
@@ -35,8 +35,33 @@ describe('createDraftPostSchema', () => {
 });
 
 describe('createDraftPostHandler — success', () => {
-  test('returns OK', async () => {
-    assert.equal(await createDraftPostHandler(VALID_ARGS), 'OK');
+  // It used to answer 'OK', which told the caller the draft existed but gave it no handle on it:
+  // the id reached only the log, on stderr, where the model cannot see it. get_draft therefore
+  // had no way in except a list_posts round trip.
+  test('returns the id of the draft it created', async () => {
+    assert.deepEqual(await createDraftPostHandler(VALID_ARGS), {
+      draft_id: 167712345,
+      is_published: false,
+    });
+  });
+
+  test('reports the id the API actually assigned, not a fixed one', async () => {
+    msw.server.use(
+      msw.draftsHandler(() => HttpResponse.json({id: 42, is_published: false}, {status: 200}))
+    );
+
+    assert.equal((await createDraftPostHandler(VALID_ARGS)).draft_id, 42);
+  });
+
+  // A response without an id would otherwise yield `undefined`, which JSON.stringify drops from
+  // the result entirely — the caller would see a success carrying no id and no explanation.
+  test('reports a null id rather than omitting it when the API sends none', async () => {
+    msw.server.use(msw.draftsHandler(() => HttpResponse.json({}, {status: 200})));
+
+    assert.deepEqual(await createDraftPostHandler(VALID_ARGS), {
+      draft_id: null,
+      is_published: false,
+    });
   });
 
   test('sends exactly one request to the drafts endpoint', async () => {

--- a/src/tools/get_draft.js
+++ b/src/tools/get_draft.js
@@ -10,7 +10,7 @@ export const getDraftSchema = z.strictObject({
     .number()
     .int()
     .describe(
-      "The numeric id of the draft, as returned in the `id` field by list_posts."
+      "The numeric id of the draft, as returned by list_posts (`id`) or create_draft_post (`draft_id`)."
     ),
 });
 

--- a/src/tools/get_draft.js
+++ b/src/tools/get_draft.js
@@ -1,0 +1,50 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call. A model sending `id`
+// instead of `draft_id` would otherwise only be told that `draft_id` is missing.
+export const getDraftSchema = z.strictObject({
+  draft_id: z
+    .number()
+    .int()
+    .describe(
+      "The numeric id of the draft, as returned in the `id` field by list_posts or create_draft_post."
+    ),
+});
+
+export const getDraftHandler = async (args) => {
+  logger.debug('get_draft.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse
+  // never rejects. It is kept so the handler stays safe when called directly.
+  let validatedArgs;
+
+  try {
+    validatedArgs = getDraftSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('get_draft.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {draft_id} = validatedArgs;
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  // Returned whole, unlike the projection list_posts applies: a caller naming one draft wants its
+  // body and its settings, and there is no further call that would fetch them.
+  const draft = await substack_api.getDraft(draft_id);
+
+  logger.info('get_draft.done', {
+    draft_id,
+    is_published: draft?.is_published ?? null,
+    has_body: Boolean(draft?.draft_body),
+  });
+
+  return draft;
+};

--- a/src/tools/get_draft.js
+++ b/src/tools/get_draft.js
@@ -10,7 +10,7 @@ export const getDraftSchema = z.strictObject({
     .number()
     .int()
     .describe(
-      "The numeric id of the draft, as returned in the `id` field by list_posts or create_draft_post."
+      "The numeric id of the draft, as returned in the `id` field by list_posts."
     ),
 });
 

--- a/src/tools/get_draft.spec.js
+++ b/src/tools/get_draft.spec.js
@@ -85,6 +85,18 @@ describe('getDraftHandler', () => {
     assert.equal(msw.requests.length, 0);
   });
 
+  // Reached only on a direct call — over MCP the SDK answers `Input validation error` before the
+  // handler runs, so this line is the only record that anything embedding the handler got it wrong.
+  test('records the validation issues when the arguments are rejected', async () => {
+    const lines = await captureLogs(
+      () => getDraftHandler({draft_id: 'abc'}).catch(() => {})
+    );
+
+    const invalid = lines.find((entry) => entry.msg === 'get_draft.args.invalid');
+    assert.ok(invalid, 'expected a get_draft.args.invalid log line');
+    assert.deepEqual(invalid.issues.map((issue) => issue.path.join('.')), ['draft_id']);
+  });
+
   test('records the id it asked for and what came back', async () => {
     const lines = await captureLogs(() => getDraftHandler({draft_id: 167712345}));
     const find = (msg) => lines.find((entry) => entry.msg === msg);

--- a/src/tools/get_draft.spec.js
+++ b/src/tools/get_draft.spec.js
@@ -1,0 +1,105 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {getDraftHandler, getDraftSchema} from './get_draft.js';
+import {createMswServer, DRAFT_DETAIL_RESPONSE} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+describe('getDraftSchema', () => {
+  test('requires a draft_id', () => {
+    assert.throws(() => getDraftSchema.parse({}), z.ZodError);
+  });
+
+  test('accepts an integer id', () => {
+    assert.deepEqual(getDraftSchema.parse({draft_id: 167712345}), {draft_id: 167712345});
+  });
+
+  test('rejects a non-integer id', () => {
+    assert.throws(() => getDraftSchema.parse({draft_id: 1.5}), z.ZodError);
+    assert.throws(() => getDraftSchema.parse({draft_id: 'abc'}), z.ZodError);
+  });
+
+  test('rejects an unknown key by name', () => {
+    assert.throws(
+      () => getDraftSchema.parse({draft_id: 1, id: 2}),
+      (error) => /Unrecognized key/.test(error.message) && /\bid\b/.test(error.message)
+    );
+  });
+
+  test('publishes a description for draft_id', () => {
+    const json = z.toJSONSchema(getDraftSchema, {target: 'draft-7', io: 'input'});
+
+    assert.ok(json.properties.draft_id.description);
+    assert.equal(json.additionalProperties, false);
+  });
+});
+
+describe('getDraftHandler', () => {
+  test('GETs the draft by id', async () => {
+    const result = await getDraftHandler({draft_id: 167712345});
+
+    assert.equal(msw.requests.length, 1);
+    assert.equal(msw.requests[0].method, 'GET');
+    assert.equal(new URL(msw.requests[0].url).pathname, '/api/v1/drafts/167712345');
+    assert.deepEqual(result, DRAFT_DETAIL_RESPONSE);
+  });
+
+  // Unlike list_posts this returns the draft untouched: a caller asking for one specific draft
+  // wants its body and its settings, and there is no second call that would fetch them.
+  test('returns the draft unprojected, body included', async () => {
+    const result = await getDraftHandler({draft_id: 167712345});
+
+    assert.equal(result.draft_body, '{"type":"doc","content":[]}');
+    assert.equal(result.draft_title, 'A draft');
+  });
+
+  test('propagates a 404 for a draft that does not exist', async () => {
+    msw.server.use(msw.draftDetailHandler(() => new HttpResponse('nope', {status: 404})));
+
+    const error = await getDraftHandler({draft_id: 1}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 404\b/);
+  });
+
+  test('throws ZodError on a malformed call without issuing any request', async () => {
+    await assert.rejects(
+      () => getDraftHandler({draft_id: 'abc'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('records the id it asked for and what came back', async () => {
+    const lines = await captureLogs(() => getDraftHandler({draft_id: 167712345}));
+    const find = (msg) => lines.find((entry) => entry.msg === msg);
+
+    assert.equal(find('get_draft.start').args.draft_id, 167712345);
+
+    const done = find('get_draft.done');
+    assert.ok(done, 'expected a get_draft.done log line');
+    assert.equal(done.draft_id, 167712345);
+    assert.equal(done.is_published, false);
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => getDraftHandler({draft_id: 1}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/src/tools/get_publication_stats.js
+++ b/src/tools/get_publication_stats.js
@@ -1,0 +1,83 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+
+/**
+ * The dashboard's headline numbers live on three separate endpoints. They are fetched together
+ * because no single one of them answers "how is the publication doing" on its own.
+ */
+const PARTS = {
+  summary: '/publish-dashboard/summary',
+  open_rate: '/publication/stats/email_stats/30d_open_rate',
+  views_30d: '/publication/stats/publication_traffic/30d_views',
+};
+
+// strictObject, not object: an unknown key must be reported rather than stripped. There are no
+// parameters at all here, so a caller passing one has misunderstood the tool and should be told.
+export const getPublicationStatsSchema = z.strictObject({});
+
+export const getPublicationStatsHandler = async (args) => {
+  logger.debug('get_publication_stats.start', {args});
+
+  let validatedArgs;
+
+  try {
+    validatedArgs = getPublicationStatsSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('get_publication_stats.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  // Fetched in parallel and settled individually: one endpoint being down should cost its own
+  // numbers, not the whole answer. A tool that returns nothing is strictly less useful than one
+  // that returns two thirds and names the third.
+  const names = Object.keys(PARTS);
+  const settled = await Promise.allSettled(
+    names.map((name) => substack_api.request({method: 'GET', path: PARTS[name]}))
+  );
+
+  const parts = {};
+  const errors = {};
+
+  settled.forEach((outcome, index) => {
+    const name = names[index];
+
+    if (outcome.status === 'fulfilled') {
+      parts[name] = outcome.value;
+      return;
+    }
+
+    // The message carries the status; the full error, cause chain included, goes to the log.
+    errors[name] = outcome.reason?.message ?? String(outcome.reason);
+    logger.warn('get_publication_stats.part.failed', {part: name, error: outcome.reason});
+  });
+
+  const {summary = null, open_rate = null, views_30d = null} = parts;
+
+  const failed = Object.keys(errors);
+  logger.info('get_publication_stats.done', {fetched: Object.keys(parts), failed});
+
+  return {
+    subscribers: summary?.subscribers ?? null,
+    subscribers_last_30_days: summary?.subscribersLast30Days ?? null,
+    email_subscribers: summary?.totalEmail ?? null,
+    email_subscribers_last_30_days: summary?.totalEmailLast30Days ?? null,
+    app_subscribers: summary?.appSubscribers ?? null,
+    arr: summary?.arr ?? null,
+    arr_change: summary?.arrDelta ?? null,
+    views: summary?.views ?? null,
+    views_change: summary?.viewsDelta ?? null,
+    open_rate_30d: open_rate?.openRate ?? null,
+    open_rate_30d_change: open_rate?.openRateDiff ?? null,
+    views_30d: views_30d?.views30d ?? null,
+    views_30d_change: views_30d?.viewsDelta30d ?? null,
+    // Present only when something failed, so a complete answer carries no misleading empty object.
+    ...(failed.length > 0 ? {errors} : {}),
+  };
+};

--- a/src/tools/get_publication_stats.spec.js
+++ b/src/tools/get_publication_stats.spec.js
@@ -1,0 +1,130 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {getPublicationStatsHandler, getPublicationStatsSchema} from './get_publication_stats.js';
+import {
+  createMswServer,
+  DASHBOARD_SUMMARY_URL,
+  OPEN_RATE_URL,
+  VIEWS_30D_URL,
+} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const paths = () => msw.requests.map((request) => new URL(request.url).pathname).sort();
+
+describe('getPublicationStatsSchema', () => {
+  test('takes no arguments', () => {
+    assert.deepEqual(getPublicationStatsSchema.parse({}), {});
+  });
+
+  test('rejects an unknown key by name rather than ignoring it', () => {
+    assert.throws(
+      () => getPublicationStatsSchema.parse({period: '30d'}),
+      (error) => /Unrecognized key/.test(error.message) && /period/.test(error.message)
+    );
+  });
+
+  test('publishes an object schema that accepts nothing else', () => {
+    const json = z.toJSONSchema(getPublicationStatsSchema, {target: 'draft-7', io: 'input'});
+
+    assert.equal(json.additionalProperties, false);
+  });
+});
+
+describe('getPublicationStatsHandler', () => {
+  test('collects the three dashboard endpoints', async () => {
+    await getPublicationStatsHandler({});
+
+    assert.equal(msw.requests.length, 3);
+    assert.deepEqual(paths(), [
+      '/api/v1/publication/stats/email_stats/30d_open_rate',
+      '/api/v1/publication/stats/publication_traffic/30d_views',
+      '/api/v1/publish-dashboard/summary',
+    ]);
+  });
+
+  test('issues them all as GETs', async () => {
+    await getPublicationStatsHandler({});
+
+    for (const request of msw.requests) assert.equal(request.method, 'GET');
+  });
+
+  test('merges them into one flat result', async () => {
+    const result = await getPublicationStatsHandler({});
+
+    assert.equal(result.subscribers, 2025);
+    assert.equal(result.subscribers_last_30_days, 77);
+    assert.equal(result.arr, 120);
+    assert.equal(result.views, 5000);
+    assert.equal(result.open_rate_30d, 0.42);
+    assert.equal(result.open_rate_30d_change, 0.01);
+    assert.equal(result.views_30d, 5000);
+    assert.equal(result.views_30d_change, 250);
+  });
+
+  // One endpoint failing must not take the whole answer down: the other two carry most of the
+  // value, and a tool that returns nothing at all is strictly worse than one that says which
+  // part it could not reach.
+  test('reports a failing endpoint without losing the ones that answered', async () => {
+    msw.server.use(msw.statsHandler(OPEN_RATE_URL, () => new HttpResponse('boom', {status: 500})));
+
+    const result = await getPublicationStatsHandler({});
+
+    assert.equal(result.subscribers, 2025);
+    assert.equal(result.open_rate_30d, null);
+    assert.match(result.errors.open_rate, /500/);
+  });
+
+  test('carries no errors key when everything answered', async () => {
+    const result = await getPublicationStatsHandler({});
+
+    assert.equal(result.errors, undefined);
+  });
+
+  test('still answers when the summary itself is the one failing', async () => {
+    msw.server.use(
+      msw.statsHandler(DASHBOARD_SUMMARY_URL, () => new HttpResponse('boom', {status: 503}))
+    );
+
+    const result = await getPublicationStatsHandler({});
+
+    assert.equal(result.subscribers, null);
+    assert.equal(result.views_30d, 5000);
+    assert.match(result.errors.summary, /503/);
+  });
+
+  test('records what it fetched and what it could not', async () => {
+    msw.server.use(msw.statsHandler(VIEWS_30D_URL, () => new HttpResponse('boom', {status: 500})));
+
+    const lines = await captureLogs(() => getPublicationStatsHandler({}));
+
+    const done = lines.find((entry) => entry.msg === 'get_publication_stats.done');
+    assert.ok(done, 'expected a get_publication_stats.done log line');
+    assert.deepEqual(done.failed, ['views_30d']);
+
+    const failure = lines.find((entry) => entry.msg === 'get_publication_stats.part.failed');
+    assert.ok(failure, 'expected the failing part to be logged on its own');
+    assert.equal(failure.part, 'views_30d');
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => getPublicationStatsHandler({}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/src/tools/get_publication_stats.spec.js
+++ b/src/tools/get_publication_stats.spec.js
@@ -108,6 +108,26 @@ describe('getPublicationStatsHandler', () => {
     assert.match(result.errors.summary, /503/);
   });
 
+  // Reached only on a direct call — over MCP the SDK rejects the unknown key first.
+  test('records the validation issues when the arguments are rejected', async () => {
+    const lines = await captureLogs(
+      () => getPublicationStatsHandler({period: '30d'}).catch(() => {})
+    );
+
+    const invalid = lines.find((entry) => entry.msg === 'get_publication_stats.args.invalid');
+    assert.ok(invalid, 'expected a get_publication_stats.args.invalid log line');
+    assert.match(JSON.stringify(invalid.issues), /period/);
+  });
+
+  test('records that it started, so a call that never returns is still visible', async () => {
+    const lines = await captureLogs(() => getPublicationStatsHandler({}));
+
+    assert.ok(
+      lines.find((entry) => entry.msg === 'get_publication_stats.start'),
+      'expected a get_publication_stats.start log line'
+    );
+  });
+
   test('records what it fetched and what it could not', async () => {
     msw.server.use(msw.statsHandler(VIEWS_30D_URL, () => new HttpResponse('boom', {status: 500})));
 

--- a/src/tools/list_posts.js
+++ b/src/tools/list_posts.js
@@ -1,0 +1,150 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+
+/**
+ * The sort each status is listed by in the dashboard.
+ *
+ * `order_by` is not optional on the API side: `/post_management/scheduled` answers 400 when it is
+ * missing, which is how the dashboard's own first request for that tab fails. Every status
+ * therefore gets a default here rather than relying on the server to pick one.
+ *
+ * `scheduled` is also the one status whose useful order is ascending — the post going out next
+ * belongs at the top, while for drafts and published posts the most recent one does.
+ */
+const SORT_BY_STATUS = {
+  drafts: {order_by: 'draft_updated_at', order_direction: 'desc'},
+  published: {order_by: 'post_date', order_direction: 'desc'},
+  scheduled: {order_by: 'trigger_at', order_direction: 'asc'},
+};
+
+// A raw post carries tens of fields — bylines, per-reaction counts, headline tests, exclusion
+// lists — that are noise when listing. These are the ones kept; the schema description says so,
+// so a caller missing a field knows to reach for get_draft rather than assuming it does not exist.
+const PROJECTED_FIELDS = [
+  'id',
+  'uuid',
+  'type',
+  'title',
+  'draft_title',
+  'subtitle',
+  'draft_subtitle',
+  'slug',
+  'audience',
+  'is_published',
+  'post_date',
+  'trigger_at',
+  'draft_created_at',
+  'draft_updated_at',
+  'email_sent_at',
+  'should_send_email',
+  'section_id',
+  'section_name',
+  'draft_section_name',
+  'cover_image',
+  'reaction_count',
+  'comment_count',
+  'stats',
+];
+
+function project(post) {
+  const projected = {};
+
+  for (const field of PROJECTED_FIELDS) {
+    if (post[field] !== undefined) projected[field] = post[field];
+  }
+
+  return projected;
+}
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call.
+export const listPostsSchema = z.strictObject({
+  status: z
+    .enum(['drafts', 'published', 'scheduled'])
+    .describe(
+      "Which list to read: 'drafts' for unpublished work in progress, 'published' for posts already out, 'scheduled' for posts queued to go out later."
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe("Free-text search over the posts, matching title and content."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("How many posts to return, 1-100, defaulting to 25."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("How many posts to skip, for paging through the archive."),
+  sort_direction: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe(
+      "Overrides the default order. Drafts and published posts are newest-first; scheduled posts are soonest-first. The column sorted on is fixed per status: draft_updated_at, post_date and trigger_at respectively."
+    ),
+});
+
+export const listPostsHandler = async (args) => {
+  logger.debug('list_posts.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse
+  // never rejects. It is kept so the handler stays safe when called directly.
+  let validatedArgs;
+
+  try {
+    validatedArgs = listPostsSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('list_posts.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {status, search = null, limit = 25, offset = 0, sort_direction = null} = validatedArgs;
+
+  const defaults = SORT_BY_STATUS[status];
+  const order_by = defaults.order_by;
+  const order_direction = sort_direction ?? defaults.order_direction;
+
+  // The caller never sees which sort was applied, and the wrong one looks like missing data
+  // rather than a different order.
+  logger.debug('list_posts.sort', {status, order_by, order_direction});
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  const response = await substack_api.getPosts({
+    status,
+    limit,
+    offset,
+    order_by,
+    order_direction,
+    query: search,
+  });
+
+  const posts = response?.posts ?? [];
+
+  logger.info('list_posts.done', {
+    status,
+    total: response?.total ?? null,
+    returned: posts.length,
+    limit,
+    offset,
+  });
+
+  return {
+    status,
+    total: response?.total ?? null,
+    returned: posts.length,
+    limit,
+    offset,
+    posts: posts.map(project),
+  };
+};

--- a/src/tools/list_posts.spec.js
+++ b/src/tools/list_posts.spec.js
@@ -231,6 +231,16 @@ describe('listPostsHandler — errors and logging', () => {
     assert.match(error.message, /^SubstackAPIException: 400\b/);
   });
 
+  // Reached only on a direct call — over MCP the SDK rejects first.
+  test('records the validation issues when the arguments are rejected', async () => {
+    const lines = await captureLogs(
+      () => listPostsHandler({status: 'nope'}).catch(() => {})
+    );
+
+    const invalid = find(lines, 'list_posts.args.invalid');
+    assert.deepEqual(invalid.issues.map((issue) => issue.path.join('.')), ['status']);
+  });
+
   test('records the arguments and what came back', async () => {
     const lines = await captureLogs(() => listPostsHandler({status: 'published', search: 'mcp'}));
 

--- a/src/tools/list_posts.spec.js
+++ b/src/tools/list_posts.spec.js
@@ -1,0 +1,258 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {listPostsHandler, listPostsSchema} from './list_posts.js';
+import {createMswServer, POSTS_RESPONSE} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const sentUrl = () => new URL(msw.requests.at(-1).url);
+const param = (name) => sentUrl().searchParams.get(name);
+
+describe('listPostsSchema', () => {
+  test('requires a status', () => {
+    assert.throws(() => listPostsSchema.parse({}), z.ZodError);
+  });
+
+  test('accepts the three statuses the API exposes', () => {
+    for (const status of ['drafts', 'published', 'scheduled']) {
+      assert.deepEqual(listPostsSchema.parse({status}), {status});
+    }
+  });
+
+  test('rejects any other status', () => {
+    assert.throws(() => listPostsSchema.parse({status: 'archived'}), z.ZodError);
+  });
+
+  test('rejects an unknown key by name', () => {
+    assert.throws(
+      () => listPostsSchema.parse({status: 'drafts', search: 'x', q: 'y'}),
+      (error) => /Unrecognized key/.test(error.message) && /q/.test(error.message)
+    );
+  });
+
+  test('publishes a description for every field', () => {
+    const json = z.toJSONSchema(listPostsSchema, {target: 'draft-7', io: 'input'});
+
+    for (const field of ['status', 'search', 'limit', 'offset', 'sort_direction']) {
+      assert.ok(json.properties[field].description, `${field} has no description`);
+    }
+
+    assert.equal(json.additionalProperties, false);
+  });
+});
+
+describe('listPostsHandler — request shape', () => {
+  test('GETs the post_management path for the requested status', async () => {
+    await listPostsHandler({status: 'published'});
+
+    assert.equal(msw.requests.length, 1);
+    assert.equal(msw.requests[0].method, 'GET');
+    assert.equal(sentUrl().pathname, '/api/v1/post_management/published');
+  });
+
+  test('drafts default to sorting by last update, newest first', async () => {
+    await listPostsHandler({status: 'drafts'});
+
+    assert.equal(param('order_by'), 'draft_updated_at');
+    assert.equal(param('order_direction'), 'desc');
+  });
+
+  test('published posts default to sorting by publication date, newest first', async () => {
+    await listPostsHandler({status: 'published'});
+
+    assert.equal(param('order_by'), 'post_date');
+    assert.equal(param('order_direction'), 'desc');
+  });
+
+  // Two things at once: `scheduled` is the one status whose natural order is ascending — the next
+  // post to go out first — and it is also the one the API refuses outright without an order_by.
+  test('scheduled posts sort by trigger time, soonest first', async () => {
+    await listPostsHandler({status: 'scheduled'});
+
+    assert.equal(param('order_by'), 'trigger_at');
+    assert.equal(param('order_direction'), 'asc');
+  });
+
+  test('every status sends an order_by, which the API requires', async () => {
+    for (const status of ['drafts', 'published', 'scheduled']) {
+      msw.requests.length = 0;
+      await listPostsHandler({status});
+
+      assert.ok(param('order_by'), `${status} sent no order_by`);
+    }
+  });
+
+  test('an explicit sort_direction overrides the default', async () => {
+    await listPostsHandler({status: 'scheduled', sort_direction: 'desc'});
+
+    assert.equal(param('order_direction'), 'desc');
+    assert.equal(param('order_by'), 'trigger_at');
+  });
+
+  test('defaults to the first page of 25', async () => {
+    await listPostsHandler({status: 'drafts'});
+
+    assert.equal(param('limit'), '25');
+    assert.equal(param('offset'), '0');
+  });
+
+  test('forwards limit and offset', async () => {
+    await listPostsHandler({status: 'drafts', limit: 5, offset: 10});
+
+    assert.equal(param('limit'), '5');
+    assert.equal(param('offset'), '10');
+  });
+
+  test('sends the search term as the `query` parameter', async () => {
+    await listPostsHandler({status: 'published', search: 'mcp'});
+
+    assert.equal(param('query'), 'mcp');
+  });
+
+  // A null search must not reach the URL as the string "null", which would be searched for
+  // literally and match nothing.
+  test('omits `query` when no search term is given', async () => {
+    await listPostsHandler({status: 'published'});
+
+    assert.equal(sentUrl().searchParams.has('query'), false);
+  });
+});
+
+describe('listPostsHandler — result', () => {
+  test('returns the total, the page size and the posts', async () => {
+    const result = await listPostsHandler({status: 'published'});
+
+    assert.equal(result.status, 'published');
+    assert.equal(result.total, POSTS_RESPONSE.total);
+    assert.equal(result.returned, 2);
+    assert.equal(result.limit, 25);
+    assert.equal(result.offset, 0);
+    assert.equal(result.posts.length, 2);
+  });
+
+  // The raw post objects carry bylines, reactions, per-post stats and more — tens of fields each,
+  // most of them noise for a caller listing posts. The projection is documented in the schema
+  // description so nothing is dropped without the caller being told.
+  test('projects each post onto the documented field set', async () => {
+    const result = await listPostsHandler({status: 'published'});
+
+    assert.deepEqual(result.posts[0], {
+      id: 10,
+      title: 'Published one',
+      slug: 'published-one',
+      is_published: true,
+      audience: 'everyone',
+    });
+  });
+
+  test('keeps the fields the projection names and drops the rest', async () => {
+    msw.server.use(msw.postsHandler(() => HttpResponse.json({
+      posts: [{
+        id: 1,
+        title: 'T',
+        draft_title: 'DT',
+        slug: 's',
+        type: 'newsletter',
+        audience: 'everyone',
+        is_published: false,
+        post_date: '2026-01-01',
+        trigger_at: '2026-02-01',
+        draft_updated_at: '2026-01-02',
+        email_sent_at: null,
+        should_send_email: true,
+        section_name: 'Main',
+        reaction_count: 3,
+        comment_count: 1,
+        bylines: [{id: 1, name: 'noise'}],
+        reactions: {'❤': 3},
+        top_exclusions: ['noise'],
+        headlineTest: {noise: true},
+      }],
+      total: 1,
+    }, {status: 200})));
+
+    const [post] = (await listPostsHandler({status: 'drafts'})).posts;
+
+    assert.equal(post.title, 'T');
+    assert.equal(post.draft_title, 'DT');
+    assert.equal(post.trigger_at, '2026-02-01');
+    assert.equal(post.reaction_count, 3);
+    assert.equal(post.bylines, undefined);
+    assert.equal(post.reactions, undefined);
+    assert.equal(post.headlineTest, undefined);
+  });
+
+  test('survives a response carrying no posts array', async () => {
+    msw.server.use(msw.postsHandler(() => HttpResponse.json({total: 0}, {status: 200})));
+
+    const result = await listPostsHandler({status: 'scheduled'});
+
+    assert.deepEqual(result.posts, []);
+    assert.equal(result.returned, 0);
+  });
+});
+
+describe('listPostsHandler — errors and logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('throws ZodError on a malformed call without issuing any request', async () => {
+    await assert.rejects(
+      () => listPostsHandler({status: 'nope'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propagates a Substack API error', async () => {
+    msw.server.use(msw.postsHandler(() => new HttpResponse('bad request', {status: 400})));
+
+    const error = await listPostsHandler({status: 'scheduled'}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+  });
+
+  test('records the arguments and what came back', async () => {
+    const lines = await captureLogs(() => listPostsHandler({status: 'published', search: 'mcp'}));
+
+    assert.deepEqual(find(lines, 'list_posts.start').args, {status: 'published', search: 'mcp'});
+
+    const done = find(lines, 'list_posts.done');
+    assert.equal(done.status, 'published');
+    assert.equal(done.total, POSTS_RESPONSE.total);
+    assert.equal(done.returned, 2);
+  });
+
+  test('records the sort it chose, which the caller never sees otherwise', async () => {
+    const lines = await captureLogs(() => listPostsHandler({status: 'scheduled'}));
+
+    const sort = find(lines, 'list_posts.sort');
+    assert.equal(sort.order_by, 'trigger_at');
+    assert.equal(sort.order_direction, 'asc');
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => listPostsHandler({status: 'drafts'}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/src/tools/list_subscribers.js
+++ b/src/tools/list_subscribers.js
@@ -1,0 +1,134 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+import {
+  buildSubscriberQuery,
+  OPERATORS_BY_TYPE,
+  SUBSCRIBER_COLUMNS,
+  SUBSCRIBER_COLUMN_NAMES,
+} from "../api/substack/SubscriberQuery.js";
+
+// Every operator name across every type. The schema accepts the union so a typo is caught by the
+// SDK before dispatch, while the column-specific restriction is enforced by buildSubscriberQuery,
+// which can say which operators *that* column would have taken.
+const OPERATOR_NAMES = [
+  ...new Set(Object.values(OPERATORS_BY_TYPE).flatMap((operators) => Object.keys(operators))),
+];
+
+// A one-line map from column to label and type, inlined into the schema description. Without it
+// the caller sees 48 opaque snake_case names and has to guess which accept which operator.
+const COLUMN_REFERENCE = Object.entries(SUBSCRIBER_COLUMNS)
+  .map(([column, {type, label}]) => `${column} (${type}) = ${label}`)
+  .join('; ');
+
+const OPERATOR_REFERENCE = Object.entries(OPERATORS_BY_TYPE)
+  .map(([type, operators]) => `${type}: ${Object.keys(operators).join(', ')}`)
+  .join('. ');
+
+// strictObject, not object: an unknown key must be reported rather than stripped, because the
+// validation message is the only feedback an LLM gets to repair the call. `relation` instead of
+// `operator` would otherwise be dropped in silence and the filter would go out incomplete.
+export const listSubscribersSchema = z.strictObject({
+  filters: z
+    .array(
+      z.strictObject({
+        column: z
+          .enum(SUBSCRIBER_COLUMN_NAMES)
+          .describe(`The column to filter on. ${COLUMN_REFERENCE}`),
+        operator: z
+          .enum(OPERATOR_NAMES)
+          .describe(
+            `How to compare. Which operators are valid depends on the column's type — ${OPERATOR_REFERENCE}`
+          ),
+        value: z
+          .union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))])
+          .describe(
+            "The value to compare against. Must be an array for is_any_of, includes_any, includes_all and includes_none, and a single value for every other operator. Dates are ISO strings, e.g. 2026-01-01."
+          ),
+      })
+    )
+    .optional()
+    .describe(
+      "Conditions to apply, combined with AND. The API supports no OR and no nesting, so anything needing OR has to be issued as separate calls. Omit to match every subscriber."
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe("Free-text search over subscriber name and email."),
+  sort_by: z
+    .enum(SUBSCRIBER_COLUMN_NAMES)
+    .optional()
+    .describe("Column to sort by. Any filterable column works."),
+  sort_direction: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe("Sort direction, defaulting to desc."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("How many subscribers to return, 1-100, defaulting to 25."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("How many subscribers to skip, for paging through a large segment."),
+});
+
+export const listSubscribersHandler = async (args) => {
+  logger.debug('list_subscribers.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse
+  // never rejects. It is kept so the handler stays safe when called directly, which is how its
+  // own tests exercise it.
+  let validatedArgs;
+
+  try {
+    validatedArgs = listSubscribersSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined
+    // instead of failing.
+    logger.error('list_subscribers.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  // Built before the request so an illegal column/operator pair costs nothing. The API would
+  // answer 400 with a body that names neither the column nor the alternatives.
+  let query;
+
+  try {
+    query = buildSubscriberQuery(validatedArgs);
+  } catch (error) {
+    logger.error('list_subscribers.query.invalid', {args: validatedArgs, error});
+    throw error;
+  }
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  const response = await substack_api.getSubscribers(query);
+
+  const subscribers = response?.subscribers ?? [];
+
+  logger.info('list_subscribers.done', {
+    count: response?.count ?? null,
+    returned: subscribers.length,
+    limit: query.limit,
+    offset: query.offset,
+  });
+
+  return {
+    // The total matching the filters, independent of `limit` — so limit:1 is a cheap way to size
+    // a segment without pulling it.
+    count: response?.count ?? null,
+    returned: subscribers.length,
+    limit: query.limit,
+    offset: query.offset,
+    subscribers,
+  };
+};

--- a/src/tools/list_subscribers.spec.js
+++ b/src/tools/list_subscribers.spec.js
@@ -267,6 +267,18 @@ describe('listSubscribersHandler — logging', () => {
     assert.equal(done.returned, 2);
   });
 
+  // Distinct from list_subscribers.query.invalid below: this one fires when the *schema* rejects
+  // the call, before any filter is translated. Reached only on a direct call — over MCP the SDK
+  // answers first.
+  test('records the validation issues when the arguments are rejected', async () => {
+    const lines = await captureLogs(
+      () => listSubscribersHandler({limit: 'many'}).catch(() => {})
+    );
+
+    const invalid = find(lines, 'list_subscribers.args.invalid');
+    assert.deepEqual(invalid.issues.map((issue) => issue.path.join('.')), ['limit']);
+  });
+
   test('records the reason a filter was refused', async () => {
     const lines = await captureLogs(() => listSubscribersHandler({
       filters: [{column: 'user_email_address', operator: 'gt', value: 1}],

--- a/src/tools/list_subscribers.spec.js
+++ b/src/tools/list_subscribers.spec.js
@@ -1,0 +1,290 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {listSubscribersHandler, listSubscribersSchema} from './list_subscribers.js';
+import {
+  createMswServer,
+  SUBSCRIBER_STATS_URL,
+  SUBSCRIBER_STATS_RESPONSE,
+} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const sentFilters = () => msw.requests.at(-1).body.filters;
+
+describe('listSubscribersSchema', () => {
+  test('accepts an empty call', () => {
+    assert.deepEqual(listSubscribersSchema.parse({}), {});
+  });
+
+  test('accepts a filter, search, sort and pagination together', () => {
+    const args = {
+      filters: [{column: 'subscription_type', operator: 'is', value: 'paid'}],
+      search: 'gmail',
+      sort_by: 'subscription_created_at',
+      sort_direction: 'desc',
+      limit: 50,
+      offset: 100,
+    };
+
+    assert.deepEqual(listSubscribersSchema.parse(args), args);
+  });
+
+  // strictObject, so a plausible-but-wrong key is reported rather than dropped. A model that
+  // sends `query` instead of `search` has to be told that, not just that nothing happened.
+  test('rejects an unknown top-level key by name', () => {
+    assert.throws(
+      () => listSubscribersSchema.parse({query: 'gmail'}),
+      (error) => /Unrecognized key/.test(error.message) && /query/.test(error.message)
+    );
+  });
+
+  test('rejects an unknown key inside a filter', () => {
+    assert.throws(
+      () => listSubscribersSchema.parse({
+        filters: [{column: 'subscription_type', relation: 'is', value: 'paid'}],
+      }),
+      (error) => /Unrecognized key/.test(error.message) && /relation/.test(error.message)
+    );
+  });
+
+  // The column list is an enum so it reaches the client in the published JSON Schema: the model
+  // sees the 48 valid names instead of guessing them.
+  test('rejects a column that does not exist', () => {
+    assert.throws(
+      () => listSubscribersSchema.parse({
+        filters: [{column: 'email', operator: 'is', value: 'a@b.c'}],
+      }),
+      z.ZodError
+    );
+  });
+
+  test('rejects an operator that does not exist', () => {
+    assert.throws(
+      () => listSubscribersSchema.parse({
+        filters: [{column: 'user_name', operator: 'like', value: 'Bob'}],
+      }),
+      z.ZodError
+    );
+  });
+
+  test('accepts a list value for the list operators', () => {
+    const args = {filters: [{column: 'subscription_type', operator: 'is_any_of', value: ['free', 'paid']}]};
+
+    assert.deepEqual(listSubscribersSchema.parse(args), args);
+  });
+
+  test('caps limit at 100 and refuses a negative offset', () => {
+    assert.throws(() => listSubscribersSchema.parse({limit: 101}), z.ZodError);
+    assert.throws(() => listSubscribersSchema.parse({offset: -1}), z.ZodError);
+  });
+
+  test('publishes a description for every field a caller has to fill in', () => {
+    const json = z.toJSONSchema(listSubscribersSchema, {target: 'draft-7', io: 'input'});
+
+    for (const field of ['filters', 'search', 'sort_by', 'sort_direction', 'limit', 'offset']) {
+      assert.ok(json.properties[field].description, `${field} has no description`);
+    }
+
+    assert.equal(json.additionalProperties, false);
+  });
+});
+
+describe('listSubscribersHandler — request shape', () => {
+  test('sends one POST to the subscriber-stats endpoint', async () => {
+    await listSubscribersHandler({});
+
+    assert.equal(msw.requests.length, 1);
+    assert.equal(msw.requests[0].method, 'POST');
+    assert.equal(msw.requests[0].url, SUBSCRIBER_STATS_URL);
+  });
+
+  test('an empty call asks for the default page with no filters', async () => {
+    await listSubscribersHandler({});
+
+    assert.deepEqual(msw.requests[0].body, {filters: {}, limit: 25, offset: 0});
+  });
+
+  test('translates a filter into the flat suffixed key the API expects', async () => {
+    await listSubscribersHandler({
+      filters: [{column: 'num_email_opens_last_30d', operator: 'gt', value: 2}],
+    });
+
+    assert.deepEqual(sentFilters(), {num_email_opens_last_30d_gt: 2});
+  });
+
+  test('ANDs several filters into several keys', async () => {
+    await listSubscribersHandler({
+      filters: [
+        {column: 'subscription_type', operator: 'is', value: 'paid'},
+        {column: 'country', operator: 'is', value: 'IT'},
+      ],
+    });
+
+    assert.deepEqual(sentFilters(), {subscription_type: 'paid', country_string_is: 'IT'});
+  });
+
+  test('puts the search term inside filters, where the API reads it', async () => {
+    await listSubscribersHandler({search: 'gmail'});
+
+    assert.deepEqual(sentFilters(), {search: 'gmail'});
+  });
+
+  test('passes the sort through as the direction-specific key', async () => {
+    await listSubscribersHandler({sort_by: 'total_revenue_generated', sort_direction: 'asc'});
+
+    assert.deepEqual(sentFilters(), {order_by: 'total_revenue_generated'});
+  });
+
+  test('forwards limit and offset', async () => {
+    await listSubscribersHandler({limit: 100, offset: 200});
+
+    assert.equal(msw.requests[0].body.limit, 100);
+    assert.equal(msw.requests[0].body.offset, 200);
+  });
+});
+
+describe('listSubscribersHandler — result', () => {
+  test('returns the total count alongside the page', async () => {
+    const result = await listSubscribersHandler({});
+
+    assert.equal(result.count, 2);
+    assert.equal(result.returned, 2);
+    assert.equal(result.limit, 25);
+    assert.equal(result.offset, 0);
+    assert.deepEqual(result.subscribers, SUBSCRIBER_STATS_RESPONSE.subscribers);
+  });
+
+  // `count` is the total matching the filters, not the size of the page, which is what makes a
+  // limit:1 call a cheap way to count a segment.
+  test('count reflects the whole segment, not the page', async () => {
+    msw.server.use(msw.subscriberStatsHandler(() => HttpResponse.json(
+      {count: 1617, subscribers: [SUBSCRIBER_STATS_RESPONSE.subscribers[0]]},
+      {status: 200}
+    )));
+
+    const result = await listSubscribersHandler({limit: 1});
+
+    assert.equal(result.count, 1617);
+    assert.equal(result.returned, 1);
+  });
+
+  test('survives a response carrying no subscribers array', async () => {
+    msw.server.use(msw.subscriberStatsHandler(() => HttpResponse.json({count: 0}, {status: 200})));
+
+    const result = await listSubscribersHandler({});
+
+    assert.deepEqual(result.subscribers, []);
+    assert.equal(result.returned, 0);
+  });
+});
+
+describe('listSubscribersHandler — validation', () => {
+  test('refuses an operator the column type does not accept, naming the alternatives', async () => {
+    const error = await listSubscribersHandler({
+      filters: [{column: 'user_email_address', operator: 'gt', value: 1}],
+    }).catch((e) => e);
+
+    assert.match(error.message, /does not apply/i);
+    assert.match(error.message, /contains/);
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('refuses an invalid enum value before spending a request', async () => {
+    const error = await listSubscribersHandler({
+      filters: [{column: 'subscription_type', operator: 'is', value: 'premium'}],
+    }).catch((e) => e);
+
+    assert.match(error.message, /premium/);
+    assert.match(error.message, /free_trial/);
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('throws ZodError on a malformed call without issuing any request', async () => {
+    await assert.rejects(
+      () => listSubscribersHandler({limit: 'many'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propagates a Substack API error', async () => {
+    msw.server.use(msw.subscriberStatsHandler(() => new HttpResponse('nope', {status: 400})));
+
+    const error = await listSubscribersHandler({}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+  });
+});
+
+describe('listSubscribersHandler — logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('records the arguments it received', async () => {
+    const args = {filters: [{column: 'subscription_type', operator: 'is', value: 'free'}], limit: 5};
+    const lines = await captureLogs(() => listSubscribersHandler(args));
+
+    assert.deepEqual(find(lines, 'list_subscribers.start').args, args);
+  });
+
+  // The translated key is the thing to grep for when the API answers 400: it says exactly what
+  // was sent, which the structured arguments alone do not.
+  test('records each filter with the key it was translated into', async () => {
+    const lines = await captureLogs(() => listSubscribersHandler({
+      filters: [{column: 'num_comments', operator: 'gte', value: 1}],
+    }));
+
+    const filter = find(lines, 'subscriber_query.filter');
+    assert.equal(filter.column, 'num_comments');
+    assert.equal(filter.operator, 'gte');
+    assert.equal(filter.key, 'num_comments_gte');
+  });
+
+  test('records how many subscribers came back out of how many matched', async () => {
+    const lines = await captureLogs(() => listSubscribersHandler({}));
+
+    const done = find(lines, 'list_subscribers.done');
+    assert.equal(done.count, 2);
+    assert.equal(done.returned, 2);
+  });
+
+  test('records the reason a filter was refused', async () => {
+    const lines = await captureLogs(() => listSubscribersHandler({
+      filters: [{column: 'user_email_address', operator: 'gt', value: 1}],
+    }).catch(() => {}));
+
+    assert.match(find(lines, 'list_subscribers.query.invalid').error.message, /does not apply/i);
+  });
+
+  test('never writes the session token to the log', async () => {
+    const lines = await captureLogs(() => listSubscribersHandler({}));
+
+    assert.equal(find(lines, 'substack.request').headers.Cookie, '***');
+    assert.doesNotMatch(JSON.stringify(lines), /test-session-token/);
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => listSubscribersHandler({}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/test/helpers/msw-server.js
+++ b/test/helpers/msw-server.js
@@ -2,7 +2,14 @@ import {setupServer} from 'msw/node';
 import {http, HttpResponse} from 'msw';
 import {TEST_ENV} from './env.js';
 
-export const DRAFTS_URL = `${TEST_ENV.SUBSTACK_PUBLICATION_URL}/api/v1/drafts`;
+const API = `${TEST_ENV.SUBSTACK_PUBLICATION_URL}/api/v1`;
+
+export const DRAFTS_URL = `${API}/drafts`;
+export const SUBSCRIBER_STATS_URL = `${API}/subscriber-stats`;
+export const POST_MANAGEMENT_URL = `${API}/post_management`;
+export const DASHBOARD_SUMMARY_URL = `${API}/publish-dashboard/summary`;
+export const OPEN_RATE_URL = `${API}/publication/stats/email_stats/30d_open_rate`;
+export const VIEWS_30D_URL = `${API}/publication/stats/publication_traffic/30d_views`;
 
 export const DRAFT_RESPONSE = {
   id: 167712345,
@@ -10,6 +17,69 @@ export const DRAFT_RESPONSE = {
   draft_subtitle: 'Test subtitle',
   is_published: false,
 };
+
+// Shaped after a real response: the endpoint answers with the page of subscribers plus `count`,
+// the total matching the filters regardless of `limit`.
+export const SUBSCRIBER_STATS_RESPONSE = {
+  count: 2,
+  subscribers: [
+    {
+      user_id: 1,
+      user_email_address: 'one@example.com',
+      user_name: 'One',
+      subscription_type: 'free',
+      activity_rating: 3,
+      subscription_created_at: '2026-01-01T00:00:00.000000+00:00',
+      total_revenue_generated: 0,
+    },
+    {
+      user_id: 2,
+      user_email_address: 'two@example.com',
+      user_name: 'Two',
+      subscription_type: 'paid',
+      activity_rating: 5,
+      subscription_created_at: '2026-02-01T00:00:00.000000+00:00',
+      total_revenue_generated: 50,
+    },
+  ],
+  order: {by: 'subscription_created_at', direction: 'desc'},
+  columnView: [{key: 'subscription_type', visible: true}],
+  lastSync: '2026-08-07T08:00:00.000Z',
+};
+
+export const POSTS_RESPONSE = {
+  posts: [
+    {id: 10, title: 'Published one', slug: 'published-one', is_published: true, audience: 'everyone'},
+    {id: 11, title: 'Published two', slug: 'published-two', is_published: true, audience: 'only_paid'},
+  ],
+  offset: 0,
+  limit: 25,
+  total: 861,
+  isCapped: false,
+};
+
+export const DRAFT_DETAIL_RESPONSE = {
+  id: 167712345,
+  draft_title: 'A draft',
+  draft_subtitle: 'Its subtitle',
+  draft_body: '{"type":"doc","content":[]}',
+  audience: 'everyone',
+  is_published: false,
+  slug: 'a-draft',
+};
+
+export const DASHBOARD_SUMMARY_RESPONSE = {
+  subscribers: 2025,
+  subscribersLast30Days: 77,
+  totalEmail: 2020,
+  arr: 120,
+  arrDelta: 10,
+  views: 5000,
+  viewsDelta: 250,
+};
+
+export const OPEN_RATE_RESPONSE = {openRate: 0.42, openRateDiff: 0.01};
+export const VIEWS_30D_RESPONSE = {views30d: 5000, viewsDelta30d: 250};
 
 /**
  * Creates the MSW server used by the integration tests.
@@ -47,14 +117,54 @@ export function createMswServer() {
     });
   }
 
+  function subscriberStatsHandler(responder) {
+    return http.post(SUBSCRIBER_STATS_URL, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
+  // One handler for all three statuses: the status is the last path segment, and a test that
+  // cares which one was requested reads it off the recorded URL.
+  function postsHandler(responder) {
+    return http.get(`${POST_MANAGEMENT_URL}/:status`, async ({request, params}) => {
+      await record(request);
+      return responder(params.status);
+    });
+  }
+
+  function draftDetailHandler(responder) {
+    return http.get(`${DRAFTS_URL}/:id`, async ({request, params}) => {
+      await record(request);
+      return responder(params.id);
+    });
+  }
+
+  function statsHandler(url, responder) {
+    return http.get(url, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
   const server = setupServer(
-    draftsHandler(() => HttpResponse.json(DRAFT_RESPONSE, {status: 200}))
+    draftsHandler(() => HttpResponse.json(DRAFT_RESPONSE, {status: 200})),
+    subscriberStatsHandler(() => HttpResponse.json(SUBSCRIBER_STATS_RESPONSE, {status: 200})),
+    postsHandler(() => HttpResponse.json(POSTS_RESPONSE, {status: 200})),
+    draftDetailHandler(() => HttpResponse.json(DRAFT_DETAIL_RESPONSE, {status: 200})),
+    statsHandler(DASHBOARD_SUMMARY_URL, () => HttpResponse.json(DASHBOARD_SUMMARY_RESPONSE, {status: 200})),
+    statsHandler(OPEN_RATE_URL, () => HttpResponse.json(OPEN_RATE_RESPONSE, {status: 200})),
+    statsHandler(VIEWS_30D_URL, () => HttpResponse.json(VIEWS_30D_RESPONSE, {status: 200}))
   );
 
   return {
     server,
     requests,
     draftsHandler,
+    subscriberStatsHandler,
+    postsHandler,
+    draftDetailHandler,
+    statsHandler,
     start() {
       server.listen({onUnhandledRequest: 'error'});
     },


### PR DESCRIPTION
Takes the server from one tool to five. `create_draft_post` is untouched.

| tool | what it does |
|---|---|
| **`list_subscribers`** | the full Subscribers dashboard filter: 48 columns, 18 operators, AND, free-text search, sorting, pagination |
| **`list_posts`** | drafts / published / scheduled, with search and paging |
| **`get_draft`** | one draft in full, body and audience/email settings included |
| **`get_publication_stats`** | subscribers, ARR, views, 30-day open rate |

## Why the filter DSL exists

None of these endpoints is documented. They were read off the publisher dashboard's own traffic and its `reactPublish.*.js` bundle, then confirmed against the live API. `CLAUDE.md` gains a section recording the contract so nobody has to re-derive it.

`src/api/substack/SubscriberQuery.js` translates a structured filter list rather than passing arguments through, because Substack's encoding is hostile to a caller constructing it blind:

- a filter is a **flat key** inside `filters`, built by gluing an operator suffix onto the column name (`num_comments_gt`); multiple keys are ANDed, and there is no OR and no nesting
- **the suffix depends on the column's type**, and every mismatch is a bare `400` naming neither the column nor the alternatives. `is not` is `_not` on `subscription_type`, `_distinct_from` on an Int, `_string_not` on a String. `_lte` is Int-only — the DateTime equivalent is `_is_on_or_before`, not `_lte`.

So the tool exposes operators **named by intent** (`is_not`, `is_before`, `includes_any`) and derives the suffix, which makes an illegal column/operator pair unrepresentable instead of a round trip away. The 48 columns ship as a zod enum, so they reach the model in the published JSON Schema rather than having to be guessed.

## Three findings a reviewer should know

- **`search` only works inside `filters`.** At the top level it is ignored *silently* and the response comes back unfiltered — which reads as "matched everything", not as an error.
- **A request-level `columnView` is ignored.** The returned fields come from the publication's saved Display settings, so engagement columns are **filterable but not readable**. The tool description says so outright, because a caller filtering on opens and then not finding them would reasonably conclude the data is missing rather than unrequestable. `count` is the way at them: it is the total matching the filters regardless of `limit`, so `limit: 1` cheaply sizes a segment.
- **`order_by` is not optional on `post_management`.** `/scheduled` answers `400` without it, so `list_posts` keeps a default per status instead of letting the server choose.

`SubstackApi` grows a shared `request()`; `postDraft` now delegates to it with its logging and `referer` behaviour unchanged.

## Deliberately out of scope

Publishing and scheduling. Their paths are built from template literals in the bundle, and resolving them would have meant publishing a real post to the publication. They are the natural next step, mapped against a sacrificial draft.

## Verification

- **243 tests green** (was 166), coverage 99.42%
- every new test was **watched failing first**; because a `module not found` proves little, **8 targeted mutations** were then applied — wrong String suffix, dropped duplicate guard, `search` moved out of `filters`, scheduled sort reversed, `query=null` serialized, `allSettled`→`all`, `count` as page size, draft body stripped — each **confirmed to land and to be caught**
- green on **both runtimes**: the `engines` floor (22) and `.nvmrc` (24.19.0)
- stdio probe against the real entrypoint: all five tools announce correct schemas, and the 48-value column enum survives JSON-RPC serialization
- **25 payloads generated by the DSL** (one per operator family plus a compound case) fired at the **live API**: 25/25 `HTTP 200`, with internally consistent counts — 62+1963, 77+1948 and 2022+3 each totalling 2025

The MSW tests prove the code sends that wire format; the live run proves the API accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)