### PR TITLE
Add export_subscribers, making every column readable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,39 @@ rather than passing arguments straight through:
 - `count` is the total matching the filters regardless of `limit`, which makes `limit: 1` a cheap
   way to size a segment.
 - **A request-level `columnView` is ignored.** The returned fields come from the publication's saved
-  Display settings, so the engagement columns are *filterable but not readable* — the tool's
-  description says so, because a caller filtering on opens and then not finding them would
-  reasonably conclude the data is missing rather than unrequestable.
+  Display settings, so this endpoint cannot be made to return the engagement columns. That does not
+  make them unreadable — the export below does read them — so `list_subscribers` points at
+  `export_subscribers` rather than telling the caller the data does not exist.
+
+**The subscriber export is a four-step flow, and it is what makes every column readable.**
+`src/tools/export_subscribers.js` owns it:
+
+```
+POST /api/v1/subscriber_set                    {query: <the same filters>}  → {id}
+POST /api/v1/subscriber_set/export             {subscriberSetId, columns}   → {export_id}
+GET  /api/v1/subscriber_set/export/<id>                                     → {url}   (poll)
+GET  <url>                                                                  → CSV
+```
+
+Verified end to end. The dashboard's polling backoff is `1, 5, 10, 30`, then `60` repeated;
+`EXPORT_POLL_BACKOFF_SECONDS` mirrors it, except the first poll happens immediately because a small
+export is usually already done. Four things this flow gets wrong if taken at face value:
+
+- **The CSV header carries human LABELS, not column keys** — `Emails opened (6mo)`, not
+  `num_email_opens`. `COLUMN_KEY_BY_LABEL` is the reverse map; it works because the labels are
+  unique, which `SubscriberQuery.spec.js` asserts by entry count so a future collision fails loudly
+  instead of dropping a column.
+- **The server chooses the column order**, not the caller. Parse by header name, never by position.
+- **Two columns cannot be exported and are dropped in silence:** `tag_ids` and `group_membership`.
+  Asking for all 48 returns 46 with no error, so the tool diffs what it asked for against the header
+  and reports `missing_columns`. This is the same silent-drop hazard as `columnView`.
+- **The download url is relative to the publication host and cookie-authenticated** (403 without it,
+  not pre-signed) and answers **CSV, not JSON**. `handleResponse` unconditionally `JSON.parse`s, so
+  `readBody` was split out of it and `requestUrl({parse: 'text'})` is the raw path. `requestUrl` also
+  exists because that url cannot be appended to `publication_url`, which already ends in `/api/v1`.
+
+`src/api/substack/csv.js` is a ~40-line parser rather than a dependency. `split(',')` is not enough
+and fails *silently*: a subscriber named `Smith, John` shifts every later column of that one row.
 
 **`GET /api/v1/post_management/{drafts,published,scheduled}`** lists posts. `order_by` is **not
 optional**: `scheduled` answers 400 without it, which is why `src/tools/list_posts.js` keeps a

--- a/README.md
+++ b/README.md
@@ -51,11 +51,40 @@ with types reaches the client in the tool's JSON Schema, so a model does not hav
 **Returns**: `{count, returned, limit, offset, subscribers}`. `count` is the total matching the
 filters regardless of `limit`, so a call with `limit: 1` is a cheap way to size a segment.
 
-> **Note**: engagement columns can be *filtered* on but are not part of the returned records —
-> Substack takes the fields it returns from the publication's saved Display settings and ignores a
-> per-request column list. Use `count` with different thresholds to learn about them.
+> **Note**: engagement columns can be *filtered* on here but are not part of the records this tool
+> returns — Substack takes the fields it returns from the publication's saved Display settings and
+> ignores a per-request column list. Use **`export_subscribers`** to read their values.
 
 There is no OR and no nesting: anything needing OR has to be issued as separate calls.
+</details>
+
+<details>
+<summary><strong>export_subscribers</strong> - Export subscribers with every column value</summary>
+
+The way to actually *read* the engagement metrics `list_subscribers` can only filter on: email opens
+over 7d/30d/6mo, unique emails seen, post views, unique posts seen, comments, shares, links clicked,
+days active and activity rating.
+
+**Inputs**:
+- `filters` (array, optional): the same conditions as `list_subscribers`, combined with AND
+- `search` (string, optional): free text matched against subscriber name and email
+- `columns` (array, optional): which columns to include, defaulting to **all** of them
+- `max_wait_seconds` (number, optional): 1–600, defaulting to 120
+
+**Returns**: `{count, columns, missing_columns, unmapped_columns, export_id, subscribers}`, where
+each subscriber is keyed by column name.
+
+Substack generates the file asynchronously, so the tool creates a subscriber set, requests the
+export, polls until it is ready and downloads it. A small export lands in a few seconds. If the wait
+budget runs out the tool says so and names the `export_id` rather than blocking.
+
+> **Two caveats**, both verified against the live API:
+> - `tag_ids` and `group_membership` **cannot** be exported. Substack drops them silently rather
+>   than failing, so they are reported in `missing_columns` — asking for all 48 columns returns 46.
+> - Values arrive **display-formatted**, not raw: revenue is `"€50.00"` here and the number `50`
+>   through `list_subscribers`. Dates are ISO strings.
+
+There is no paging: an export covers the whole matching set.
 </details>
 
 <details>

--- a/src/api/substack/SubscriberQuery.js
+++ b/src/api/substack/SubscriberQuery.js
@@ -138,6 +138,20 @@ export const SUBSCRIBER_COLUMNS = {
 
 export const SUBSCRIBER_COLUMN_NAMES = Object.keys(SUBSCRIBER_COLUMNS);
 
+/**
+ * label -> column key, the reverse of `SUBSCRIBER_COLUMNS[*].label`.
+ *
+ * The subscriber export answers with a header of human labels rather than column keys —
+ * `Emails opened (6mo)`, not `num_email_opens` — so this is what turns an export back into keyed
+ * records. Confirmed against a real export: every one of the 46 returned headers resolved here.
+ *
+ * Labels are unique across the table, which is what makes the reverse safe; a collision would
+ * silently drop a column, so `SubscriberQuery.spec.js` asserts the entry count matches.
+ */
+export const COLUMN_KEY_BY_LABEL = Object.fromEntries(
+  Object.entries(SUBSCRIBER_COLUMNS).map(([column, {label}]) => [label, column])
+);
+
 function describeColumn(column) {
   const {type, label} = SUBSCRIBER_COLUMNS[column];
   return `${column} (${label}, ${type})`;

--- a/src/api/substack/SubscriberQuery.spec.js
+++ b/src/api/substack/SubscriberQuery.spec.js
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import {
   buildSubscriberQuery,
   SUBSCRIBER_COLUMNS,
+  SUBSCRIBER_COLUMN_NAMES,
   OPERATORS_BY_TYPE,
+  COLUMN_KEY_BY_LABEL,
 } from './SubscriberQuery.js';
 import {setTestEnv} from '../../../test/helpers/env.js';
 import {captureLogs} from '../../../test/helpers/capture-logs.js';
@@ -36,6 +38,39 @@ describe('SUBSCRIBER_COLUMNS', () => {
       assert.equal(typeof label, 'string', `${column} has no label`);
       assert.ok(label.length > 0, `${column} has an empty label`);
     }
+  });
+});
+
+describe('COLUMN_KEY_BY_LABEL', () => {
+  // The subscriber export answers with a header of human labels — `Emails opened (6mo)`, not
+  // `num_email_opens` — so reading it back into keyed objects is a reverse lookup on this table.
+  // These were confirmed against a real export: all 46 returned headers resolved, none unmapped.
+  test('maps every column label back to its key', () => {
+    for (const column of SUBSCRIBER_COLUMN_NAMES) {
+      assert.equal(COLUMN_KEY_BY_LABEL[SUBSCRIBER_COLUMNS[column].label], column);
+    }
+  });
+
+  // A duplicate label would make the reverse map lose a column silently: the second entry
+  // overwrites the first and one key becomes unreachable from an export header.
+  test('has an entry per column, so no label collided', () => {
+    assert.equal(Object.keys(COLUMN_KEY_BY_LABEL).length, SUBSCRIBER_COLUMN_NAMES.length);
+  });
+
+  // Spot checks on the ones whose label looks nothing like the key, which is where a hand-written
+  // map would drift first.
+  test('resolves the labels that do not resemble their key', () => {
+    assert.equal(COLUMN_KEY_BY_LABEL['Can see paid content'], 'is_subscribed');
+    assert.equal(COLUMN_KEY_BY_LABEL['Sections'], 'emails_enabled');
+    assert.equal(COLUMN_KEY_BY_LABEL['Activity'], 'activity_rating');
+    assert.equal(COLUMN_KEY_BY_LABEL['Revenue'], 'total_revenue_generated');
+    assert.equal(COLUMN_KEY_BY_LABEL['Type'], 'subscription_type');
+    assert.equal(COLUMN_KEY_BY_LABEL['Start date'], 'subscription_created_at');
+    assert.equal(COLUMN_KEY_BY_LABEL['Bundle origin'], 'is_bundle_parent');
+  });
+
+  test('an unknown label resolves to nothing rather than a wrong key', () => {
+    assert.equal(COLUMN_KEY_BY_LABEL['Not A Column'], undefined);
   });
 });
 

--- a/src/api/substack/SubstackApi.js
+++ b/src/api/substack/SubstackApi.js
@@ -24,7 +24,14 @@ export default class SubstackApi {
     });
   }
 
-  static async handleResponse(response) {
+  /**
+   * Turns a failing status into an error and a successful one into its raw body text.
+   *
+   * Split out of handleResponse so the text and JSON paths share one refusal branch: the subscriber
+   * export answers with CSV, and a 403 there must still throw rather than hand the parser an error
+   * page to read as rows.
+   */
+  static async readBody(response) {
     if (!response.ok) {
       // Substack explains the refusal in the body, and the thrown message carries only the
       // status. Reading it here is what makes a 400 debuggable at all.
@@ -38,7 +45,11 @@ export default class SubstackApi {
       throw new Error(`SubstackAPIException: ${response.status} ${response.statusText}`);
     }
 
-    const text = await response.text();
+    return response.text();
+  }
+
+  static async handleResponse(response) {
+    const text = await SubstackApi.readBody(response);
     let parsed;
 
     try {
@@ -58,9 +69,29 @@ export default class SubstackApi {
    * `path` is relative to `/api/v1` (`/drafts`, `/subscriber-stats`). `params` become the query
    * string, with null and undefined entries dropped rather than serialized — a `query=null` in
    * the URL is a search for the literal string "null", which silently returns nothing.
+   *
+   * `parse: 'text'` returns the raw body instead, for the endpoints that do not answer JSON.
    */
-  async request({method, path, body = null, params = null, referer = '/publish/posts'}) {
-    const target = new URL(`${this.publication_url}${path}`);
+  async request({method, path, ...options}) {
+    return this.requestUrl({url: `${this.publication_url}${path}`, method, ...options});
+  }
+
+  /**
+   * The same as `request`, but taking an absolute url.
+   *
+   * Needed because the subscriber export answers with a url relative to the publication *host*
+   * (`/api/v1/subscriber_set/export/…`), which cannot be appended to `publication_url` — that
+   * already ends in `/api/v1` and the result would be `/api/v1/api/v1/…`.
+   */
+  async requestUrl({
+    method,
+    url: rawUrl,
+    body = null,
+    params = null,
+    referer = '/publish/posts',
+    parse = 'json',
+  }) {
+    const target = new URL(rawUrl);
 
     for (const [key, value] of Object.entries(params ?? {})) {
       if (value !== null && value !== undefined) target.searchParams.set(key, value);
@@ -104,7 +135,9 @@ export default class SubstackApi {
       duration_ms: Date.now() - startedAt,
     });
 
-    return SubstackApi.handleResponse(response)
+    return parse === 'text'
+      ? SubstackApi.readBody(response)
+      : SubstackApi.handleResponse(response)
   }
 
   async postDraft(body) {
@@ -140,5 +173,63 @@ export default class SubstackApi {
 
   async getDraft(draft_id) {
     return this.request({method: 'GET', path: `/drafts/${draft_id}`, referer: '/publish/post'});
+  }
+
+  /**
+   * Creates a subscriber set — a server-side handle on a group of subscribers, addressed either by
+   * the same `filters` object the subscribers list uses or by explicit user ids.
+   *
+   * The set id is the input to two different operations: exporting the group, and bulk-tagging it.
+   */
+  async createSubscriberSet(query, user_ids = null) {
+    return this.request({
+      method: 'POST',
+      path: '/subscriber_set',
+      body: user_ids ? {user_ids} : {query},
+      referer: '/publish/subscribers',
+    });
+  }
+
+  /**
+   * Asks for an export of a subscriber set and returns its `export_id`.
+   *
+   * `columns` is the list of column keys wanted in the CSV. Unsupported ones are dropped
+   * **silently** rather than refused — `group_membership` and `tag_ids` do not come back — so the
+   * caller has to compare what it asked for against the header it got.
+   */
+  async requestSubscriberSetExport({subscriber_set_id, columns}) {
+    return this.request({
+      method: 'POST',
+      path: '/subscriber_set/export',
+      body: {subscriberSetId: subscriber_set_id, columns},
+      referer: '/publish/subscribers',
+    });
+  }
+
+  /**
+   * Polls one export. Answers `{url}` once the file is ready; the url is absent while it is still
+   * being generated.
+   */
+  async getSubscriberSetExport(export_id) {
+    return this.request({
+      method: 'GET',
+      path: `/subscriber_set/export/${export_id}`,
+      referer: '/publish/subscribers',
+    });
+  }
+
+  /**
+   * Downloads a finished export as raw CSV text.
+   *
+   * The url handed back by the export is relative to the publication host and authenticated by the
+   * same session cookie — it is not pre-signed, and fetching it without the cookie is a 403.
+   */
+  async downloadExport(url) {
+    return this.requestUrl({
+      method: 'GET',
+      url: new URL(url, this.hostname).toString(),
+      parse: 'text',
+      referer: '/publish/subscribers',
+    });
   }
 }

--- a/src/api/substack/SubstackApi.spec.js
+++ b/src/api/substack/SubstackApi.spec.js
@@ -11,6 +11,13 @@ import {
   POSTS_RESPONSE,
   DRAFT_DETAIL_RESPONSE,
   DASHBOARD_SUMMARY_RESPONSE,
+  SUBSCRIBER_SET_URL,
+  SUBSCRIBER_SET_EXPORT_URL,
+  SUBSCRIBER_SET_ID,
+  EXPORT_ID,
+  EXPORT_FILE_PATH,
+  EXPORT_FILE_URL,
+  EXPORT_CSV,
 } from '../../../test/helpers/msw-server.js';
 import {TEST_ENV, setTestEnv} from '../../../test/helpers/env.js';
 import {captureLogs} from '../../../test/helpers/capture-logs.js';
@@ -245,6 +252,87 @@ describe('SubstackApi — request', () => {
     await createApi().request({method: 'GET', path: '/publish-dashboard/summary'});
 
     assert.equal(msw.requests[0].body, '');
+  });
+});
+
+describe('SubstackApi — subscriber set and export', () => {
+  test('createSubscriberSet posts the query and returns the set id', async () => {
+    const result = await createApi().createSubscriberSet({activity_rating: 5});
+
+    assert.deepEqual(result, {id: SUBSCRIBER_SET_ID});
+    assert.equal(msw.requests[0].method, 'POST');
+    assert.equal(msw.requests[0].url, SUBSCRIBER_SET_URL);
+    assert.deepEqual(msw.requests[0].body, {query: {activity_rating: 5}});
+  });
+
+  test('createSubscriberSet can build a set from explicit user ids instead', async () => {
+    await createApi().createSubscriberSet(null, [1, 2, 3]);
+
+    assert.deepEqual(msw.requests[0].body, {user_ids: [1, 2, 3]});
+  });
+
+  test('requestSubscriberSetExport posts the set id and the columns', async () => {
+    const result = await createApi().requestSubscriberSetExport({
+      subscriber_set_id: SUBSCRIBER_SET_ID,
+      columns: ['user_email_address', 'num_email_opens'],
+    });
+
+    assert.deepEqual(result, {export_id: EXPORT_ID});
+    assert.equal(msw.requests[0].url, SUBSCRIBER_SET_EXPORT_URL);
+    assert.deepEqual(msw.requests[0].body, {
+      subscriberSetId: SUBSCRIBER_SET_ID,
+      columns: ['user_email_address', 'num_email_opens'],
+    });
+  });
+
+  test('getSubscriberSetExport polls the export by id', async () => {
+    const result = await createApi().getSubscriberSetExport(EXPORT_ID);
+
+    assert.deepEqual(result, {url: EXPORT_FILE_PATH});
+    assert.equal(msw.requests[0].method, 'GET');
+    assert.equal(new URL(msw.requests[0].url).pathname, `/api/v1/subscriber_set/export/${EXPORT_ID}`);
+  });
+
+  // The export answers with a relative url, so it has to be resolved against the publication host
+  // rather than concatenated onto publication_url — which already ends in /api/v1 and would produce
+  // /api/v1/api/v1/...
+  test('downloadExport resolves the relative url against the publication host', async () => {
+    const csv = await createApi().downloadExport(EXPORT_FILE_PATH);
+
+    assert.equal(csv, EXPORT_CSV);
+    assert.equal(msw.requests[0].url, EXPORT_FILE_URL);
+  });
+
+  test('downloadExport returns the CSV as text rather than trying to parse it as JSON', async () => {
+    const csv = await createApi().downloadExport(EXPORT_FILE_PATH);
+
+    assert.equal(typeof csv, 'string');
+    assert.match(csv, /^Email,Name,/);
+  });
+
+  test('downloadExport sends the session cookie, which the file requires', async () => {
+    await createApi().downloadExport(EXPORT_FILE_PATH);
+
+    assert.equal(
+      msw.requests[0].headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+
+  test('downloadExport accepts an absolute url too', async () => {
+    await createApi().downloadExport(EXPORT_FILE_URL);
+
+    assert.equal(msw.requests[0].url, EXPORT_FILE_URL);
+  });
+
+  // A raw-text request must still refuse a failing status: silently returning an error page as if it
+  // were the CSV would have the parser produce nonsense rows instead of an error.
+  test('a failing status on a text request still throws SubstackAPIException', async () => {
+    msw.server.use(msw.exportFileHandler(() => new HttpResponse('nope', {status: 403})));
+
+    const error = await createApi().downloadExport(EXPORT_FILE_PATH).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 403\b/);
   });
 });
 

--- a/src/api/substack/csv.js
+++ b/src/api/substack/csv.js
@@ -1,0 +1,92 @@
+/**
+ * Minimal RFC-4180-ish CSV reader, enough for what Substack's subscriber export produces.
+ *
+ * A `split(',')` is not enough and the failure is silent rather than loud: subscriber names and
+ * place names contain commas ("Smith, John"), and one of them shifts every later field onto the
+ * wrong column for that row only. The export also quotes its currency values, so the quotes have
+ * to come off.
+ *
+ * Deliberately not a dependency: this is ~40 lines against a format the export controls, and the
+ * project pins everything exactly and keeps its dependency surface minimal.
+ */
+
+/**
+ * Parses `text` into `{header, rows}`, both arrays of string cells.
+ *
+ * Quoted fields may contain commas, newlines and doubled quotes (`""` → `"`). Malformed input
+ * degrades rather than throwing — an unterminated quote simply consumes the rest of the input —
+ * because a caller inspecting a broken export is better served than one holding an exception.
+ */
+export function parseCsv(text) {
+  if (text.trim() === '') return {header: [], rows: []};
+
+  const records = [];
+  let record = [];
+  let field = '';
+  let quoted = false;
+  let i = 0;
+
+  const endField = () => {
+    record.push(field);
+    field = '';
+  };
+
+  const endRecord = () => {
+    endField();
+    records.push(record);
+    record = [];
+  };
+
+  while (i < text.length) {
+    const char = text[i];
+
+    if (quoted) {
+      if (char === '"') {
+        // A doubled quote is an escaped quote; a lone one closes the field.
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        quoted = false;
+        i += 1;
+        continue;
+      }
+
+      field += char;
+      i += 1;
+      continue;
+    }
+
+    // A quote only opens a quoted field at the start of one; mid-field it is literal, so `12" pizza`
+    // survives intact.
+    if (char === '"' && field === '') {
+      quoted = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === ',') {
+      endField();
+      i += 1;
+      continue;
+    }
+
+    if (char === '\n' || char === '\r') {
+      endRecord();
+      // Consume the LF of a CRLF pair so it does not open an empty record.
+      i += char === '\r' && text[i + 1] === '\n' ? 2 : 1;
+      continue;
+    }
+
+    field += char;
+    i += 1;
+  }
+
+  // Whatever is still buffered is the last record, unless the input ended on a line break and left
+  // nothing behind — that trailing newline must not become an empty row.
+  if (field !== '' || record.length > 0 || quoted) endRecord();
+
+  const [header = [], ...rows] = records;
+  return {header, rows};
+}

--- a/src/api/substack/csv.spec.js
+++ b/src/api/substack/csv.spec.js
@@ -1,0 +1,92 @@
+import {test, describe} from 'node:test';
+import assert from 'node:assert/strict';
+import {parseCsv} from './csv.js';
+
+describe('parseCsv — basics', () => {
+  test('splits the header from the rows', () => {
+    assert.deepEqual(parseCsv('a,b\n1,2'), {header: ['a', 'b'], rows: [['1', '2']]});
+  });
+
+  test('an empty input has no header and no rows', () => {
+    assert.deepEqual(parseCsv(''), {header: [], rows: []});
+    assert.deepEqual(parseCsv('   '), {header: [], rows: []});
+  });
+
+  test('a header with no data rows yields an empty rows list', () => {
+    assert.deepEqual(parseCsv('a,b'), {header: ['a', 'b'], rows: []});
+  });
+
+  test('a trailing newline does not become an empty row', () => {
+    assert.deepEqual(parseCsv('a,b\n1,2\n').rows, [['1', '2']]);
+  });
+
+  test('handles CRLF line endings', () => {
+    assert.deepEqual(parseCsv('a,b\r\n1,2\r\n'), {header: ['a', 'b'], rows: [['1', '2']]});
+  });
+
+  test('an empty field is an empty string, not undefined', () => {
+    assert.deepEqual(parseCsv('a,b,c\n1,,3').rows, [['1', '', '3']]);
+  });
+
+  test('keeps a trailing empty field', () => {
+    assert.deepEqual(parseCsv('a,b\n1,').rows, [['1', '']]);
+  });
+});
+
+describe('parseCsv — quoting', () => {
+  // The reason this parser exists at all: subscriber names and place names contain commas, and a
+  // split(',') silently shifts every field after one of them onto the wrong column.
+  test('a comma inside quotes does not split the field', () => {
+    assert.deepEqual(
+      parseCsv('name,country\n"Smith, John",IT').rows,
+      [['Smith, John', 'IT']]
+    );
+  });
+
+  test('strips the surrounding quotes', () => {
+    assert.deepEqual(parseCsv('a\n"plain"').rows, [['plain']]);
+  });
+
+  test('a doubled quote inside a quoted field becomes one quote', () => {
+    assert.deepEqual(parseCsv('a\n"say ""hi"" now"').rows, [['say "hi" now']]);
+  });
+
+  test('a newline inside quotes stays inside the field', () => {
+    assert.deepEqual(parseCsv('a,b\n"line one\nline two",x').rows, [['line one\nline two', 'x']]);
+  });
+
+  test('a quoted header cell is unquoted too', () => {
+    assert.deepEqual(parseCsv('"a,1",b').header, ['a,1', 'b']);
+  });
+
+  test('an unterminated quote consumes the rest of the input rather than throwing', () => {
+    // Malformed input should degrade, not explode: the caller gets something inspectable.
+    assert.deepEqual(parseCsv('a,b\n"never closed,x').rows, [['never closed,x']]);
+  });
+
+  test('a quote in the middle of an unquoted field is kept literally', () => {
+    assert.deepEqual(parseCsv('a\n12" pizza').rows, [['12" pizza']]);
+  });
+});
+
+describe('parseCsv — real Substack shapes', () => {
+  // Shaped after a real export: the header carries human labels, values are display-formatted
+  // (a currency string, not a number), and the column order is the server's, not the caller's.
+  test('parses an export row with a formatted currency and ISO dates', () => {
+    const csv = [
+      'Email,Name,Start date,Emails opened (30d),Revenue,Activity',
+      'a@b.c,Daniel,2026-07-29T22:07:50.299Z,2,"€0.00",5',
+    ].join('\n');
+
+    const {header, rows} = parseCsv(csv);
+
+    assert.deepEqual(header, ['Email', 'Name', 'Start date', 'Emails opened (30d)', 'Revenue', 'Activity']);
+    assert.deepEqual(rows, [['a@b.c', 'Daniel', '2026-07-29T22:07:50.299Z', '2', '€0.00', '5']]);
+  });
+
+  test('a row with fewer cells than the header is still returned', () => {
+    // Not padded or rejected here: the caller decides, and silently inventing cells would hide a
+    // malformed export.
+    assert.deepEqual(parseCsv('a,b,c\n1,2').rows, [['1', '2']]);
+  });
+});

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -132,6 +132,7 @@ describe('entrypoint — stdio transport', () => {
 
     assert.deepEqual(Object.keys(byName).sort(), [
       'create_draft_post',
+      'export_subscribers',
       'get_draft',
       'get_publication_stats',
       'list_posts',

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
 import {listSubscribersSchema, listSubscribersHandler} from "./tools/list_subscribers.js";
+import {exportSubscribersSchema, exportSubscribersHandler} from "./tools/export_subscribers.js";
 import {listPostsSchema, listPostsHandler} from "./tools/list_posts.js";
 import {getDraftSchema, getDraftHandler} from "./tools/get_draft.js";
 import {getPublicationStatsSchema, getPublicationStatsHandler} from "./tools/get_publication_stats.js";
@@ -13,21 +14,31 @@ export const tools = {
     handler: createDraftPostHandler,
   },
   list_subscribers: {
-    // The engagement caveat belongs in the description rather than a comment: the columns are
-    // filterable but never come back in the response, because the API takes the fields it returns
-    // from the publication's saved Display settings and ignores a per-request column list. A
-    // caller filtering on opens and then looking for them in the result would otherwise conclude
-    // the data is missing. `count` is the way to read them — filter and look at how many match.
+    // The engagement caveat still belongs in the description: this endpoint takes the fields it
+    // returns from the publication's saved Display settings and ignores a per-request column list,
+    // so a caller filtering on opens and then looking for them here would conclude the data is
+    // missing. It is not — export_subscribers reads it, which is what the pointer below is for.
     description:
       "List and filter the subscribers of your Substack publication. Supports the same 48 columns " +
       "and operators as the Subscribers dashboard, combined with AND, plus free-text search, " +
       "sorting and pagination. Returns `count`, the total matching the filters regardless of " +
       "`limit`, so a call with limit 1 is a cheap way to size a segment. Engagement columns " +
-      "(email opens, post views, comments, shares, activity rating) can be filtered on but are " +
-      "not included in the returned subscriber records — use `count` with different thresholds to " +
-      "learn about them.",
+      "(email opens, post views, comments, shares, activity rating) can be filtered on here but " +
+      "are not part of the records this tool returns — use export_subscribers to read their values.",
     schema: listSubscribersSchema,
     handler: listSubscribersHandler,
+  },
+  export_subscribers: {
+    description:
+      "Export subscribers with their full column values, including the engagement metrics " +
+      "list_subscribers can filter on but not return: email opens over 7d/30d/6mo, unique emails " +
+      "seen, post views, unique posts seen, comments, shares, links clicked, days active and " +
+      "activity rating. Takes the same filters as list_subscribers and covers the whole matching " +
+      "set — there is no paging. Substack generates the file asynchronously, so this waits for it " +
+      "and returns the parsed records. Two columns cannot be exported and are reported in " +
+      "`missing_columns` rather than failing: tag_ids and group_membership.",
+    schema: exportSubscribersSchema,
+    handler: exportSubscribersHandler,
   },
   list_posts: {
     description:

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -39,6 +39,7 @@ describe('MCP server — list_tools', () => {
 
   const EXPECTED_TOOLS = [
     'create_draft_post',
+    'export_subscribers',
     'get_draft',
     'get_publication_stats',
     'list_posts',

--- a/src/tools/export_subscribers.js
+++ b/src/tools/export_subscribers.js
@@ -1,0 +1,194 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+import {parseCsv} from "../api/substack/csv.js";
+import {
+  buildSubscriberQuery,
+  COLUMN_KEY_BY_LABEL,
+  SUBSCRIBER_COLUMNS,
+  SUBSCRIBER_COLUMN_NAMES,
+} from "../api/substack/SubscriberQuery.js";
+
+/**
+ * The backoff Substack's own dashboard uses while waiting for an export: 1s, 5s, 10s, 30s, then a
+ * minute at a time. The last entry repeats until the caller's wait budget runs out.
+ */
+export const EXPORT_POLL_BACKOFF_SECONDS = [1, 5, 10, 30, 60];
+
+const DEFAULT_MAX_WAIT_SECONDS = 120;
+
+const sleepSeconds = (seconds) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+
+const COLUMN_REFERENCE = Object.entries(SUBSCRIBER_COLUMNS)
+  .map(([column, {label}]) => `${column} = ${label}`)
+  .join('; ');
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call.
+export const exportSubscribersSchema = z.strictObject({
+  filters: z
+    .array(
+      z.strictObject({
+        column: z.enum(SUBSCRIBER_COLUMN_NAMES).describe("The column to filter on."),
+        operator: z.string().describe("How to compare, exactly as in list_subscribers."),
+        value: z
+          .union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))])
+          .describe("The value to compare against."),
+      })
+    )
+    .optional()
+    .describe(
+      "Which subscribers to export, using the same conditions as list_subscribers, combined with AND. Omit to export everyone."
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe("Free-text search over subscriber name and email."),
+  columns: z
+    .array(z.enum(SUBSCRIBER_COLUMN_NAMES))
+    .optional()
+    .describe(
+      `Which columns to include. Defaults to every column. Available: ${COLUMN_REFERENCE}`
+    ),
+  max_wait_seconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(600)
+    .optional()
+    .describe(
+      "How long to wait for Substack to generate the file, 1-600, defaulting to 120. A small export is ready in a few seconds."
+    ),
+});
+
+/**
+ * Reads a subscriber export back into records keyed by column name.
+ *
+ * The CSV header carries human labels rather than column keys, and in the server's own order rather
+ * than the requested one, so everything keys off the header row — never off position.
+ */
+function recordsFromCsv(csv) {
+  const {header, rows} = parseCsv(csv);
+
+  const keys = header.map((label) => COLUMN_KEY_BY_LABEL[label] ?? label);
+  const unmapped = header.filter((label) => !COLUMN_KEY_BY_LABEL[label]);
+
+  const subscribers = rows.map((cells) =>
+    Object.fromEntries(keys.map((key, index) => [key, cells[index] ?? null]))
+  );
+
+  return {columns: keys.filter((key) => !unmapped.includes(key)), unmapped, subscribers};
+}
+
+export const exportSubscribersHandler = async (args, {sleep = sleepSeconds} = {}) => {
+  logger.debug('export_subscribers.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse
+  // never rejects. It is kept so the handler stays safe when called directly.
+  let validatedArgs;
+
+  try {
+    validatedArgs = exportSubscribersSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('export_subscribers.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {
+    filters = [],
+    search = null,
+    columns = SUBSCRIBER_COLUMN_NAMES,
+    max_wait_seconds = DEFAULT_MAX_WAIT_SECONDS,
+  } = validatedArgs;
+
+  // Built before anything is created, so an illegal column/operator pair costs no server state.
+  // limit and offset are dropped on purpose: an export covers the whole matching set, and paging it
+  // would quietly return a slice of the audience.
+  let query;
+
+  try {
+    ({filters: query} = buildSubscriberQuery({filters, search}));
+  } catch (error) {
+    logger.error('export_subscribers.query.invalid', {args: validatedArgs, error});
+    throw error;
+  }
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  const set = await substack_api.createSubscriberSet(query);
+  logger.info('export_subscribers.set.created', {subscriber_set_id: set?.id ?? null});
+
+  const requested = await substack_api.requestSubscriberSetExport({
+    subscriber_set_id: set?.id,
+    columns,
+  });
+  const export_id = requested?.export_id ?? null;
+  logger.info('export_subscribers.export.requested', {export_id, columns: columns.length});
+
+  // Polled immediately first — a small export is often already done, and the dashboard's own first
+  // wait of a second is pure latency in that case.
+  let waited = 0;
+  let url = null;
+
+  for (let attempt = 0; ; attempt++) {
+    const status = await substack_api.getSubscriberSetExport(export_id);
+
+    if (status?.url) {
+      url = status.url;
+      break;
+    }
+
+    const delay = EXPORT_POLL_BACKOFF_SECONDS[
+      Math.min(attempt, EXPORT_POLL_BACKOFF_SECONDS.length - 1)
+    ];
+
+    // Refusing rather than overshooting the budget: a tool call that blocks far longer than the
+    // caller allowed is worse than one that says where to pick the export up.
+    if (waited + delay > max_wait_seconds) {
+      logger.warn('export_subscribers.export.timeout', {export_id, waited_seconds: waited});
+      throw new Error(
+        `Export ${export_id} is not ready after ${waited}s. Retry with a larger max_wait_seconds.`
+      );
+    }
+
+    logger.debug('export_subscribers.export.pending', {export_id, waited_seconds: waited, next_in: delay});
+    await sleep(delay);
+    waited += delay;
+  }
+
+  logger.info('export_subscribers.export.ready', {export_id, waited_seconds: waited});
+
+  const csv = await substack_api.downloadExport(url);
+  const {columns: returned, unmapped, subscribers} = recordsFromCsv(csv);
+
+  // Unsupported columns are dropped by the API with no error at all — `group_membership` and
+  // `tag_ids` never come back. Reporting the difference is the only way the caller learns it.
+  const missing_columns = columns.filter((column) => !returned.includes(column));
+
+  if (missing_columns.length > 0) {
+    logger.warn('export_subscribers.columns.missing', {missing_columns});
+  }
+
+  logger.info('export_subscribers.done', {
+    export_id,
+    count: subscribers.length,
+    columns: returned.length,
+    missing: missing_columns.length,
+    waited_seconds: waited,
+  });
+
+  return {
+    count: subscribers.length,
+    columns: returned,
+    // Requested but absent from the file. Empty is the normal case.
+    missing_columns,
+    // Headers the export sent that are not known columns; kept in the records under their raw label.
+    unmapped_columns: unmapped,
+    export_id,
+    subscribers,
+  };
+};

--- a/src/tools/export_subscribers.spec.js
+++ b/src/tools/export_subscribers.spec.js
@@ -1,0 +1,396 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {
+  exportSubscribersHandler,
+  exportSubscribersSchema,
+  EXPORT_POLL_BACKOFF_SECONDS,
+} from './export_subscribers.js';
+import {
+  createMswServer,
+  SUBSCRIBER_SET_URL,
+  SUBSCRIBER_SET_EXPORT_URL,
+  SUBSCRIBER_SET_ID,
+  EXPORT_ID,
+  EXPORT_FILE_PATH,
+} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+import {SUBSCRIBER_COLUMN_NAMES} from '../api/substack/SubscriberQuery.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+// The real backoff sleeps for seconds at a time. Tests inject a no-op that records what it was
+// asked to wait, so the polling behaviour is asserted without the suite paying for it.
+function fakeClock() {
+  const slept = [];
+  return {slept, sleep: async (seconds) => { slept.push(seconds); }};
+}
+
+const run = (args = {}, clock = fakeClock()) => exportSubscribersHandler(args, clock);
+
+describe('exportSubscribersSchema', () => {
+  test('accepts an empty call', () => {
+    assert.deepEqual(exportSubscribersSchema.parse({}), {});
+  });
+
+  test('accepts filters, search, columns and a wait budget', () => {
+    const args = {
+      filters: [{column: 'activity_rating', operator: 'is', value: 5}],
+      search: 'gmail',
+      columns: ['user_email_address', 'num_email_opens'],
+      max_wait_seconds: 60,
+    };
+
+    assert.deepEqual(exportSubscribersSchema.parse(args), args);
+  });
+
+  test('rejects an unknown key by name', () => {
+    assert.throws(
+      () => exportSubscribersSchema.parse({cols: []}),
+      (error) => /Unrecognized key/.test(error.message) && /cols/.test(error.message)
+    );
+  });
+
+  test('rejects a column that does not exist', () => {
+    assert.throws(() => exportSubscribersSchema.parse({columns: ['email']}), z.ZodError);
+  });
+
+  test('bounds the wait budget', () => {
+    assert.throws(() => exportSubscribersSchema.parse({max_wait_seconds: 0}), z.ZodError);
+    assert.throws(() => exportSubscribersSchema.parse({max_wait_seconds: 601}), z.ZodError);
+  });
+
+  test('publishes a description for every field', () => {
+    const json = z.toJSONSchema(exportSubscribersSchema, {target: 'draft-7', io: 'input'});
+
+    for (const field of ['filters', 'search', 'columns', 'max_wait_seconds']) {
+      assert.ok(json.properties[field].description, `${field} has no description`);
+    }
+
+    assert.equal(json.additionalProperties, false);
+  });
+});
+
+describe('exportSubscribersHandler — the four-step flow', () => {
+  test('creates a set, asks for the export, polls it and downloads the file', async () => {
+    await run();
+
+    const paths = msw.requests.map((request) => new URL(request.url).pathname);
+    assert.deepEqual(paths, [
+      '/api/v1/subscriber_set',
+      '/api/v1/subscriber_set/export',
+      `/api/v1/subscriber_set/export/${EXPORT_ID}`,
+      EXPORT_FILE_PATH,
+    ]);
+  });
+
+  test('sends the translated filters as the set query', async () => {
+    await run({filters: [{column: 'activity_rating', operator: 'is', value: 5}]});
+
+    assert.equal(msw.requests[0].url, SUBSCRIBER_SET_URL);
+    assert.deepEqual(msw.requests[0].body, {query: {activity_rating: 5}});
+  });
+
+  // The same translation as list_subscribers, so `contains` on a String column has to arrive as
+  // the _similar_to suffix rather than the raw operator name.
+  test('reuses the subscriber filter translation, suffixes included', async () => {
+    await run({filters: [{column: 'user_email_address', operator: 'contains', value: 'gmail'}]});
+
+    assert.deepEqual(msw.requests[0].body, {query: {user_email_address_similar_to: 'gmail'}});
+  });
+
+  test('search travels inside the query, where the API reads it', async () => {
+    await run({search: 'gmail'});
+
+    assert.deepEqual(msw.requests[0].body, {query: {search: 'gmail'}});
+  });
+
+  // Neither belongs in a set: the export covers the whole matching group, and paging it would
+  // silently return a slice of the audience.
+  test('sends no limit or offset — an export is the whole set', async () => {
+    await run({filters: [{column: 'subscription_type', operator: 'is', value: 'free'}]});
+
+    assert.deepEqual(Object.keys(msw.requests[0].body), ['query']);
+    assert.equal(msw.requests[0].body.query.limit, undefined);
+    assert.equal(msw.requests[0].body.query.offset, undefined);
+  });
+
+  test('passes the set id it was given back to the export request', async () => {
+    await run();
+
+    assert.equal(msw.requests[1].url, SUBSCRIBER_SET_EXPORT_URL);
+    assert.equal(msw.requests[1].body.subscriberSetId, SUBSCRIBER_SET_ID);
+  });
+
+  // The whole point of the tool: engagement columns are filterable but not readable through
+  // subscriber-stats, and the export is what makes them readable. Defaulting to a subset would
+  // quietly give up that capability.
+  test('defaults to asking for every column', async () => {
+    await run();
+
+    assert.deepEqual(msw.requests[1].body.columns, SUBSCRIBER_COLUMN_NAMES);
+  });
+
+  test('an explicit column list is sent as given', async () => {
+    await run({columns: ['user_email_address', 'num_comments']});
+
+    assert.deepEqual(msw.requests[1].body.columns, ['user_email_address', 'num_comments']);
+  });
+});
+
+describe('exportSubscribersHandler — parsing the CSV back', () => {
+  test('returns one record per data row', async () => {
+    const result = await run();
+
+    assert.equal(result.count, 2);
+    assert.equal(result.subscribers.length, 2);
+  });
+
+  // The header carries human labels; the records must come back keyed by column name, or the caller
+  // cannot correlate them with the filters it just used.
+  test('maps the label header back onto column keys', async () => {
+    const [first] = (await run()).subscribers;
+
+    assert.equal(first.user_email_address, 'one@example.com');
+    assert.equal(first.user_name, 'One');
+    assert.equal(first.num_email_opens_last_30d, '2');
+    assert.equal(first.num_web_post_views, '1');
+    assert.equal(first.activity_rating, '5');
+    assert.equal(first.country, 'BR');
+  });
+
+  test('does not key anything by the raw label', async () => {
+    const [first] = (await run()).subscribers;
+
+    assert.equal(first['Emails opened (30d)'], undefined);
+    assert.equal(first['Email'], undefined);
+  });
+
+  // A name containing a comma is the case a split(',') gets wrong, shifting every later column of
+  // that row by one.
+  test('keeps a comma inside a quoted name in one field', async () => {
+    const [, second] = (await run()).subscribers;
+
+    assert.equal(second.user_name, 'Two, Junior');
+    assert.equal(second.country, 'IT');
+  });
+
+  test('reports the columns it actually got back', async () => {
+    const result = await run();
+
+    assert.deepEqual(result.columns, [
+      'user_email_address', 'user_name', 'subscription_created_at',
+      'num_email_opens_last_30d', 'num_web_post_views', 'total_revenue_generated',
+      'activity_rating', 'country',
+    ]);
+  });
+
+  // Verified against the live API: asking for all 48 returns 46. `group_membership` and `tag_ids`
+  // are dropped with no error at all, so a caller told only "success" would believe it had them.
+  test('names the requested columns that never came back', async () => {
+    const result = await run({columns: ['user_email_address', 'user_name', 'tag_ids', 'group_membership']});
+
+    assert.deepEqual(result.missing_columns, ['tag_ids', 'group_membership']);
+  });
+
+  test('missing_columns is empty when everything asked for arrived', async () => {
+    const result = await run({columns: ['user_email_address', 'user_name']});
+
+    assert.deepEqual(result.missing_columns, []);
+  });
+
+  test('an export with only a header yields no records and no error', async () => {
+    msw.server.use(msw.exportFileHandler(() => new HttpResponse('Email,Name', {status: 200})));
+
+    const result = await run();
+
+    assert.equal(result.count, 0);
+    assert.deepEqual(result.subscribers, []);
+  });
+
+  // Values arrive display-formatted, not raw: the same field is the number 50 through
+  // subscriber-stats and the string "€50.00" here. Pinning it so the difference stays visible.
+  test('leaves values as the export formatted them', async () => {
+    const [, second] = (await run()).subscribers;
+
+    assert.equal(second.total_revenue_generated, '€50.00');
+    assert.equal(second.subscription_created_at, '2026-06-01T10:00:00.000Z');
+  });
+
+  test('an unrecognised header is kept under its raw label rather than dropped', async () => {
+    msw.server.use(msw.exportFileHandler(() => new HttpResponse('Email,Brand New Column\na@b.c,42', {status: 200})));
+
+    const result = await run();
+
+    assert.equal(result.subscribers[0]['Brand New Column'], '42');
+    assert.deepEqual(result.unmapped_columns, ['Brand New Column']);
+  });
+});
+
+describe('exportSubscribersHandler — polling', () => {
+  test('polls once and does not sleep when the file is ready immediately', async () => {
+    const clock = fakeClock();
+    await run({}, clock);
+
+    assert.deepEqual(clock.slept, []);
+  });
+
+  test('waits and retries while the export has no url yet', async () => {
+    msw.server.use(msw.exportStatusHandler((exportId, attempt) =>
+      HttpResponse.json(attempt < 3 ? {} : {url: EXPORT_FILE_PATH}, {status: 200})
+    ));
+
+    const clock = fakeClock();
+    const result = await run({}, clock);
+
+    assert.equal(result.count, 2);
+    assert.deepEqual(clock.slept, [EXPORT_POLL_BACKOFF_SECONDS[0], EXPORT_POLL_BACKOFF_SECONDS[1]]);
+  });
+
+  test('follows the documented backoff rather than a fixed interval', async () => {
+    assert.deepEqual(EXPORT_POLL_BACKOFF_SECONDS.slice(0, 4), [1, 5, 10, 30]);
+    assert.equal(EXPORT_POLL_BACKOFF_SECONDS.at(-1), 60);
+  });
+
+  // Better than hanging: the caller is told the export exists and can be retried, instead of the
+  // tool call blocking for the full backoff.
+  test('gives up at the wait budget and names the export it abandoned', async () => {
+    msw.server.use(msw.exportStatusHandler(() => HttpResponse.json({}, {status: 200})));
+
+    const error = await run({max_wait_seconds: 20}, fakeClock()).catch((e) => e);
+
+    assert.match(error.message, /not ready/i);
+    assert.match(error.message, new RegExp(EXPORT_ID));
+    assert.match(error.message, /max_wait_seconds/);
+  });
+
+  test('never sleeps past the wait budget', async () => {
+    msw.server.use(msw.exportStatusHandler(() => HttpResponse.json({}, {status: 200})));
+
+    const clock = fakeClock();
+    await run({max_wait_seconds: 20}, clock).catch(() => {});
+
+    assert.ok(
+      clock.slept.reduce((total, seconds) => total + seconds, 0) <= 20,
+      `slept ${clock.slept.join('+')} which exceeds the 20s budget`
+    );
+  });
+});
+
+describe('exportSubscribersHandler — errors', () => {
+  test('refuses an illegal filter before creating anything', async () => {
+    const error = await run({
+      filters: [{column: 'user_email_address', operator: 'gt', value: 1}],
+    }).catch((e) => e);
+
+    assert.match(error.message, /does not apply/i);
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('throws ZodError on a malformed call without issuing any request', async () => {
+    await assert.rejects(
+      () => run({max_wait_seconds: 'lots'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propagates a failure creating the set', async () => {
+    msw.server.use(msw.subscriberSetHandler(() => new HttpResponse('nope', {status: 400})));
+
+    const error = await run().catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+    assert.equal(msw.requests.length, 1);
+  });
+
+  test('propagates a failure requesting the export', async () => {
+    msw.server.use(msw.exportRequestHandler(() => new HttpResponse('nope', {status: 500})));
+
+    const error = await run().catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 500\b/);
+  });
+
+  test('propagates a failure downloading the file', async () => {
+    msw.server.use(msw.exportFileHandler(() => new HttpResponse('forbidden', {status: 403})));
+
+    const error = await run().catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 403\b/);
+  });
+});
+
+describe('exportSubscribersHandler — logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('records the arguments it received', async () => {
+    const args = {columns: ['user_email_address']};
+    const lines = await captureLogs(() => run(args));
+
+    assert.deepEqual(find(lines, 'export_subscribers.start').args, args);
+  });
+
+  // Each step is a separate request against a private API; without these, a stalled export is
+  // indistinguishable from a stalled download.
+  test('records each step of the flow', async () => {
+    const lines = await captureLogs(() => run());
+
+    assert.equal(find(lines, 'export_subscribers.set.created').subscriber_set_id, SUBSCRIBER_SET_ID);
+    assert.equal(find(lines, 'export_subscribers.export.requested').export_id, EXPORT_ID);
+    assert.ok(find(lines, 'export_subscribers.export.ready'));
+
+    const done = find(lines, 'export_subscribers.done');
+    assert.equal(done.count, 2);
+    assert.equal(done.columns, 8);
+  });
+
+  test('records each poll that found the export unfinished', async () => {
+    msw.server.use(msw.exportStatusHandler((exportId, attempt) =>
+      HttpResponse.json(attempt < 2 ? {} : {url: EXPORT_FILE_PATH}, {status: 200})
+    ));
+
+    const lines = await captureLogs(() => run({}, fakeClock()));
+
+    const pending = find(lines, 'export_subscribers.export.pending');
+    assert.equal(typeof pending.waited_seconds, 'number');
+  });
+
+  // Silently dropped columns are the failure mode most likely to mislead, so they get a line of
+  // their own at warn rather than only appearing in the result.
+  test('warns about columns the export dropped', async () => {
+    const lines = await captureLogs(() => run({columns: ['user_email_address', 'tag_ids']}));
+
+    assert.deepEqual(find(lines, 'export_subscribers.columns.missing').missing_columns, ['tag_ids']);
+  });
+
+  test('never writes the session token to the log', async () => {
+    const lines = await captureLogs(() => run());
+
+    assert.doesNotMatch(JSON.stringify(lines), /test-session-token/);
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => run(), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/test/helpers/msw-server.js
+++ b/test/helpers/msw-server.js
@@ -10,6 +10,27 @@ export const POST_MANAGEMENT_URL = `${API}/post_management`;
 export const DASHBOARD_SUMMARY_URL = `${API}/publish-dashboard/summary`;
 export const OPEN_RATE_URL = `${API}/publication/stats/email_stats/30d_open_rate`;
 export const VIEWS_30D_URL = `${API}/publication/stats/publication_traffic/30d_views`;
+export const SUBSCRIBER_SET_URL = `${API}/subscriber_set`;
+export const SUBSCRIBER_SET_EXPORT_URL = `${API}/subscriber_set/export`;
+
+export const SUBSCRIBER_SET_ID = 1135508;
+export const EXPORT_ID = 'test-export-id';
+
+// The export answers with a *relative* url on the publication host, cookie-authenticated — not a
+// pre-signed one. Verified against the live API: fetching it without the session cookie is a 403.
+export const EXPORT_FILE_PATH = `/api/v1/subscriber_set/export/${EXPORT_ID}/subscribers.csv`;
+export const EXPORT_FILE_URL = `${TEST_ENV.SUBSTACK_PUBLICATION_URL}${EXPORT_FILE_PATH}`;
+
+/**
+ * A CSV shaped exactly like a real export: the header carries human LABELS rather than column keys,
+ * the server's own column order (not the requested one), a quoted currency value instead of a
+ * number, and a name containing a comma — the case a `split(',')` gets wrong.
+ */
+export const EXPORT_CSV = [
+  'Email,Name,Start date,Emails opened (30d),Post views,Revenue,Activity,Country',
+  'one@example.com,One,2026-07-29T22:07:50.299Z,2,1,"€0.00",5,BR',
+  'two@example.com,"Two, Junior",2026-06-01T10:00:00.000Z,0,7,"€50.00",3,IT',
+].join('\n');
 
 export const DRAFT_RESPONSE = {
   id: 167712345,
@@ -147,6 +168,39 @@ export function createMswServer() {
     });
   }
 
+  function subscriberSetHandler(responder) {
+    return http.post(SUBSCRIBER_SET_URL, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
+  function exportRequestHandler(responder) {
+    return http.post(SUBSCRIBER_SET_EXPORT_URL, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
+  // Polling: `attempt` counts how many times the status has been asked for, so a test can make the
+  // export become ready only on the Nth poll.
+  let exportPolls = 0;
+
+  function exportStatusHandler(responder) {
+    return http.get(`${SUBSCRIBER_SET_EXPORT_URL}/:exportId`, async ({request, params}) => {
+      await record(request);
+      exportPolls += 1;
+      return responder(params.exportId, exportPolls);
+    });
+  }
+
+  function exportFileHandler(responder) {
+    return http.get(`${SUBSCRIBER_SET_EXPORT_URL}/:exportId/:file`, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
   const server = setupServer(
     draftsHandler(() => HttpResponse.json(DRAFT_RESPONSE, {status: 200})),
     subscriberStatsHandler(() => HttpResponse.json(SUBSCRIBER_STATS_RESPONSE, {status: 200})),
@@ -154,7 +208,15 @@ export function createMswServer() {
     draftDetailHandler(() => HttpResponse.json(DRAFT_DETAIL_RESPONSE, {status: 200})),
     statsHandler(DASHBOARD_SUMMARY_URL, () => HttpResponse.json(DASHBOARD_SUMMARY_RESPONSE, {status: 200})),
     statsHandler(OPEN_RATE_URL, () => HttpResponse.json(OPEN_RATE_RESPONSE, {status: 200})),
-    statsHandler(VIEWS_30D_URL, () => HttpResponse.json(VIEWS_30D_RESPONSE, {status: 200}))
+    statsHandler(VIEWS_30D_URL, () => HttpResponse.json(VIEWS_30D_RESPONSE, {status: 200})),
+    subscriberSetHandler(() => HttpResponse.json({id: SUBSCRIBER_SET_ID}, {status: 200})),
+    exportRequestHandler(() => HttpResponse.json({export_id: EXPORT_ID}, {status: 200})),
+    // Ready on the first poll by default; a test that cares about the wait overrides this.
+    exportStatusHandler(() => HttpResponse.json({url: EXPORT_FILE_PATH}, {status: 200})),
+    exportFileHandler(() => new HttpResponse(EXPORT_CSV, {
+      status: 200,
+      headers: {'Content-Type': 'text/csv'},
+    }))
   );
 
   return {
@@ -165,12 +227,17 @@ export function createMswServer() {
     postsHandler,
     draftDetailHandler,
     statsHandler,
+    subscriberSetHandler,
+    exportRequestHandler,
+    exportStatusHandler,
+    exportFileHandler,
     start() {
       server.listen({onUnhandledRequest: 'error'});
     },
     reset() {
       server.resetHandlers();
       requests.length = 0;
+      exportPolls = 0;
     },
     stop() {
       server.close();


### PR DESCRIPTION
`list_subscribers` can filter on the engagement columns but cannot return them: the endpoint takes the fields it answers with from the publication's saved Display settings and ignores a per-request `columnView`. PR #13 documented that as a flat limitation.

It is not one. The subscriber export reads them, and this wires it up.

```
POST /api/v1/subscriber_set          {query: <the same filters>} → {id}
POST /api/v1/subscriber_set/export   {subscriberSetId, columns}  → {export_id}
GET  /api/v1/subscriber_set/export/<id>                          → {url}   (poll)
GET  <url>                                                       → CSV
```

**Verified end to end against the live API before any of this was written**, on a 3-subscriber filter. The engagement values come back real: `Emails opened (6mo)=2`, `(7d)=1`, `(30d)=2`, `Last email open=<ts>`, `Post views=1`, `Days active (30d)=3`. The filter translation is reused as it stands — the set query is the same `filters` object `SubscriberQuery` already builds.

## Four things the flow gets wrong if taken at face value

Each one shaped the code, and each was found by measuring rather than assuming:

1. **The CSV header carries human LABELS, not column keys** — `Emails opened (6mo)`, not `num_email_opens`. `COLUMN_KEY_BY_LABEL` is the reverse map, built from the `label` field the column table already had. It is safe only because labels are unique, so the spec asserts the entry count: a future collision fails loudly instead of silently dropping a column.
2. **The server picks the column order**, not the caller. 19 columns were requested in one order and came back in another. Parsing keys off the header row, never off position.
3. **`tag_ids` and `group_membership` cannot be exported, and are dropped in silence** — asking for all 48 returns 46, with no error. The tool diffs what it asked for against the header and reports `missing_columns`. This is the same silent-drop hazard as the ignored `columnView`.
4. **The download url is relative to the publication host and cookie-authenticated** (403 without it, not pre-signed) and answers **CSV, not JSON**. `readBody` was split out of `handleResponse` so the text and JSON paths share one refusal branch — a 403 must still throw rather than hand the parser an error page to read as rows. `requestUrl` exists because that url cannot be appended to `publication_url`, which already ends in `/api/v1`.

## Notes

- `src/api/substack/csv.js` is a ~40-line parser rather than a dependency. `split(',')` is not enough and fails *silently*: a subscriber named `Smith, John` shifts every later column of that one row.
- Polling mirrors the dashboard's backoff (`1, 5, 10, 30`, then `60`) with one deliberate difference: the first poll is immediate, since a small export is usually already done. The wait is bounded by `max_wait_seconds` and **refuses rather than overshooting**, naming the `export_id` instead of blocking.
- No paging: an export covers the whole matching set, and `limit`/`offset` are dropped on purpose — paging an export would quietly return a slice of the audience.
- Values arrive display-formatted: revenue is `"€50.00"` here and the number `50` through `list_subscribers`. Pinned in a test so the difference stays visible.

## Verification

- **321 tests** (was 281), green on both the `engines` floor (22) and `.nvmrc` (24.19.0)
- every test watched failing first, then **six targeted mutations**: label map bypassed, `missing_columns` suppressed, fixed poll interval, budget guard removed, default narrowed to a column subset, `limit`/`offset` leaked into the set query. Five produce assertion failures; removing the budget guard makes the poll loop **never terminate**, which is its own kind of proof.
- CSV parser mutated separately on four axes (quoting disabled, doubled-quote escape dropped, CRLF mishandled, trailing newline producing a phantom row) — all four caught
- stdio probe: 6 tools announce correct schemas
- `npm pack --dry-run`: new sources ship, 0 spec files in the tarball

`CLAUDE.md` and the README are updated — the "filterable but not readable" caveat now points at this tool instead of presenting itself as the end of the road.

🤖 Generated with [Claude Code](https://claude.com/claude-code)