### PR TITLE
Add get_analytics, covering the 17 verified Stats reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,21 @@ export is usually already done. Four things this flow gets wrong if taken at fac
 `src/api/substack/csv.js` is a ~40-line parser rather than a dependency. `split(',')` is not enough
 and fails *silently*: a subscriber named `Smith, John` shifts every later column of that one row.
 
+**The analytics reports live in one registry**, `ANALYTICS_REPORTS` in `src/tools/get_analytics.js`:
+17 verified endpoints under `/publication/stats/`, exposed as one tool with a `report` enum rather
+than 17 near-identical tools, which would make a model's choice harder rather than easier. Each entry
+carries its path, whether it takes a date window (`from_date`/`to_date`, or full ISO `start`/`end`
+for retention), a default `limit` for the two that answer 400 without one, and the fixed extras the
+dashboard always sends. **An unexpected parameter is a 400 on several of these**, so a parameter that
+does not apply to the chosen report is dropped *and named* in `ignored_params` — the same
+silent-drop hazard as `columnView` and the export's columns, which is now three for three.
+
+**Two endpoints next to them are broken upstream, not mis-called:**
+`/publication/stats/audience_insights/location` (the subscriber map) and
+`/publication/stats/visitor_sources` answer **400 even for Substack's own dashboard** — observed in
+the page's own network log, with and without parameters. They are deliberately absent from the
+registry, and `get_analytics.spec.js` asserts they stay absent. Do not "fix" them by guessing params.
+
 **`GET /api/v1/post_management/{drafts,published,scheduled}`** lists posts. `order_by` is **not
 optional**: `scheduled` answers 400 without it, which is why `src/tools/list_posts.js` keeps a
 default per status rather than letting the server choose. Free-text search is `query`, and a null

--- a/README.md
+++ b/README.md
@@ -119,6 +119,46 @@ There is no paging: an export covers the whole matching set.
 **Returns**: total and recent subscribers, email and app subscribers, ARR, site views and the
 30-day email open rate, each with its change where Substack reports one. If one of the underlying
 endpoints fails the rest are still returned, and the failure is named under `errors`.
+
+For anything deeper, use `get_analytics`.
+</details>
+
+<details>
+<summary><strong>get_analytics</strong> - Read one of 17 analytics reports</summary>
+
+Everything behind the dashboard's Stats tabs, as one tool with a `report` enum rather than
+seventeen near-identical tools.
+
+**Inputs**:
+- `report` (string): which report to read — see the table below
+- `from_date`, `to_date` (string, optional): `YYYY-MM-DD`. Used only by the reports covering a
+  period, which default to the last 30 days
+- `limit` (number, optional): 1–100, used only by `audience_overlap` and `subscriber_notes`
+
+| report | what it tells you |
+|---|---|
+| `retention` | cohort retention — how much of each signup cohort is still subscribed months later |
+| `retention_summary` | headline retention at 1, 6 and 12 months |
+| `unsubscribes` / `unsubscribes_timeseries` | churn, with the reasons given |
+| `growth_sources` | where new subscribers came from, ranked |
+| `growth_events` | the individual growth events in a window |
+| `referrals_leaderboard` / `referrals_summary` | who refers most; gifts sent, accepted, converted |
+| `audience_overlap` | other Substacks whose audience overlaps yours — the collaboration shortlist |
+| `audience_locations` | how many countries and US states your subscribers span |
+| `subscriber_notes` | recent Notes written by your subscribers |
+| `email_stats` | per-send delivery and open statistics |
+| `paid_subscriber_growth` | paid growth rate, new subscriptions, expirations |
+| `subscribers_timeseries`, `followers_timeseries`, `arr_timeseries` | counts and revenue over time |
+| `network_attribution` | what share of subscribers arrived via the Substack network |
+
+**Returns**: `{report, params, ignored_params, data}`. `params` is what was actually sent, defaults
+included — the same report answers very differently over a different window, so the numbers mean
+little without it. `ignored_params` names anything you passed that the chosen report does not
+accept, rather than dropping it silently.
+
+> Two neighbouring endpoints are deliberately **not** exposed: `audience_insights/location` (the
+> subscriber map) and `visitor_sources` answer `400` even for Substack's own dashboard, so they are
+> broken upstream rather than mis-called.
 </details>
 
 ### 📋 Requirements

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -133,6 +133,7 @@ describe('entrypoint — stdio transport', () => {
     assert.deepEqual(Object.keys(byName).sort(), [
       'create_draft_post',
       'export_subscribers',
+      'get_analytics',
       'get_draft',
       'get_publication_stats',
       'list_posts',

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import {exportSubscribersSchema, exportSubscribersHandler} from "./tools/export_
 import {listPostsSchema, listPostsHandler} from "./tools/list_posts.js";
 import {getDraftSchema, getDraftHandler} from "./tools/get_draft.js";
 import {getPublicationStatsSchema, getPublicationStatsHandler} from "./tools/get_publication_stats.js";
+import {getAnalyticsSchema, getAnalyticsHandler} from "./tools/get_analytics.js";
 import {logger} from "./logger.js";
 
 export const tools = {
@@ -58,9 +59,23 @@ export const tools = {
   get_publication_stats: {
     description:
       "Read the headline stats of your Substack publication: total and recent subscribers, ARR, " +
-      "site views, and the 30-day email open rate. Takes no arguments.",
+      "site views, and the 30-day email open rate. Takes no arguments. For anything deeper — " +
+      "retention, churn, growth sources, referrals — use get_analytics.",
     schema: getPublicationStatsSchema,
     handler: getPublicationStatsHandler,
+  },
+  get_analytics: {
+    // One tool with a report enum rather than seventeen tools: the reports differ only in their
+    // path and a couple of parameters, and seventeen near-identical entries in tools/list would
+    // make the choice harder for a model rather than easier.
+    description:
+      "Read one analytics report from your Substack publication, covering everything behind the " +
+      "dashboard's Stats tabs: cohort retention, unsubscribes and their reasons, growth sources, " +
+      "referrals, audience overlap with other Substacks, subscriber Notes, paid growth, and " +
+      "timeseries for subscribers, followers and ARR. Pick a report with `report`; the ones " +
+      "covering a period accept from_date and to_date and otherwise default to the last 30 days.",
+    schema: getAnalyticsSchema,
+    handler: getAnalyticsHandler,
   },
 };
 

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -40,6 +40,7 @@ describe('MCP server — list_tools', () => {
   const EXPECTED_TOOLS = [
     'create_draft_post',
     'export_subscribers',
+    'get_analytics',
     'get_draft',
     'get_publication_stats',
     'list_posts',

--- a/src/tools/get_analytics.js
+++ b/src/tools/get_analytics.js
@@ -1,0 +1,239 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+
+/**
+ * The analytics reports behind the dashboard's Stats tabs, one entry per verified endpoint.
+ *
+ * Every one of these was called against the live API during reconnaissance and answered 200. Two
+ * neighbours are deliberately absent: `audience_insights/location` and `visitor_sources` answer 400
+ * even for Substack's own dashboard — observed in the page's own network log, with and without
+ * parameters — so they are broken upstream rather than mis-called, and must not be added back
+ * without re-checking.
+ *
+ * `window: 'date'` takes `from_date`/`to_date` as `YYYY-MM-DD`; `window: 'iso'` takes `start`/`end`
+ * as full ISO timestamps, which is what the retention endpoint wants. `limit` is a default for the
+ * reports that answer 400 without one. `params` are fixed extras the dashboard always sends.
+ */
+export const ANALYTICS_REPORTS = {
+  email_stats: {
+    path: '/publication/stats/email_stats',
+    description: 'Per-email delivery and open statistics for every send.',
+  },
+  unsubscribes: {
+    path: '/publication/stats/unsubscribes',
+    window: 'date',
+    description: 'Unsubscribes in a window, broken down by the reason given.',
+  },
+  unsubscribes_timeseries: {
+    path: '/publication/stats/unsubscribes/timeseries',
+    window: 'date',
+    description: 'Unsubscribes over time.',
+  },
+  retention: {
+    path: '/publication/stats/subscriber_retention',
+    window: 'iso',
+    params: {months: 12, is_subscribed: false},
+    description: 'Cohort retention: how much of each signup cohort is still subscribed months later.',
+  },
+  retention_summary: {
+    path: '/publication/stats/subscriber_retention/summary',
+    params: {is_subscribed: false},
+    description: 'Headline retention rates at 1, 6 and 12 months.',
+  },
+  referrals_leaderboard: {
+    path: '/publication/stats/referrals/leaderboard',
+    description: 'Which subscribers have referred the most readers.',
+  },
+  referrals_summary: {
+    path: '/publication/stats/referrals/summary',
+    description: 'Gifts sent, accepted and converted.',
+  },
+  audience_overlap: {
+    path: '/publication/stats/audience_insights/overlap',
+    limit: 6,
+    description: 'Other Substacks whose audience overlaps yours, with the overlap percentage — the publications worth collaborating with.',
+  },
+  audience_locations: {
+    path: '/publication/stats/audience_insights/location/total',
+    description: 'How many distinct countries and US states your subscribers span.',
+  },
+  subscriber_notes: {
+    path: '/publication/stats/subscriber_notes',
+    limit: 8,
+    description: 'Recent Notes written by your subscribers.',
+  },
+  paid_subscriber_growth: {
+    path: '/publication/stats/paid_subscriber_growth/summary',
+    description: 'Paid growth rate for the period, with new subscriptions and expirations.',
+  },
+  arr_timeseries: {
+    path: '/publication/stats/arr/timeseries',
+    description: 'Annual recurring revenue over time.',
+  },
+  followers_timeseries: {
+    path: '/publication/stats/followers/timeseries',
+    description: 'Follower count over time.',
+  },
+  subscribers_timeseries: {
+    path: '/publication/stats/subscribers/timeseries',
+    params: {period: 'month'},
+    description: 'Subscriber count over time.',
+  },
+  growth_sources: {
+    path: '/publication/stats/growth/sources',
+    window: 'date',
+    params: {order_by: 'users', order_direction: 'desc'},
+    description: 'Where new subscribers came from in a window, ranked by how many each source brought.',
+  },
+  growth_events: {
+    path: '/publication/stats/growth/events',
+    window: 'date',
+    description: 'The individual growth events in a window.',
+  },
+  network_attribution: {
+    path: '/publication/stats/network_attribution',
+    params: {time_window: '90 days', is_subscribed: false},
+    description: 'What share of your subscribers arrived through the Substack network rather than your own channels.',
+  },
+};
+
+const REPORT_NAMES = Object.keys(ANALYTICS_REPORTS);
+
+const DEFAULT_WINDOW_DAYS = 30;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const REPORT_REFERENCE = Object.entries(ANALYTICS_REPORTS)
+  .map(([name, {description}]) => `${name} — ${description}`)
+  .join(' ');
+
+const asDate = (date) => date.toISOString().slice(0, 10);
+
+const daysBefore = (date, days) => new Date(date.getTime() - days * 86400000);
+
+// A calendar year rather than 365 days, so a leap year does not shift the window by a day.
+function yearBefore(date) {
+  const shifted = new Date(date);
+  shifted.setUTCFullYear(shifted.getUTCFullYear() - 1);
+  return shifted;
+}
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call.
+export const getAnalyticsSchema = z.strictObject({
+  report: z
+    .enum(REPORT_NAMES)
+    .describe(`Which report to read. ${REPORT_REFERENCE}`),
+  from_date: z
+    .string()
+    .regex(DATE_PATTERN, 'from_date must be YYYY-MM-DD')
+    .optional()
+    .describe(
+      "Start of the window, as YYYY-MM-DD. Only used by the reports that cover a period; defaults to 30 days ago, or a year ago for retention."
+    ),
+  to_date: z
+    .string()
+    .regex(DATE_PATTERN, 'to_date must be YYYY-MM-DD')
+    .optional()
+    .describe("End of the window, as YYYY-MM-DD. Defaults to today."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      "How many rows to return. Only used by audience_overlap and subscriber_notes, which default to 6 and 8."
+    ),
+});
+
+/**
+ * Works out the query string for one report, and which of the caller's parameters it could not use.
+ *
+ * Sending an extra parameter is not harmless here — several of these endpoints answer 400 on one —
+ * so a parameter that does not apply is dropped and named rather than passed along.
+ */
+function resolveParams(report, {from_date, to_date, limit}, now) {
+  const definition = ANALYTICS_REPORTS[report];
+  const params = {...(definition.params ?? {})};
+  const ignored = [];
+
+  if (definition.window) {
+    const to = to_date ?? asDate(now);
+    const from = from_date ?? asDate(
+      definition.window === 'iso' ? yearBefore(now) : daysBefore(now, DEFAULT_WINDOW_DAYS)
+    );
+
+    if (definition.window === 'iso') {
+      // The retention endpoint takes full timestamps, not plain dates.
+      params.start = `${from}T00:00:00.000Z`;
+      params.end = `${to}T00:00:00.000Z`;
+    } else {
+      params.from_date = from;
+      params.to_date = to;
+    }
+  } else {
+    if (from_date !== undefined) ignored.push('from_date');
+    if (to_date !== undefined) ignored.push('to_date');
+  }
+
+  if (definition.limit !== undefined) {
+    params.limit = limit ?? definition.limit;
+  } else if (limit !== undefined) {
+    ignored.push('limit');
+  }
+
+  return {params, ignored};
+}
+
+export const getAnalyticsHandler = async (args, {now = () => new Date()} = {}) => {
+  logger.debug('get_analytics.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse
+  // never rejects. It is kept so the handler stays safe when called directly.
+  let validatedArgs;
+
+  try {
+    validatedArgs = getAnalyticsSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('get_analytics.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {report} = validatedArgs;
+  const {path} = ANALYTICS_REPORTS[report];
+  const {params, ignored} = resolveParams(report, validatedArgs, now());
+
+  logger.debug('get_analytics.resolved', {report, path, params});
+
+  // Dropping a parameter the caller believed in is the failure mode this API has already produced
+  // twice — the ignored columnView, and the export's silently dropped columns — so it is said out
+  // loud rather than left for the caller to notice.
+  if (ignored.length > 0) {
+    logger.warn('get_analytics.params.ignored', {report, ignored_params: ignored});
+  }
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  const data = await substack_api.request({
+    method: 'GET',
+    path,
+    params,
+    referer: '/publish/stats',
+  });
+
+  logger.info('get_analytics.done', {report, path, params});
+
+  return {
+    report,
+    // The parameters actually sent, defaults included: the same report answers very differently
+    // over a different window, so the answer is meaningless without them.
+    params,
+    ignored_params: ignored,
+    data,
+  };
+};

--- a/src/tools/get_analytics.spec.js
+++ b/src/tools/get_analytics.spec.js
@@ -1,0 +1,316 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {getAnalyticsHandler, getAnalyticsSchema, ANALYTICS_REPORTS} from './get_analytics.js';
+import {createMswServer, ANALYTICS_RESPONSE} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+// Date defaults are derived from "now", so the clock is injected rather than read: otherwise every
+// assertion about a default window would change meaning tomorrow.
+const NOW = new Date('2026-08-07T12:00:00.000Z');
+const run = (args, now = () => NOW) => getAnalyticsHandler(args, {now});
+
+const sentUrl = () => new URL(msw.requests.at(-1).url);
+const param = (name) => sentUrl().searchParams.get(name);
+
+describe('ANALYTICS_REPORTS', () => {
+  // Every report here was verified against the live API during reconnaissance. Two endpoints that
+  // exist but answer 400 even for Substack's own dashboard — audience_insights/location and
+  // visitor_sources — are deliberately absent, and must not be added back without re-checking.
+  test('covers the verified reports and nothing else', () => {
+    assert.equal(Object.keys(ANALYTICS_REPORTS).length, 17);
+  });
+
+  test('excludes the endpoints that are broken upstream', () => {
+    const paths = Object.values(ANALYTICS_REPORTS).map((report) => report.path);
+
+    assert.ok(!paths.some((path) => path.endsWith('/audience_insights/location')));
+    assert.ok(!paths.some((path) => path.includes('visitor_sources')));
+  });
+
+  test('gives every report a path under the publication stats prefix', () => {
+    for (const [name, {path}] of Object.entries(ANALYTICS_REPORTS)) {
+      assert.match(path, /^\/publication\/stats\//, `${name} has an unexpected path`);
+    }
+  });
+
+  test('gives every report a one-line description for the tool schema', () => {
+    for (const [name, {description}] of Object.entries(ANALYTICS_REPORTS)) {
+      assert.equal(typeof description, 'string', `${name} has no description`);
+      assert.ok(description.length > 0, `${name} has an empty description`);
+    }
+  });
+});
+
+describe('getAnalyticsSchema', () => {
+  test('requires a report', () => {
+    assert.throws(() => getAnalyticsSchema.parse({}), z.ZodError);
+  });
+
+  test('accepts every report name', () => {
+    for (const report of Object.keys(ANALYTICS_REPORTS)) {
+      assert.deepEqual(getAnalyticsSchema.parse({report}), {report});
+    }
+  });
+
+  test('rejects an unknown report', () => {
+    assert.throws(() => getAnalyticsSchema.parse({report: 'revenue'}), z.ZodError);
+  });
+
+  test('rejects an unknown key by name', () => {
+    assert.throws(
+      () => getAnalyticsSchema.parse({report: 'email_stats', period: 'month'}),
+      (error) => /Unrecognized key/.test(error.message) && /period/.test(error.message)
+    );
+  });
+
+  test('accepts a date window and a limit', () => {
+    const args = {report: 'unsubscribes', from_date: '2026-07-01', to_date: '2026-07-31', limit: 20};
+
+    assert.deepEqual(getAnalyticsSchema.parse(args), args);
+  });
+
+  test('rejects a date that is not YYYY-MM-DD', () => {
+    assert.throws(() => getAnalyticsSchema.parse({report: 'unsubscribes', from_date: '01/07/2026'}), z.ZodError);
+    assert.throws(() => getAnalyticsSchema.parse({report: 'unsubscribes', to_date: 'yesterday'}), z.ZodError);
+  });
+
+  test('bounds the limit', () => {
+    assert.throws(() => getAnalyticsSchema.parse({report: 'audience_overlap', limit: 0}), z.ZodError);
+    assert.throws(() => getAnalyticsSchema.parse({report: 'audience_overlap', limit: 101}), z.ZodError);
+  });
+
+  test('publishes a description for every field', () => {
+    const json = z.toJSONSchema(getAnalyticsSchema, {target: 'draft-7', io: 'input'});
+
+    for (const field of ['report', 'from_date', 'to_date', 'limit']) {
+      assert.ok(json.properties[field].description, `${field} has no description`);
+    }
+
+    assert.equal(json.additionalProperties, false);
+  });
+
+  // The 17 report names reach the model only through this enum; published as a bare string it would
+  // be unusable by a caller that does not already know them.
+  test('publishes the report names as an enum', () => {
+    const json = z.toJSONSchema(getAnalyticsSchema, {target: 'draft-7', io: 'input'});
+
+    assert.deepEqual(json.properties.report.enum.sort(), Object.keys(ANALYTICS_REPORTS).sort());
+  });
+});
+
+describe('getAnalyticsHandler — routing', () => {
+  test('every report reaches its own endpoint with a GET', async () => {
+    for (const [report, {path}] of Object.entries(ANALYTICS_REPORTS)) {
+      msw.requests.length = 0;
+      await run({report});
+
+      assert.equal(msw.requests.length, 1, `${report} issued ${msw.requests.length} requests`);
+      assert.equal(msw.requests[0].method, 'GET', `${report} was not a GET`);
+      assert.equal(sentUrl().pathname, `/api/v1${path}`, `${report} hit the wrong path`);
+    }
+  });
+
+  test('returns the payload under the report name it was asked for', async () => {
+    const result = await run({report: 'email_stats'});
+
+    assert.equal(result.report, 'email_stats');
+    assert.deepEqual(result.data, ANALYTICS_RESPONSE);
+  });
+});
+
+describe('getAnalyticsHandler — date windows', () => {
+  const DATE_REPORTS = ['unsubscribes', 'unsubscribes_timeseries', 'growth_sources', 'growth_events'];
+
+  test('the reports that take a window default to the last 30 days', async () => {
+    for (const report of DATE_REPORTS) {
+      msw.requests.length = 0;
+      await run({report});
+
+      assert.equal(param('from_date'), '2026-07-08', `${report} from_date`);
+      assert.equal(param('to_date'), '2026-08-07', `${report} to_date`);
+    }
+  });
+
+  test('an explicit window is used as given', async () => {
+    await run({report: 'unsubscribes', from_date: '2026-01-01', to_date: '2026-03-31'});
+
+    assert.equal(param('from_date'), '2026-01-01');
+    assert.equal(param('to_date'), '2026-03-31');
+  });
+
+  test('one half of a window still defaults the other', async () => {
+    await run({report: 'unsubscribes', from_date: '2026-01-01'});
+
+    assert.equal(param('from_date'), '2026-01-01');
+    assert.equal(param('to_date'), '2026-08-07');
+  });
+
+  // A report that takes no window must not receive one: an unexpected parameter is how several of
+  // these endpoints answer 400.
+  test('a report that takes no window is sent none', async () => {
+    await run({report: 'email_stats', from_date: '2026-01-01', to_date: '2026-03-31'});
+
+    assert.equal(sentUrl().searchParams.has('from_date'), false);
+    assert.equal(sentUrl().searchParams.has('to_date'), false);
+  });
+
+  // Cohort retention needs a much longer window than 30 days to say anything, and its endpoint takes
+  // full ISO timestamps rather than plain dates.
+  test('retention spans a year and sends ISO timestamps', async () => {
+    await run({report: 'retention'});
+
+    assert.equal(param('start'), '2025-08-07T00:00:00.000Z');
+    assert.equal(param('end'), '2026-08-07T00:00:00.000Z');
+    assert.equal(param('months'), '12');
+    assert.equal(param('is_subscribed'), 'false');
+  });
+
+  test('retention honours an explicit window, converted to ISO', async () => {
+    await run({report: 'retention', from_date: '2025-01-01', to_date: '2025-12-31'});
+
+    assert.equal(param('start'), '2025-01-01T00:00:00.000Z');
+    assert.equal(param('end'), '2025-12-31T00:00:00.000Z');
+  });
+});
+
+describe('getAnalyticsHandler — fixed parameters', () => {
+  // Both of these answer 400 without a limit, which is what makes the default load-bearing rather
+  // than cosmetic.
+  test('the reports that require a limit get a default one', async () => {
+    await run({report: 'audience_overlap'});
+    assert.equal(param('limit'), '6');
+
+    await run({report: 'subscriber_notes'});
+    assert.equal(param('limit'), '8');
+  });
+
+  test('an explicit limit overrides the default', async () => {
+    await run({report: 'audience_overlap', limit: 25});
+
+    assert.equal(param('limit'), '25');
+  });
+
+  test('a report that takes no limit is sent none', async () => {
+    await run({report: 'arr_timeseries', limit: 25});
+
+    assert.equal(sentUrl().searchParams.has('limit'), false);
+  });
+
+  test('growth_sources carries the sort the dashboard uses', async () => {
+    await run({report: 'growth_sources'});
+
+    assert.equal(param('order_by'), 'users');
+    assert.equal(param('order_direction'), 'desc');
+  });
+
+  test('network_attribution carries its time window and audience', async () => {
+    await run({report: 'network_attribution'});
+
+    assert.equal(param('time_window'), '90 days');
+    assert.equal(param('is_subscribed'), 'false');
+  });
+
+  test('subscribers_timeseries carries its period', async () => {
+    await run({report: 'subscribers_timeseries'});
+
+    assert.equal(param('period'), 'month');
+  });
+});
+
+describe('getAnalyticsHandler — ignored parameters', () => {
+  // Silently dropping a parameter the caller believed in is the failure mode this project has hit
+  // twice already, with columnView and with the export's dropped columns. Reporting it instead.
+  test('names the parameters the chosen report does not accept', async () => {
+    const result = await run({report: 'email_stats', from_date: '2026-01-01', limit: 5});
+
+    assert.deepEqual(result.ignored_params.sort(), ['from_date', 'limit']);
+  });
+
+  test('ignored_params is empty when everything given was used', async () => {
+    const result = await run({report: 'unsubscribes', from_date: '2026-01-01'});
+
+    assert.deepEqual(result.ignored_params, []);
+  });
+
+  test('reports the parameters it actually sent', async () => {
+    const result = await run({report: 'audience_overlap'});
+
+    assert.deepEqual(result.params, {limit: 6});
+  });
+});
+
+describe('getAnalyticsHandler — errors and logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('throws ZodError on an unknown report without issuing any request', async () => {
+    await assert.rejects(
+      () => run({report: 'nope'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propagates a Substack API error', async () => {
+    msw.server.use(msw.analyticsHandler(() => new HttpResponse('bad window', {status: 400})));
+
+    const error = await run({report: 'unsubscribes'}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+  });
+
+  test('records the arguments and the report it resolved them to', async () => {
+    const lines = await captureLogs(() => run({report: 'retention'}));
+
+    assert.deepEqual(find(lines, 'get_analytics.start').args, {report: 'retention'});
+
+    const resolved = find(lines, 'get_analytics.resolved');
+    assert.equal(resolved.report, 'retention');
+    assert.equal(resolved.path, '/publication/stats/subscriber_retention');
+    assert.equal(resolved.params.months, 12);
+  });
+
+  test('records how much came back', async () => {
+    const lines = await captureLogs(() => run({report: 'email_stats'}));
+
+    assert.equal(find(lines, 'get_analytics.done').report, 'email_stats');
+  });
+
+  test('warns about parameters it had to ignore', async () => {
+    const lines = await captureLogs(() => run({report: 'email_stats', limit: 5}));
+
+    assert.deepEqual(find(lines, 'get_analytics.params.ignored').ignored_params, ['limit']);
+  });
+
+  test('never writes the session token to the log', async () => {
+    const lines = await captureLogs(() => run({report: 'email_stats'}));
+
+    assert.doesNotMatch(JSON.stringify(lines), /test-session-token/);
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => run({report: 'email_stats'}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/test/helpers/msw-server.js
+++ b/test/helpers/msw-server.js
@@ -102,6 +102,12 @@ export const DASHBOARD_SUMMARY_RESPONSE = {
 export const OPEN_RATE_RESPONSE = {openRate: 0.42, openRateDiff: 0.01};
 export const VIEWS_30D_RESPONSE = {views30d: 5000, viewsDelta30d: 250};
 
+export const PUBLICATION_STATS_URL = `${API}/publication/stats`;
+
+// One payload for every analytics report: the tool passes the body through untouched, so what it is
+// matters far less than which path was asked for and with which parameters.
+export const ANALYTICS_RESPONSE = {rows: [{label: 'a', value: 1}], total: 1};
+
 /**
  * Creates the MSW server used by the integration tests.
  *
@@ -168,6 +174,15 @@ export function createMswServer() {
     });
   }
 
+  // A catch-all for the analytics reports: their paths are two and three segments deep, so `*`
+  // matches any of them. Registered last so the narrower stats handlers above still win.
+  function analyticsHandler(responder) {
+    return http.get(`${PUBLICATION_STATS_URL}/*`, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
   function subscriberSetHandler(responder) {
     return http.post(SUBSCRIBER_SET_URL, async ({request}) => {
       await record(request);
@@ -216,7 +231,10 @@ export function createMswServer() {
     exportFileHandler(() => new HttpResponse(EXPORT_CSV, {
       status: 200,
       headers: {'Content-Type': 'text/csv'},
-    }))
+    })),
+    // Last on purpose: MSW resolves in registration order, so the two narrower
+    // /publication/stats/... handlers above keep their own payloads and this catches the rest.
+    analyticsHandler(() => HttpResponse.json(ANALYTICS_RESPONSE, {status: 200}))
   );
 
   return {
@@ -227,6 +245,7 @@ export function createMswServer() {
     postsHandler,
     draftDetailHandler,
     statsHandler,
+    analyticsHandler,
     subscriberSetHandler,
     exportRequestHandler,
     exportStatusHandler,


### PR DESCRIPTION
> Replaces #15, which GitHub auto-closed when its base branch was deleted on merging #14. Same commit, rebased onto `main`.

Everything behind the dashboard's Stats tabs, in one tool: cohort retention, churn and its reasons, growth sources, referrals, audience overlap, subscriber Notes, paid growth, and timeseries for subscribers, followers and ARR.

## One tool, not seventeen

The 17 reports differ only in a path and a couple of parameters. Seventeen near-identical entries in `tools/list` would make a model's choice *harder*, not easier, so this is a single tool with a `report` enum. `ANALYTICS_REPORTS` holds the path, the window kind, a default `limit` for the two that need one, and the fixed extras the dashboard always sends.

| report | what it tells you |
|---|---|
| `retention`, `retention_summary` | cohort retention; headline rates at 1/6/12 months |
| `unsubscribes`, `unsubscribes_timeseries` | churn, with the reasons given |
| `growth_sources`, `growth_events` | where new subscribers came from, ranked |
| `referrals_leaderboard`, `referrals_summary` | who refers most; gifts sent/accepted/converted |
| `audience_overlap` | Substacks whose audience overlaps yours — the collaboration shortlist |
| `audience_locations`, `subscriber_notes`, `email_stats`, `paid_subscriber_growth` | |
| `subscribers_timeseries`, `followers_timeseries`, `arr_timeseries`, `network_attribution` | |

## Two endpoints deliberately left out

`/publication/stats/audience_insights/location` (the subscriber map) and `/publication/stats/visitor_sources` answer **400 even for Substack's own dashboard** — observed in the page's own network log, with and without parameters. They are broken upstream, not mis-called, so guessing parameters is wasted work. The spec asserts they stay absent from the registry.

## Design notes

- **An unexpected parameter is a 400 on several of these endpoints**, so a parameter the chosen report does not accept is dropped *and named* in `ignored_params`. That is the third instance of the same silent-drop hazard in this API — after the ignored `columnView` and the export's dropped columns — so it now gets handled the same way by default.
- `params` comes back in the result too: the same report answers very differently over a different window, so the numbers mean little without knowing which one was used.
- **Retention is the one report needing different treatment.** It takes full ISO timestamps rather than plain dates, and a 30-day window says nothing about cohorts, so it defaults to a calendar year — a year rather than 365 days, so a leap year does not shift the window.
- `now` is injected the way `sleep` is in `export_subscribers`, so the date-window defaults are assertable instead of changing meaning tomorrow.

## Known follow-up

Reconnaissance after this branch was written found that **`email_stats` is not an aggregate report at all** — it is the per-post table, 43 metrics across 863 posts, and the dashboard calls it with `offset`/`limit`/`order_by`/`order_direction`. As shipped here it returns the server's default page and cannot be sorted, which is a poor fit for a `get_analytics` report. The plan is to move it into a dedicated `get_post_stats` tool in a follow-up rather than hold this PR.

## Verification

- **358 tests** (was 321), green on both the `engines` floor (22) and `.nvmrc` (24.19.0)
- every test watched failing first, then **six mutations**: window sent to every report regardless, `ignored_params` suppressed, retention downgraded to plain dates, caller's `limit` ignored, retention window shortened to 30 days, fixed dashboard params dropped. All six caught.
- one test walks the whole registry and asserts each report hits its own path with a GET, so a copy-pasted path cannot slip through
- stdio probe: 7 tools, and all 17 report names survive into the published enum
- the MSW catch-all for `/publication/stats/*` is registered last on purpose, so the two narrower handlers `get_publication_stats` relies on keep their own payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)