### PR TITLE
Add get_post_stats and move email_stats out of get_analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,13 +122,33 @@ export is usually already done. Four things this flow gets wrong if taken at fac
 and fails *silently*: a subscriber named `Smith, John` shifts every later column of that one row.
 
 **The analytics reports live in one registry**, `ANALYTICS_REPORTS` in `src/tools/get_analytics.js`:
-17 verified endpoints under `/publication/stats/`, exposed as one tool with a `report` enum rather
-than 17 near-identical tools, which would make a model's choice harder rather than easier. Each entry
+16 verified endpoints under `/publication/stats/`, exposed as one tool with a `report` enum rather
+than 16 near-identical tools, which would make a model's choice harder rather than easier. Each entry
 carries its path, whether it takes a date window (`from_date`/`to_date`, or full ISO `start`/`end`
 for retention), a default `limit` for the two that answer 400 without one, and the fixed extras the
 dashboard always sends. **An unexpected parameter is a 400 on several of these**, so a parameter that
 does not apply to the chosen report is dropped *and named* in `ignored_params` — the same
 silent-drop hazard as `columnView` and the export's columns, which is now three for three.
+
+**`email_stats` is misnamed and is not one of those reports.** Despite living under
+`/publication/stats/` it is the **per-post table** behind the dashboard's "Posts" tab — which itself
+lives at `/publish/stats/emails`, not `/publish/stats/posts` — with one row per post across the whole
+archive: 43 fields covering delivery, opens, clicks, conversion (`signups`, `subscribes`,
+`free_to_paid_upgrades`, `estimated_value`), churn (`unsubscribes`) and completion
+(`subscribers_finished_post`). It takes `offset`/`limit`/`order_by`/`order_direction`, so it belongs
+to `src/tools/get_post_stats.js` and is deliberately absent from `ANALYTICS_REPORTS`; both specs
+assert the split, because two doors to the same data would mean choosing between a full report and a
+crippled one. Two measured facts shape that tool:
+
+- **`order_by` must be validated against the field list.** An unrecognised value answers **200** with
+  an arbitrary order, so a typo yields a ranking that looks authoritative. The enum is the only
+  guard — this is the *fourth* silent-ignore in this API.
+- **There is no date filter.** `from_date`/`to_date` leave `total` unchanged at 863, so the schema
+  does not offer them; `strictObject` then tells a caller that guesses `from_date` that it is
+  unrecognised, which is the difference between knowing there is no window and believing there is.
+  Sorting works for real, though: `signups` descending returns 42, 41, 41, 27, 23… Ranking by a
+  *rate* puts `null` first, and the tool does not filter those out — that would answer a different
+  question than the one asked.
 
 **Two endpoints next to them are broken upstream, not mis-called:**
 `/publication/stats/audience_insights/location` (the subscriber map) and

--- a/README.md
+++ b/README.md
@@ -124,7 +124,45 @@ For anything deeper, use `get_analytics`.
 </details>
 
 <details>
-<summary><strong>get_analytics</strong> - Read one of 17 analytics reports</summary>
+<summary><strong>get_post_stats</strong> - Rank your posts by any of 43 metrics</summary>
+
+Which post actually grew the list, which was worth most, which cost you subscribers. The dashboard's
+"Posts" tab, sortable and paged.
+
+**Inputs**:
+- `order_by` (string, optional): any of the 43 metrics, defaulting to `post_date`
+- `order_direction` (`asc` | `desc`, optional): defaults to `desc`
+- `limit` (number, optional): 1–100, defaults to 25
+- `offset` (number, optional): for paging the archive
+
+The metrics worth reaching for:
+
+| group | fields |
+|---|---|
+| conversion | `signups` `subscribes` `founding_subscribes` `annual_subscribes` `monthly_subscribes` `free_trials` `free_to_paid_upgrades` `signups_within_1_day` `estimated_value` |
+| churn | `unsubscribes` |
+| reading | `opens` `open_rate` `clicks` `click_through_rate` `views` `subscribers_finished_post` |
+| social | `likes` `shares` `restacks` `engagement_rate` `unique_engagements` |
+| delivery | `queued` `sent` `delivered` `dropped` |
+| video / podcast | `video_views` `video_minutes_watched` `downloads` `downloads_day30` … |
+
+**Returns**: `{total, returned, limit, offset, order_by, order_direction, posts}`. `total` is the
+whole archive, not the page; `order_by` and `order_direction` are echoed so a ranking is never read
+without knowing what produced it.
+
+> **Two caveats**, both verified:
+> - **There is no date filter.** `from_date`/`to_date` are ignored by this endpoint — `total` does not
+>   change — so the schema does not offer them. Narrow by sorting and paging instead.
+> - Ranking by a **rate** (`open_rate`, `engagement_rate`, `click_through_rate`) descending puts posts
+>   with no data first, because `null` sorts before numbers. The tool does not filter them out, since
+>   that would silently answer a different question.
+>
+> `order_by` is an enum on purpose: the API answers `200` for a field it does not recognise and
+> returns an arbitrary order, so a typo would produce a ranking that looks authoritative.
+</details>
+
+<details>
+<summary><strong>get_analytics</strong> - Read one of 16 publication-level reports</summary>
 
 Everything behind the dashboard's Stats tabs, as one tool with a `report` enum rather than
 seventeen near-identical tools.
@@ -146,7 +184,6 @@ seventeen near-identical tools.
 | `audience_overlap` | other Substacks whose audience overlaps yours — the collaboration shortlist |
 | `audience_locations` | how many countries and US states your subscribers span |
 | `subscriber_notes` | recent Notes written by your subscribers |
-| `email_stats` | per-send delivery and open statistics |
 | `paid_subscriber_growth` | paid growth rate, new subscriptions, expirations |
 | `subscribers_timeseries`, `followers_timeseries`, `arr_timeseries` | counts and revenue over time |
 | `network_attribution` | what share of subscribers arrived via the Substack network |

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -135,6 +135,7 @@ describe('entrypoint — stdio transport', () => {
       'export_subscribers',
       'get_analytics',
       'get_draft',
+      'get_post_stats',
       'get_publication_stats',
       'list_posts',
       'list_subscribers',

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,7 @@ import {listPostsSchema, listPostsHandler} from "./tools/list_posts.js";
 import {getDraftSchema, getDraftHandler} from "./tools/get_draft.js";
 import {getPublicationStatsSchema, getPublicationStatsHandler} from "./tools/get_publication_stats.js";
 import {getAnalyticsSchema, getAnalyticsHandler} from "./tools/get_analytics.js";
+import {getPostStatsSchema, getPostStatsHandler} from "./tools/get_post_stats.js";
 import {logger} from "./logger.js";
 
 export const tools = {
@@ -64,15 +65,30 @@ export const tools = {
     schema: getPublicationStatsSchema,
     handler: getPublicationStatsHandler,
   },
-  get_analytics: {
-    // One tool with a report enum rather than seventeen tools: the reports differ only in their
-    // path and a couple of parameters, and seventeen near-identical entries in tools/list would
-    // make the choice harder for a model rather than easier.
+  get_post_stats: {
+    // Its own tool rather than a get_analytics report: it is the only one that returns per-entity
+    // rows instead of an aggregate, it needs paging over 863 posts, and its sort key comes from its
+    // own 43-field vocabulary. Folding it in would have meant a report that cannot be sorted.
     description:
-      "Read one analytics report from your Substack publication, covering everything behind the " +
-      "dashboard's Stats tabs: cohort retention, unsubscribes and their reasons, growth sources, " +
-      "referrals, audience overlap with other Substacks, subscriber Notes, paid growth, and " +
-      "timeseries for subscribers, followers and ARR. Pick a report with `report`; the ones " +
+      "Rank the posts of your Substack publication by any of 43 per-post metrics. This is how to " +
+      "tell which post actually grew the list (signups, subscribes, free_to_paid_upgrades), which " +
+      "was worth most (estimated_value), which cost you subscribers (unsubscribes), and which " +
+      "people read to the end (subscribers_finished_post) — alongside delivery, opens, clicks, " +
+      "views and restacks. Covers the whole archive with paging. There is no date filter: the " +
+      "endpoint ignores one, so narrow by sorting and paging instead.",
+    schema: getPostStatsSchema,
+    handler: getPostStatsHandler,
+  },
+  get_analytics: {
+    // One tool with a report enum rather than sixteen tools: the reports differ only in their
+    // path and a couple of parameters, and sixteen near-identical entries in tools/list would
+    // make the choice harder for a model rather than easier. Per-post numbers are the exception and
+    // live in get_post_stats — they are rows, not aggregates, and need their own sort and paging.
+    description:
+      "Read one publication-level analytics report, covering the dashboard's Stats tabs: cohort " +
+      "retention, unsubscribes and their reasons, growth sources, referrals, audience overlap with " +
+      "other Substacks, subscriber Notes, paid growth, and timeseries for subscribers, followers " +
+      "and ARR. For per-post numbers use get_post_stats instead. Pick a report with `report`; the ones " +
       "covering a period accept from_date and to_date and otherwise default to the last 30 days.",
     schema: getAnalyticsSchema,
     handler: getAnalyticsHandler,

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -42,6 +42,7 @@ describe('MCP server — list_tools', () => {
     'export_subscribers',
     'get_analytics',
     'get_draft',
+    'get_post_stats',
     'get_publication_stats',
     'list_posts',
     'list_subscribers',

--- a/src/tools/get_analytics.js
+++ b/src/tools/get_analytics.js
@@ -16,10 +16,6 @@ import {logger} from "../logger.js";
  * reports that answer 400 without one. `params` are fixed extras the dashboard always sends.
  */
 export const ANALYTICS_REPORTS = {
-  email_stats: {
-    path: '/publication/stats/email_stats',
-    description: 'Per-email delivery and open statistics for every send.',
-  },
   unsubscribes: {
     path: '/publication/stats/unsubscribes',
     window: 'date',

--- a/src/tools/get_analytics.spec.js
+++ b/src/tools/get_analytics.spec.js
@@ -33,7 +33,17 @@ describe('ANALYTICS_REPORTS', () => {
   // exist but answer 400 even for Substack's own dashboard — audience_insights/location and
   // visitor_sources — are deliberately absent, and must not be added back without re-checking.
   test('covers the verified reports and nothing else', () => {
-    assert.equal(Object.keys(ANALYTICS_REPORTS).length, 17);
+    assert.equal(Object.keys(ANALYTICS_REPORTS).length, 16);
+  });
+
+  // email_stats lives here no longer: despite the name it is the per-post table, not an aggregate,
+  // and it needs pagination and a sort over its own 43 fields. get_post_stats owns it. Two doors to
+  // the same data would leave a caller choosing between a full report and a crippled one.
+  test('does not expose email_stats, which get_post_stats owns', () => {
+    assert.equal(ANALYTICS_REPORTS.email_stats, undefined);
+
+    const paths = Object.values(ANALYTICS_REPORTS).map((report) => report.path);
+    assert.ok(!paths.includes('/publication/stats/email_stats'));
   });
 
   test('excludes the endpoints that are broken upstream', () => {
@@ -74,7 +84,7 @@ describe('getAnalyticsSchema', () => {
 
   test('rejects an unknown key by name', () => {
     assert.throws(
-      () => getAnalyticsSchema.parse({report: 'email_stats', period: 'month'}),
+      () => getAnalyticsSchema.parse({report: 'referrals_summary', period: 'month'}),
       (error) => /Unrecognized key/.test(error.message) && /period/.test(error.message)
     );
   });
@@ -127,9 +137,9 @@ describe('getAnalyticsHandler — routing', () => {
   });
 
   test('returns the payload under the report name it was asked for', async () => {
-    const result = await run({report: 'email_stats'});
+    const result = await run({report: 'referrals_summary'});
 
-    assert.equal(result.report, 'email_stats');
+    assert.equal(result.report, 'referrals_summary');
     assert.deepEqual(result.data, ANALYTICS_RESPONSE);
   });
 });
@@ -164,7 +174,7 @@ describe('getAnalyticsHandler — date windows', () => {
   // A report that takes no window must not receive one: an unexpected parameter is how several of
   // these endpoints answer 400.
   test('a report that takes no window is sent none', async () => {
-    await run({report: 'email_stats', from_date: '2026-01-01', to_date: '2026-03-31'});
+    await run({report: 'referrals_summary', from_date: '2026-01-01', to_date: '2026-03-31'});
 
     assert.equal(sentUrl().searchParams.has('from_date'), false);
     assert.equal(sentUrl().searchParams.has('to_date'), false);
@@ -237,7 +247,7 @@ describe('getAnalyticsHandler — ignored parameters', () => {
   // Silently dropping a parameter the caller believed in is the failure mode this project has hit
   // twice already, with columnView and with the export's dropped columns. Reporting it instead.
   test('names the parameters the chosen report does not accept', async () => {
-    const result = await run({report: 'email_stats', from_date: '2026-01-01', limit: 5});
+    const result = await run({report: 'referrals_summary', from_date: '2026-01-01', limit: 5});
 
     assert.deepEqual(result.ignored_params.sort(), ['from_date', 'limit']);
   });
@@ -291,25 +301,25 @@ describe('getAnalyticsHandler — errors and logging', () => {
   });
 
   test('records how much came back', async () => {
-    const lines = await captureLogs(() => run({report: 'email_stats'}));
+    const lines = await captureLogs(() => run({report: 'referrals_summary'}));
 
-    assert.equal(find(lines, 'get_analytics.done').report, 'email_stats');
+    assert.equal(find(lines, 'get_analytics.done').report, 'referrals_summary');
   });
 
   test('warns about parameters it had to ignore', async () => {
-    const lines = await captureLogs(() => run({report: 'email_stats', limit: 5}));
+    const lines = await captureLogs(() => run({report: 'referrals_summary', limit: 5}));
 
     assert.deepEqual(find(lines, 'get_analytics.params.ignored').ignored_params, ['limit']);
   });
 
   test('never writes the session token to the log', async () => {
-    const lines = await captureLogs(() => run({report: 'email_stats'}));
+    const lines = await captureLogs(() => run({report: 'referrals_summary'}));
 
     assert.doesNotMatch(JSON.stringify(lines), /test-session-token/);
   });
 
   test('says nothing at all when logging is silenced', async () => {
-    const lines = await captureLogs(() => run({report: 'email_stats'}), {level: 'silent'});
+    const lines = await captureLogs(() => run({report: 'referrals_summary'}), {level: 'silent'});
 
     assert.deepEqual(lines, []);
   });

--- a/src/tools/get_post_stats.js
+++ b/src/tools/get_post_stats.js
@@ -1,0 +1,168 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {logger} from "../logger.js";
+
+/**
+ * The 43 fields `GET /publication/stats/email_stats` returns for each post, read off a real response.
+ *
+ * Despite its name that endpoint is not an aggregate email report: it is the per-post table behind
+ * the dashboard's "Posts" tab (which lives at /publish/stats/emails), one row per post across the
+ * whole archive, paginated and sortable.
+ *
+ * Every field is offered as a sort key, and that enum is load-bearing rather than cosmetic: the API
+ * answers **200 for an order_by it does not recognise** and returns an arbitrary order. A typo would
+ * otherwise yield a ranking that looks authoritative and means nothing.
+ */
+export const POST_STAT_FIELDS = [
+  // Identity
+  'post_id',
+  'title',
+  'post_date',
+  'audience',
+  'type',
+  'section_id',
+  'section_name',
+  'tags',
+  'bylines',
+
+  // Delivery
+  'queued',
+  'sent',
+  'delivered',
+  'dropped',
+
+  // Reading
+  'opens',
+  'opened',
+  'open_rate',
+  'clicks',
+  'clicked',
+  'click_through_rate',
+  'views',
+  'subscribers_finished_post',
+
+  // Conversion — what a post was actually worth
+  'signups',
+  'subscribes',
+  'founding_subscribes',
+  'annual_subscribes',
+  'monthly_subscribes',
+  'free_trials',
+  'free_to_paid_upgrades',
+  'signups_within_1_day',
+  'subscriptions_within_1_day',
+  'estimated_value',
+
+  // Churn
+  'unsubscribes',
+
+  // Social
+  'likes',
+  'shares',
+  'restacks',
+  'engagement_rate',
+  'unique_engagements',
+
+  // Video and podcast
+  'video_views',
+  'video_minutes_watched',
+  'downloads',
+  'downloads_day30',
+  'podcast_preview_downloads',
+  'podcast_preview_downloads_day30',
+];
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call. It also matters here for a
+// second reason — `from_date` is a plausible key that this endpoint ignores, so being told it is
+// unrecognised is the difference between knowing there is no date filter and believing there is one.
+export const getPostStatsSchema = z.strictObject({
+  order_by: z
+    .enum(POST_STAT_FIELDS)
+    .optional()
+    .describe(
+      "Which metric to rank by, defaulting to post_date. Use signups or subscribes for the posts " +
+      "that grew the list, estimated_value for the most valuable, unsubscribes for the ones that " +
+      "cost subscribers, subscribers_finished_post for the ones people actually read to the end."
+    ),
+  order_direction: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe("Sort direction, defaulting to desc — the highest first."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("How many posts to return, 1-100, defaulting to 25."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("How many posts to skip, for paging through the archive."),
+});
+
+export const getPostStatsHandler = async (args) => {
+  logger.debug('get_post_stats.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse
+  // never rejects. It is kept so the handler stays safe when called directly.
+  let validatedArgs;
+
+  try {
+    validatedArgs = getPostStatsSchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('get_post_stats.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {
+    order_by = 'post_date',
+    order_direction = 'desc',
+    limit = 25,
+    offset = 0,
+  } = validatedArgs;
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  // No date parameters: verified that from_date/to_date leave `total` unchanged, so the endpoint
+  // ignores them. Sending them anyway would suggest a narrowing that never happens.
+  const response = await substack_api.request({
+    method: 'GET',
+    path: '/publication/stats/email_stats',
+    params: {offset, limit, order_by, order_direction},
+    referer: '/publish/stats/emails',
+  });
+
+  // Returned in the order the API chose, unsorted and unfiltered by this tool. That matters for the
+  // rate fields: `null` sorts before numbers, so ranking by open_rate descending puts posts with no
+  // data at the top. Quietly dropping them would be inventing a different question.
+  const posts = response?.rows ?? [];
+
+  logger.info('get_post_stats.done', {
+    order_by,
+    order_direction,
+    total: response?.total ?? null,
+    returned: posts.length,
+    limit,
+    offset,
+  });
+
+  return {
+    // The whole archive, not the page — 863 posts on the publication this was built against.
+    total: response?.total ?? null,
+    returned: posts.length,
+    limit,
+    offset,
+    // Echoed so a ranking is never read without knowing what produced it.
+    order_by,
+    order_direction,
+    posts,
+  };
+};

--- a/src/tools/get_post_stats.spec.js
+++ b/src/tools/get_post_stats.spec.js
@@ -1,0 +1,283 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {getPostStatsHandler, getPostStatsSchema, POST_STAT_FIELDS} from './get_post_stats.js';
+import {createMswServer, EMAIL_STATS_URL, POST_STATS_RESPONSE} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const sentUrl = () => new URL(msw.requests.at(-1).url);
+const param = (name) => sentUrl().searchParams.get(name);
+
+describe('POST_STAT_FIELDS', () => {
+  // The 43 fields a real response carries. The count is the guard: this list is what the schema
+  // enum is built from, and a field quietly dropped from it becomes a sort the caller cannot ask for.
+  test('lists all 43 fields the endpoint returns', () => {
+    assert.equal(POST_STAT_FIELDS.length, 43);
+  });
+
+  test('has no duplicates', () => {
+    assert.equal(new Set(POST_STAT_FIELDS).size, POST_STAT_FIELDS.length);
+  });
+
+  test('covers the conversion metrics, which are the point of the tool', () => {
+    for (const field of [
+      'signups', 'subscribes', 'founding_subscribes', 'annual_subscribes', 'monthly_subscribes',
+      'free_trials', 'free_to_paid_upgrades', 'signups_within_1_day', 'subscriptions_within_1_day',
+      'estimated_value',
+    ]) {
+      assert.ok(POST_STAT_FIELDS.includes(field), `${field} is missing`);
+    }
+  });
+
+  test('covers churn and completion, which nothing else reports per post', () => {
+    assert.ok(POST_STAT_FIELDS.includes('unsubscribes'));
+    assert.ok(POST_STAT_FIELDS.includes('subscribers_finished_post'));
+  });
+});
+
+describe('getPostStatsSchema', () => {
+  test('accepts an empty call', () => {
+    assert.deepEqual(getPostStatsSchema.parse({}), {});
+  });
+
+  test('accepts a sort, direction and page', () => {
+    const args = {order_by: 'signups', order_direction: 'desc', limit: 50, offset: 100};
+
+    assert.deepEqual(getPostStatsSchema.parse(args), args);
+  });
+
+  // The API answers 200 for an order_by it does not recognise and returns an arbitrary order, so a
+  // typo would otherwise produce a ranking that looks authoritative and is not. The enum is the only
+  // thing standing between the caller and that.
+  test('rejects an order_by that is not a real field', () => {
+    assert.throws(() => getPostStatsSchema.parse({order_by: 'signup'}), z.ZodError);
+    assert.throws(() => getPostStatsSchema.parse({order_by: 'best'}), z.ZodError);
+  });
+
+  test('accepts every field as a sort key', () => {
+    for (const order_by of POST_STAT_FIELDS) {
+      assert.deepEqual(getPostStatsSchema.parse({order_by}), {order_by});
+    }
+  });
+
+  test('rejects an unknown key by name', () => {
+    assert.throws(
+      () => getPostStatsSchema.parse({from_date: '2026-01-01'}),
+      (error) => /Unrecognized key/.test(error.message) && /from_date/.test(error.message)
+    );
+  });
+
+  test('bounds limit and offset', () => {
+    assert.throws(() => getPostStatsSchema.parse({limit: 0}), z.ZodError);
+    assert.throws(() => getPostStatsSchema.parse({limit: 101}), z.ZodError);
+    assert.throws(() => getPostStatsSchema.parse({offset: -1}), z.ZodError);
+  });
+
+  test('publishes a description for every field', () => {
+    const json = z.toJSONSchema(getPostStatsSchema, {target: 'draft-7', io: 'input'});
+
+    for (const field of ['order_by', 'order_direction', 'limit', 'offset']) {
+      assert.ok(json.properties[field].description, `${field} has no description`);
+    }
+
+    assert.equal(json.additionalProperties, false);
+  });
+
+  test('publishes the sortable fields as an enum', () => {
+    const json = z.toJSONSchema(getPostStatsSchema, {target: 'draft-7', io: 'input'});
+
+    assert.deepEqual(json.properties.order_by.enum.sort(), [...POST_STAT_FIELDS].sort());
+  });
+
+  // There is no date filtering on this endpoint — verified: from_date/to_date leave `total`
+  // unchanged at 863. Accepting them would imply a narrowing that never happens.
+  test('exposes no date window, because the endpoint ignores one', () => {
+    const json = z.toJSONSchema(getPostStatsSchema, {target: 'draft-7', io: 'input'});
+
+    assert.equal(json.properties.from_date, undefined);
+    assert.equal(json.properties.to_date, undefined);
+  });
+});
+
+describe('getPostStatsHandler — request shape', () => {
+  test('GETs the email_stats endpoint, which is the per-post table', async () => {
+    await getPostStatsHandler({});
+
+    assert.equal(msw.requests.length, 1);
+    assert.equal(msw.requests[0].method, 'GET');
+    assert.equal(sentUrl().pathname, '/api/v1/publication/stats/email_stats');
+  });
+
+  test('defaults to the most recent posts first', async () => {
+    await getPostStatsHandler({});
+
+    assert.equal(param('order_by'), 'post_date');
+    assert.equal(param('order_direction'), 'desc');
+  });
+
+  test('defaults to the first page of 25', async () => {
+    await getPostStatsHandler({});
+
+    assert.equal(param('limit'), '25');
+    assert.equal(param('offset'), '0');
+  });
+
+  test('sorts by the requested metric', async () => {
+    await getPostStatsHandler({order_by: 'estimated_value'});
+
+    assert.equal(param('order_by'), 'estimated_value');
+    assert.equal(param('order_direction'), 'desc');
+  });
+
+  test('an explicit direction is used as given', async () => {
+    await getPostStatsHandler({order_by: 'unsubscribes', order_direction: 'asc'});
+
+    assert.equal(param('order_direction'), 'asc');
+  });
+
+  test('forwards limit and offset', async () => {
+    await getPostStatsHandler({limit: 5, offset: 40});
+
+    assert.equal(param('limit'), '5');
+    assert.equal(param('offset'), '40');
+  });
+
+  // Sending one would be silently ignored, which is worse than not offering it: the caller would
+  // believe the numbers covered a window they never did.
+  test('sends no date parameters at all', async () => {
+    await getPostStatsHandler({});
+
+    assert.equal(sentUrl().searchParams.has('from_date'), false);
+    assert.equal(sentUrl().searchParams.has('to_date'), false);
+  });
+});
+
+describe('getPostStatsHandler — result', () => {
+  test('returns the archive total alongside the page', async () => {
+    const result = await getPostStatsHandler({});
+
+    assert.equal(result.total, 863);
+    assert.equal(result.returned, 2);
+    assert.equal(result.limit, 25);
+    assert.equal(result.offset, 0);
+  });
+
+  test('echoes the sort that produced the ranking', async () => {
+    const result = await getPostStatsHandler({order_by: 'signups'});
+
+    assert.equal(result.order_by, 'signups');
+    assert.equal(result.order_direction, 'desc');
+  });
+
+  test('returns the posts with their metrics intact', async () => {
+    const [first] = (await getPostStatsHandler({})).posts;
+
+    assert.equal(first.title, 'MCP Server for Substack');
+    assert.equal(first.signups, 42);
+    assert.equal(first.subscribes, 6);
+    assert.equal(first.estimated_value, 669.5023091726059);
+    assert.equal(first.unsubscribes, 1);
+    assert.equal(first.subscribers_finished_post, 610);
+  });
+
+  test('survives a response carrying no rows', async () => {
+    msw.server.use(msw.postStatsHandler(() => HttpResponse.json({total: 0}, {status: 200})));
+
+    const result = await getPostStatsHandler({});
+
+    assert.deepEqual(result.posts, []);
+    assert.equal(result.returned, 0);
+  });
+
+  // Sorting descending on a rate puts posts with no data first, because null sorts before numbers.
+  // Pinned so the caveat in the description stays honest rather than drifting.
+  test('does not reorder or filter what the API returned', async () => {
+    msw.server.use(msw.postStatsHandler(() => HttpResponse.json({
+      total: 3,
+      rows: [{title: 'no data', open_rate: null}, {title: 'good', open_rate: 0.5}],
+    }, {status: 200})));
+
+    const {posts} = await getPostStatsHandler({order_by: 'open_rate'});
+
+    assert.deepEqual(posts.map((post) => post.title), ['no data', 'good']);
+  });
+});
+
+describe('getPostStatsHandler — errors and logging', () => {
+  function find(lines, msg) {
+    const line = lines.find((entry) => entry.msg === msg);
+    assert.ok(line, `expected a ${msg} log line, got: ${lines.map((l) => l.msg).join(', ')}`);
+    return line;
+  }
+
+  test('throws ZodError on an invalid sort without issuing any request', async () => {
+    await assert.rejects(
+      () => getPostStatsHandler({order_by: 'nope'}),
+      (error) => error instanceof z.ZodError
+    );
+
+    assert.equal(msw.requests.length, 0);
+  });
+
+  test('propagates a Substack API error', async () => {
+    msw.server.use(msw.postStatsHandler(() => new HttpResponse('boom', {status: 500})));
+
+    const error = await getPostStatsHandler({}).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 500\b/);
+  });
+
+  test('records the arguments it received', async () => {
+    const lines = await captureLogs(() => getPostStatsHandler({order_by: 'signups'}));
+
+    assert.deepEqual(find(lines, 'get_post_stats.start').args, {order_by: 'signups'});
+  });
+
+  test('records the sort and page it resolved, and what came back', async () => {
+    const lines = await captureLogs(() => getPostStatsHandler({}));
+
+    const done = find(lines, 'get_post_stats.done');
+    assert.equal(done.order_by, 'post_date');
+    assert.equal(done.order_direction, 'desc');
+    assert.equal(done.total, 863);
+    assert.equal(done.returned, 2);
+  });
+
+  test('records the validation issues when the arguments are rejected', async () => {
+    const lines = await captureLogs(
+      () => getPostStatsHandler({order_by: 'nope'}).catch(() => {})
+    );
+
+    assert.deepEqual(
+      find(lines, 'get_post_stats.args.invalid').issues.map((issue) => issue.path.join('.')),
+      ['order_by']
+    );
+  });
+
+  test('never writes the session token to the log', async () => {
+    const lines = await captureLogs(() => getPostStatsHandler({}));
+
+    assert.doesNotMatch(JSON.stringify(lines), /test-session-token/);
+  });
+
+  test('says nothing at all when logging is silenced', async () => {
+    const lines = await captureLogs(() => getPostStatsHandler({}), {level: 'silent'});
+
+    assert.deepEqual(lines, []);
+  });
+});

--- a/test/helpers/msw-server.js
+++ b/test/helpers/msw-server.js
@@ -103,6 +103,66 @@ export const OPEN_RATE_RESPONSE = {openRate: 0.42, openRateDiff: 0.01};
 export const VIEWS_30D_RESPONSE = {views30d: 5000, viewsDelta30d: 250};
 
 export const PUBLICATION_STATS_URL = `${API}/publication/stats`;
+export const EMAIL_STATS_URL = `${API}/publication/stats/email_stats`;
+
+/**
+ * Shaped after a real response: `email_stats` is the per-post table, not an aggregate, and `total`
+ * is the whole archive rather than the page. Ordered by `signups` descending here, which is what the
+ * live API actually returns for that sort.
+ */
+export const POST_STATS_RESPONSE = {
+  total: 863,
+  rows: [
+    {
+      post_id: 163262717,
+      title: 'MCP Server for Substack',
+      post_date: '2026-05-08T09:00:00.000Z',
+      audience: 'everyone',
+      type: 'newsletter',
+      sent: 1900,
+      delivered: 1880,
+      opens: 800,
+      open_rate: 0.42,
+      clicks: 120,
+      click_through_rate: 0.06,
+      signups: 42,
+      subscribes: 6,
+      estimated_value: 669.5023091726059,
+      unsubscribes: 1,
+      views: 3100,
+      likes: 30,
+      restacks: 4,
+      subscribers_finished_post: 610,
+      section_name: null,
+      tags: [],
+      bylines: [{id: 12345}],
+    },
+    {
+      post_id: 163262700,
+      title: 'How to Summarize Youtube Video using AI',
+      post_date: '2026-04-02T09:00:00.000Z',
+      audience: 'everyone',
+      type: 'newsletter',
+      sent: 1500,
+      delivered: 1490,
+      opens: 500,
+      open_rate: 0.33,
+      clicks: 60,
+      click_through_rate: 0.04,
+      signups: 27,
+      subscribes: 2,
+      estimated_value: 210.25,
+      unsubscribes: 3,
+      views: 5195,
+      likes: 12,
+      restacks: 1,
+      subscribers_finished_post: 300,
+      section_name: null,
+      tags: [],
+      bylines: [{id: 12345}],
+    },
+  ],
+};
 
 // One payload for every analytics report: the tool passes the body through untouched, so what it is
 // matters far less than which path was asked for and with which parameters.
@@ -174,6 +234,13 @@ export function createMswServer() {
     });
   }
 
+  function postStatsHandler(responder) {
+    return http.get(EMAIL_STATS_URL, async ({request}) => {
+      await record(request);
+      return responder();
+    });
+  }
+
   // A catch-all for the analytics reports: their paths are two and three segments deep, so `*`
   // matches any of them. Registered last so the narrower stats handlers above still win.
   function analyticsHandler(responder) {
@@ -224,6 +291,7 @@ export function createMswServer() {
     statsHandler(DASHBOARD_SUMMARY_URL, () => HttpResponse.json(DASHBOARD_SUMMARY_RESPONSE, {status: 200})),
     statsHandler(OPEN_RATE_URL, () => HttpResponse.json(OPEN_RATE_RESPONSE, {status: 200})),
     statsHandler(VIEWS_30D_URL, () => HttpResponse.json(VIEWS_30D_RESPONSE, {status: 200})),
+    postStatsHandler(() => HttpResponse.json(POST_STATS_RESPONSE, {status: 200})),
     subscriberSetHandler(() => HttpResponse.json({id: SUBSCRIBER_SET_ID}, {status: 200})),
     exportRequestHandler(() => HttpResponse.json({export_id: EXPORT_ID}, {status: 200})),
     // Ready on the first poll by default; a test that cares about the wait overrides this.
@@ -245,6 +313,7 @@ export function createMswServer() {
     postsHandler,
     draftDetailHandler,
     statsHandler,
+    postStatsHandler,
     analyticsHandler,
     subscriberSetHandler,
     exportRequestHandler,


### PR DESCRIPTION
`email_stats` is misnamed. Despite sitting under `/publication/stats/` it is **not an aggregate email report**: it is the per-post table behind the dashboard's "Posts" tab — which itself lives at `/publish/stats/emails`, not `/publish/stats/posts` — one row per post across the whole archive, with 43 fields and its own paging and sort.

Shipped as a `get_analytics` report in #16 it returned the server's default page and could not be sorted, which wastes the interesting part. It gets its own tool, and both specs now assert the split: two doors to the same data would mean choosing between a full report and a crippled one.

## What this unlocks

Questions the publication-level reports cannot answer:

| question | sort by |
|---|---|
| which post grew the list | `signups`, `subscribes`, `free_to_paid_upgrades` |
| which was worth most | `estimated_value` |
| which cost me subscribers | `unsubscribes` |
| which did people read to the end | `subscribers_finished_post` |
| which travelled | `restacks`, `shares`, `views` |

On the publication this was built against, the top post by `signups` is "MCP Server for Substack" — 42 signups, 6 subscribes, €669.50 of `estimated_value`.

## Two measured facts that shaped it

**`order_by` is a 43-value enum, and that is load-bearing.** An unrecognised field answers **200** with an arbitrary order rather than failing, so a typo would produce a ranking that looks authoritative and means nothing. This is the **fourth** silent-ignore found in this API, after the ignored `columnView`, the export's dropped columns and the analytics parameters — the pattern is now the default assumption rather than a surprise.

**There is no date filter.** `from_date`/`to_date` leave `total` unchanged at 863. The schema therefore does not offer them, and `strictObject` tells a caller that guesses `from_date` that it is unrecognised — the difference between *knowing* there is no window and *believing* there is one.

Sorting itself was verified rather than assumed: `signups` descending returns `42, 41, 41, 27, 23, 19, 17, 14, 13, 12` — monotonic. Ranking by a **rate** puts `null` first, since null sorts before numbers, and the tool does not filter those rows out: that would silently answer a different question than the one asked, so it is documented and pinned by a test instead.

## Verification

- **391 tests** (was 358), green on both the `engines` floor (22) and `.nvmrc` (24.19.0)
- every test watched failing first, then **six mutations**: enum guard dropped from `order_by`, a date window sent anyway, page size reported as the archive total, default direction flipped to ascending, null-valued rows filtered out, sort no longer echoed in the result. All six caught.
- one of the landing checks was itself wrong — a `grep -c` miscount on a token that appears twice in the file reported "DID NOT LAND" while the mutation had in fact applied. That is exactly the trap `CLAUDE.md` warns about, so it was redone with the mutated region printed as proof.
- stdio probe: 8 tools, `get_post_stats` publishes all 43 sort fields, `get_analytics` is down to 16 reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)