### PR TITLE
Give the post body a validated contract, and a tool that publishes it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,59 @@ so none of it ships without a live check first; they are open by choice, not by 
 where there is one. Nothing in this server can unpublish, delete a comment or undo a restack, so that
 line is the only record that it happened.
 
+**The post body has a contract, and `set_post_body` is where it lives.** `src/api/substack/document.js`
+models the ProseMirror document in zod — a discriminated union over the fifteen node types observed in
+the live archive, published as that tool's JSON Schema so a calling model reads the vocabulary from
+`tools/list` instead of guessing. It is the only tool that publishes it: at 20 KB, carrying it on
+`create_draft_post` and `update_draft` too would more than double a `tools/list` that is 56 KB with one
+copy. `create_draft_post`'s JSON branch runs the **same validator without publishing it**, which cost
+nothing and closed the last route that accepted a body unchecked. Six measured facts shape it:
+
+- **The code block is `highlighted_code_block`.** `python-substack` declares `codeBlock`, which is not
+  what the editor writes and does not render. Both that and the legacy `code_block` are accepted —
+  16 occurrences against 5 in the survey, so refusing the old one would refuse those posts.
+- **`order` numbers a list, not `start`.** A list given `{start: 3}` is stored verbatim, answers 200 and
+  renders from **1**; `{order: 3}` renders from 3. The editor writes both, so reading its own output
+  suggests either would do — this is the **sixth** silent-ignore in this API and the only one this
+  server nearly authored itself.
+- **`type` is strict, `attrs` are loose**, in opposite directions on purpose. The editor writes
+  `textAlign: null` on every block and `nodeId: null` on code blocks, so strict attrs would reject every
+  real post; the discriminated union on `type` is what produces `Invalid discriminator value. Expected
+  'paragraph' | 'heading' | …`, the only repair instruction an LLM gets. **A generic unknown-node branch
+  was tried and rejected**: it keeps a malformed `heading` out but reports only the generic branch's
+  error, so the caller never learns which field is wrong. Every observed type is enumerated instead,
+  including three whose internals were never read — `digestPostEmbed`, `substack_mentions`,
+  `directMessage` — as `looseObject`s that survive a round trip whole. `digestPostEmbed` alone is in 59
+  of 60 sampled posts, so this is what makes read-modify-write possible at all.
+- **Survey both publications before trusting the enumeration.** The first pass covered `implementing`
+  only and missed `youtube2`, which is in 33 of 40 sampled `quickviewai` posts — `{videoId}`, no content.
+  22 real posts across both now validate with no unknown node, no unknown mark and every required attr
+  present.
+- **A document may carry one `paywall`, and we are the only ones enforcing it.** Two are accepted with a
+  200 and rendered as two "Paid content below this line" markers, leaving it undefined which one cuts
+  the post. Since a `.refine()` does **not** survive into the published JSON Schema, the rule is repeated
+  in the node's description or a model meets it only by failing.
+- **The code-block `language` is a closed set that fails silently.** `auto` is the auto-detect sentinel,
+  `plaintext` the plain-text value, and an unrecognised name renders as Plain Text with no error, so
+  omitting the attr beats guessing.
+
+**Images can be referenced but not uploaded**, which is the contract's sharpest limit: `captionedImage`
+is in 60 of 60 sampled posts and `image2.src` must already point at a Substack-hosted asset.
+`POST /api/v1/image` was tried on the publication host as JSON, as form-urlencoded and as multipart —
+**all three hang**, the network log showing the request pending past a minute with no response, and the
+cross-origin `substack.com` attempt never settled either. So neither `python-substack`'s signature nor
+the fork's is confirmed. **Do not implement an upload from either.**
+
+**`set_post_body` returns a node tally, not `'OK'`**, because validation cannot report what was never
+sent: a document with no paywall is exactly as valid as one with a paywall. This was measured — a model
+asked for a paywall through a Markdown contract omitted it, produced valid Markdown, and the document it
+rendered to passes this very schema. The tally is the caller's only way to see what landed.
+
+**The descriptions are load-bearing and a test enforces them.** The published schema is the vocabulary,
+so `document.spec.js` walks the whole converted schema and fails on any union branch without a
+`description`, naming it. The walk is recursive on purpose: `list_item`, `image2` and `caption` are
+reachable only nested, and an earlier top-level-only version left stripping every mark description green.
+
 ## Logging
 
 **Everything must be logged well enough to debug a session from the log alone**, because the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,18 @@ browser download, a broken Docker image, and a technique that breaks on Cloudfla
 Also skipped: `update_payment_settings` (paywall pricing from an LLM), deleting *published* posts,
 and a hand-maintained `list_resources` catalog — a second tool list that can drift from `tools/list`.
 
+**The forks are exhausted, and a re-survey costs more than it returns.** All eight were compared
+against `main` again on 2026-08-07, after #18: five are zero-commit snapshots, `adamhwoodworth`'s
+`fix-draft-body-double-encoding` is already merged as #4 (its two residual commits carry a `parseBody`
+test this repo has in English *plus* the logging assertions), and `jcllobet`'s reader work went in
+with #18. Only `jefflee1990710` still holds anything, and it is one coherent area rather than a list:
+**account and publication settings** — `PUT /api/v1/publication` (`name`, `hero_text`, `copyright`,
+`email_from_name`, `logo_url`), `PUT substack.com/api/v1/user/profile` (`name`, `bio`, `photo_url`),
+and the `POST substack.com/api/v1/image` upload both depend on, since per the fork an external url is
+stored but does not render. That upload is also the only route to an image *inside* a post, which
+nothing here can do. All three are unverified writes from the fork that invented `share_automatically`,
+so none of it ships without a live check first; they are open by choice, not by oversight.
+
 **Writes log their intent at `info` *before* the request**, not only their outcome —
 `publish_draft.publishing`, `comment_on_post.posting`, `restack_item.restacking`, with the full text
 where there is one. Nothing in this server can unpublish, delete a comment or undo a restack, so that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ line is the only record that it happened.
 **The post body has a contract, and `set_post_body` is where it lives.** `src/api/substack/document.js`
 models the ProseMirror document in zod — a discriminated union over the fifteen node types observed in
 the live archive, published as that tool's JSON Schema so a calling model reads the vocabulary from
-`tools/list` instead of guessing. It is the only tool that publishes it: at 20 KB, carrying it on
+`tools/list` instead of guessing. It is the only tool that publishes it: at roughly 21 KB, carrying it on
 `create_draft_post` and `update_draft` too would more than double a `tools/list` that is 56 KB with one
 copy. `create_draft_post`'s JSON branch runs the **same validator without publishing it**, which cost
 nothing and closed the last route that accepted a body unchecked. Six measured facts shape it:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@ A Model Context Protocol (MCP) Server for [Substack](https://substack.com) enabl
 **Inputs**:
 - `title` (string): Title of the post
 - `subtitle` (string): Subtitle of the post
-- `body` (string): Body of the post
+- `body` (string): Body of the post. Plain text becomes one paragraph per line — **Markdown is not
+  interpreted**, so `## Heading` arrives literally. A JSON string of a Substack document also works
+  and is validated against the same schema `set_post_body` publishes, so an unrecognised node name
+  is an error rather than a silently mangled post.
 
 **Returns**: `{draft_id, is_published}`. Pass `draft_id` to `get_draft` to read the draft back.
+
+For anything structured — headings, lists, links, code, images, a paywall — use `set_post_body`
+after creating the draft: the schema is published there, so the calling model can read the node
+vocabulary rather than guess at it.
 </details>
 
 <details>
@@ -109,6 +116,36 @@ There is no paging: an export covers the whole matching set.
 - `draft_id` (number): the id returned by `list_posts` or `create_draft_post`
 
 **Returns**: the draft as Substack stores it, body and audience/email settings included.
+</details>
+
+<details>
+<summary><strong>set_post_body</strong> - Replace a draft's body with a structured document</summary>
+
+The only way to write structured content: headings, lists, links, code blocks, quotes, images,
+buttons and a paywall. `create_draft_post` takes plain text; this takes the document Substack
+actually stores, and its schema is published in `tools/list` so the calling model can read the node
+vocabulary instead of guessing.
+
+**Inputs**:
+- `draft_id` (number): the id returned by `list_posts` or `create_draft_post`
+- `body` (object): a Substack ProseMirror document — `{type: 'doc', content: [...]}`
+
+Fifteen node types are accepted: `paragraph`, `heading`, `bullet_list`, `ordered_list`, `list_item`,
+`blockquote`, `highlighted_code_block`, `code_block`, `horizontal_rule`, `captionedImage`, `button`,
+`paywall`, `youtube2`, plus `digestPostEmbed`, `substack_mentions` and `directMessage` passed through
+unchanged so a document read with `get_draft` can be written back. Marks: `strong`, `em`, `code`,
+`strikethrough`, `link`.
+
+**Returns**: `{draft_id, nodes}`, where `nodes` counts what was stored by type — so a caller that
+asked for a paywall can confirm there is one. Validation cannot report a node that was never sent.
+
+Three things worth knowing:
+- **An image must already be hosted by Substack.** `image2.src` pointing at an external URL is
+  stored but does not render, and this server cannot upload one.
+- **A document may contain at most one `paywall`.** Substack accepts two and renders both, leaving
+  it undefined which one cuts the post, so this tool refuses the second.
+- **`ordered_list` numbers from `attrs.order`, not `attrs.start`.** A list given only `start`
+  renders from 1 with no error.
 </details>
 
 <details>

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -64,7 +64,7 @@ Create `src/api/substack/document.spec.js`:
 import {test, describe, before, after} from 'node:test';
 import assert from 'node:assert/strict';
 import {postBodySchema} from './document.js';
-import {setTestEnv} from '../../test/helpers/env.js';
+import {setTestEnv} from '../../../test/helpers/env.js';
 
 // setTestEnv is called even though this module reads no env var of its own: CLAUDE.md requires it
 // from every spec whose subject could log, and it keeps the reporter clean if that ever changes.
@@ -1035,7 +1035,7 @@ import {z} from 'zod';
 import {HttpResponse} from 'msw';
 import {setPostBodyHandler, setPostBodySchema} from './set_post_body.js';
 import {createMswServer, DRAFT_RESPONSE} from '../../test/helpers/msw-server.js';
-import {setTestEnv} from '../../test/helpers/env.js';
+import {setTestEnv} from '../../../test/helpers/env.js';
 import {captureLogs} from '../../test/helpers/capture-logs.js';
 
 const msw = createMswServer();

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -48,6 +48,16 @@ Baseline before you begin: 590 tests passing.
 
 `document.js` will end up around 200 lines and that is its whole job. Do not put the tool's logging or the API call in it.
 
+**Two conventions every node added in Tasks 2–4 must follow**, both established by the Task 1 review:
+
+- **Every node and mark carries a `.describe()`.** The schema is published as a tool's JSON Schema and
+  the descriptions are how a calling model learns the vocabulary — a node without one is invisible to
+  the caller. Task 1 adds a test that loops over every branch of the document union and asserts each
+  has a description, so a new node with no description **fails the suite**. That is deliberate.
+- **Pin what you add.** Before committing, mutate the thing you just wrote — swap a `strictObject` for
+  `z.object`, drop a required field, widen a bound — grep to confirm the mutation landed, and check a
+  test goes red. The Task 1 review found three surviving mutants in code that looked well tested.
+
 ---
 
 ## Task 1: The document module — marks, text, paragraph, heading
@@ -1471,6 +1481,10 @@ describe('set_post_body over the protocol', () => {
 
   // The recursion has to survive conversion, and draft-7 puts the shared shapes under `definitions`.
   // A $ref pointing at a definition that is not there would publish a schema no client can resolve.
+  //
+  // Asserting refs *exist* first is the point: the Task 1 reviewer found that with no recursion the
+  // schema contains zero $refs, so a loop over discovered refs passes while checking nothing. The
+  // recursive list and blockquote nodes are what put them there.
   test('publishes a self-contained schema, definitions included', async () => {
     const {client, close} = await connect();
 
@@ -1478,6 +1492,8 @@ describe('set_post_body over the protocol', () => {
       const {tools} = await client.listTools();
       const schema = tools.find(t => t.name === 'set_post_body').inputSchema;
       const refs = [...JSON.stringify(schema).matchAll(/"\$ref":"#\/definitions\/([^"]+)"/g)].map(m => m[1]);
+
+      assert.ok(refs.length > 0, 'the recursive nodes should produce at least one $ref');
 
       for (const ref of refs) {
         assert.ok(schema.definitions?.[ref], `definitions.${ref} should exist`);

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -363,7 +363,9 @@ Expected: a non-zero count — every new test fails on the discriminator, which 
 
 - [ ] **Step 3: Add the recursive nodes**
 
-In `src/api/substack/document.js`, insert after `headingNode` and before `postBodySchema`:
+In `src/api/substack/document.js`, insert after `headingNode` and before `postBodySchema`. Note the
+node-level `.describe()` on each: the description test from Task 1 loops over every branch of the
+document union, so a node without one fails the suite.
 
 ```js
 // Recursion through getters, which is how zod 4 expresses it. The unions here stay discriminated
@@ -375,25 +377,25 @@ const listItemNode = z.strictObject({
     return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode]))
       .describe('A paragraph, plus a nested list for sub-items.');
   },
-});
+}).describe('One item of a list. Its text goes in a paragraph, never directly in the item.');
 
 const bulletListNode = z.strictObject({
   type: z.literal('bullet_list'),
   attrs: looseAttrs.optional(),
   get content() { return z.array(listItemNode); },
-});
+}).describe('A bulleted list.');
 
 const orderedListNode = z.strictObject({
   type: z.literal('ordered_list'),
-  attrs: z.looseObject({start: z.number().int().optional()}).optional()
+  attrs: looseAttrs.extend({start: z.number().int().optional()}).optional()
     .describe('Omit unless the list starts somewhere other than 1.'),
   get content() { return z.array(listItemNode); },
-});
+}).describe('A numbered list.');
 
 const blockquoteNode = z.strictObject({
   type: z.literal('blockquote'),
   get content() { return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode])); },
-});
+}).describe('A quotation. Holds paragraphs and lists, not bare text.');
 ```
 
 Then extend the document's union:
@@ -417,9 +419,7 @@ Expected: all pass.
 
 - [ ] **Step 5: Prove the nesting test can fail**
 
-Make `list_item` accept only paragraphs, so the nested case breaks:
-
-Swap the marker `list_item` accepts, so the nested case breaks. Reversible in place — do **not** use
+Make `list_item` accept only paragraphs, so the nested case breaks. Reversible in place — do **not** use
 `git checkout` here, it would discard this task's uncommitted work:
 
 ```bash
@@ -528,7 +528,7 @@ const codeBlockNode = z.strictObject({
     ),
   }).optional(),
   content: inlineContent.describe('One text node holding the whole snippet, newlines included.'),
-});
+}).describe('A syntax-highlighted code block.');
 
 const legacyCodeBlockNode = z.strictObject({
   type: z.literal('code_block'),
@@ -536,7 +536,8 @@ const legacyCodeBlockNode = z.strictObject({
   content: inlineContent,
 }).describe('The older code block, still present in existing posts. Use highlighted_code_block for new content.');
 
-const horizontalRuleNode = z.strictObject({type: z.literal('horizontal_rule')});
+const horizontalRuleNode = z.strictObject({type: z.literal('horizontal_rule')})
+  .describe('A horizontal divider.');
 
 const paywallNode = z.strictObject({type: z.literal('paywall')})
   .describe('Everything after this node is for paying subscribers only. At most one per document.');

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -52,8 +52,11 @@ Baseline before you begin: 590 tests passing.
 
 - **Every node and mark carries a `.describe()`.** The schema is published as a tool's JSON Schema and
   the descriptions are how a calling model learns the vocabulary — a node without one is invisible to
-  the caller. Task 1 adds a test that loops over every branch of the document union and asserts each
-  has a description, so a new node with no description **fails the suite**. That is deliberate.
+  the caller. Task 1 adds a test that walks the whole converted schema and asserts every branch of
+  every union, **nested ones included**, carries a description; a new node without one **fails the
+  suite** and is named in the assertion. That is deliberate, and the walk has to be recursive because
+  `list_item`, `image2` and `caption` are reachable only from inside another node, never as a
+  top-level branch.
 - **Pin what you add.** Before committing, mutate the thing you just wrote — swap a `strictObject` for
   `z.object`, drop a required field, widen a bound — grep to confirm the mutation landed, and check a
   test goes red. The Task 1 review found three surviving mutants in code that looked well tested.
@@ -364,8 +367,8 @@ Expected: a non-zero count — every new test fails on the discriminator, which 
 - [ ] **Step 3: Add the recursive nodes**
 
 In `src/api/substack/document.js`, insert after `headingNode` and before `postBodySchema`. Note the
-node-level `.describe()` on each: the description test from Task 1 loops over every branch of the
-document union, so a node without one fails the suite.
+node-level `.describe()` on each: the description test from Task 1 walks every union in the converted
+schema, nested ones included, so a node without one fails the suite and gets named.
 
 ```js
 // Recursion through getters, which is how zod 4 expresses it. The unions here stay discriminated

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -1558,7 +1558,9 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
     timeout 5 node src/index.js 2>/dev/null | sed -n '2p' | wc -c
 ```
 
-Expected: roughly 50,000–52,000 bytes, up from 34,721. If it is materially larger, something is being published twice — check that `create_draft_post` did not gain the document schema.
+Expected: roughly 55,000 bytes, up from 34,721 — the document schema measures 20,342 bytes on its own
+once every node carries a description. If it is closer to 75,000, something is being published twice:
+check that `create_draft_post` did not gain the document schema.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -646,8 +646,18 @@ describe('postBodySchema — images, buttons and opaque nodes', () => {
     });
   }
 
+  // In 33 of 40 sampled posts on the second publication. Its absence would have blocked the round
+  // trip on most of that archive — which is what a survey of only one publication had missed.
+  test('accepts a youtube embed', () => {
+    assert.equal(parse(doc({type: 'youtube2', attrs: {videoId: '0chZFIZLR_0'}})).success, true);
+  });
+
+  test('rejects a youtube embed with no videoId', () => {
+    assert.equal(parse(doc({type: 'youtube2', attrs: {}})).success, false);
+  });
+
   test('rejects a node type outside the enumeration, naming the alternatives', () => {
-    const message = issues(doc({type: 'youtube2', attrs: {videoId: 'x'}})).join(' ');
+    const message = issues(doc({type: 'subscribeWidget', attrs: {}})).join(' ');
 
     assert.match(message, /Invalid discriminator value/);
     assert.match(message, /'captionedImage'/);
@@ -690,6 +700,14 @@ const buttonNode = z.strictObject({
   }),
 }).describe('A call-to-action button.');
 
+// Verified 2026-08-07 on the quickviewai publication, where it appears in 33 of 40 sampled posts:
+// exactly `{videoId}` and no content, identical in every occurrence. `SubstackPost.youtubeVideo()`
+// already builds this shape, so on this one node the existing builder was right.
+const youtubeNode = z.strictObject({
+  type: z.literal('youtube2'),
+  attrs: z.looseObject({videoId: z.string().describe('The YouTube video id, not the watch URL.')}),
+}).describe('An embedded YouTube video.');
+
 // A node whose internals were never read. `looseObject` keeps everything it carries — including its
 // content — so a round trip preserves it exactly, while claiming no knowledge we do not have.
 const opaqueNode = (type, description) =>
@@ -706,7 +724,7 @@ Extend the union to its final membership:
 ```js
     paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
     codeBlockNode, legacyCodeBlockNode, horizontalRuleNode, paywallNode,
-    captionedImageNode, buttonNode,
+    captionedImageNode, buttonNode, youtubeNode,
     digestPostEmbedNode, substackMentionsNode, directMessageNode,
 ```
 
@@ -1610,8 +1628,9 @@ degrades to Plain Text without an error.
 `get_draft` on a **real published post**, `JSON.parse` its `draft_body`, and feed that straight back
 through `set_post_body` on the scratch draft. It must validate untouched.
 
-Do this for **at least five** posts from different points in the archive, not one: the enumeration came
-from a survey, and one post exercises one subset of it. A post using a node the union does not list
+Do this for **at least five** posts from each of the two publications — `implementing` and
+`quickviewai` — not five in total. The enumeration came from a survey, and surveying only the first
+publication is exactly what missed `youtube2`, which turned out to be in 33 of 40 posts on the second. A post using a node the union does not list
 fails loudly and names the alternatives — that is the designed behaviour, and the fix is to read that
 node's shape off a live draft and add it, never to loosen the union.
 
@@ -1700,6 +1719,8 @@ Use `superpowers:finishing-a-development-branch` to decide how this integrates.
 
 **The open item, carried from the spec:** the code-block language table. `auto` and `plaintext` are confirmed sentinels and the values are lowercase highlight.js names, but the full label-to-value mapping has to be lifted from the editor bundle (`grep` the loaded chunks for `plaintext` — the list is a `{value, label}` array near the "Auto-detect" string) rather than guessed. Until then the schema's description names the common ones and says omitting beats guessing, which is correct and honest; do not invent the rest.
 
-**Do not add** `youtube2`, `subscribeWidget`, `latex`, `footnote`, `poll`, `poetry`, `calloutBlock` or `pullquote` to the union in this plan. The first six exist as names in the editor's "More" menu but their shapes were never read; the last two come only from `python-substack`, the same file that was wrong about `codeBlock`, and do not appear in that menu at all. Each is a later addition after its shape is read off a live draft. A node outside the enumeration fails loudly and names the alternatives, which is the correct behaviour in the meantime.
+**Do not add** `subscribeWidget`, `latex`, `footnote`, `poll`, `poetry`, `calloutBlock` or `pullquote` to the union in this plan. The first five exist as names in the editor's "More" menu but their shapes were never read; the last two come only from `python-substack`, the same file that was wrong about `codeBlock`, and do not appear in that menu at all. Each is a later addition after its shape is read off a live draft. A node outside the enumeration fails loudly and names the alternatives, which is the correct behaviour in the meantime.
+
+`youtube2` **is** in the union, and how it got there is the cautionary tale: the first survey covered one publication and missed it, while it appears in 33 of 40 sampled posts on the second. If a third publication is ever added, survey it before trusting this enumeration.
 
 **`SubstackPost.js` already has a builder** — `paywall()`, `shareButton()`, `customButton()`, `captionedImage()`, `subscribeWithCaption()` — that no tool reaches. This plan does not use it and does not delete it. Its index-based mutation (`content[length - 1]`) cannot express nesting, which is why the schema route exists; removing it is a separate decision.

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -1035,7 +1035,7 @@ import {z} from 'zod';
 import {HttpResponse} from 'msw';
 import {setPostBodyHandler, setPostBodySchema} from './set_post_body.js';
 import {createMswServer, DRAFT_RESPONSE} from '../../test/helpers/msw-server.js';
-import {setTestEnv} from '../../../test/helpers/env.js';
+import {setTestEnv} from '../../test/helpers/env.js';
 import {captureLogs} from '../../test/helpers/capture-logs.js';
 
 const msw = createMswServer();

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -1,0 +1,1705 @@
+# Validated Post Body Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Substack post body a real contract — a zod-modelled ProseMirror document, published as a tool's own JSON Schema and validated on the way in — so a wrong node name is an error instead of a silently mangled post.
+
+**Architecture:** One new pure module, `src/api/substack/document.js`, holds the schema (a discriminated union over every node type observed in the live archive, with permissive `attrs`) plus a node tally. One new tool, `set_post_body`, publishes that schema and PUTs `draft_body`. `create_draft_post`'s existing JSON branch — today forwarded unvalidated — starts using the same validator without publishing the schema, so it costs nothing and protects fully.
+
+**Tech Stack:** Node 24 for development / Node 22 floor (`src/` must use nothing newer than 22 offers), ESM, zod 4.4.3, `@modelcontextprotocol/sdk` 1.30.0, `node:test` + `node:assert/strict`, MSW for HTTP mocking.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-post-body-contract-design.md`
+
+---
+
+## Before you start
+
+Read `CLAUDE.md` in full. The conventions it sets are not optional here, and three matter constantly:
+
+- **Everything in the repository is written in English** — code, comments, test names, commit messages. The chat language does not change this.
+- **Style:** two-space indent, semicolons, single quotes in code (double in imports), compact object literals (`{a: 1}` not `{ a: 1 }`).
+- **Tool schemas are `z.strictObject`, never `z.object`.** The validation message is the only feedback an LLM gets to repair a call.
+
+**Test output shape depends on the Node version.** On 24 it is the spec reporter (`ℹ pass`, failures `✖`); on the 22 floor it is TAP (`# pass`, failures `not ok`). Grep for both or a green run reads as a broken command:
+
+```bash
+npm test 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+**A new test that passes on the first run has proven nothing.** Every task below has a step that breaks the source on purpose and confirms the test goes red. Grep the file for a marker first to check the mutation actually landed — a `sed` regex that fails to match leaves the file untouched and reads exactly like a test asserting nothing.
+
+Baseline before you begin: 590 tests passing.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/api/substack/document.js` | **Create.** The post-body schema and `summarizeNodes`. Pure: no I/O, no env reads, no logging. Sits beside `csv.js` for the same reason — one bounded translation with its own colocated spec. |
+| `src/api/substack/document.spec.js` | **Create.** Schema behaviour: every node, every mark, the paywall cap, error-message wording, the tally. |
+| `src/tools/set_post_body.js` | **Create.** The tool: validates, PUTs `draft_body`, returns the tally. |
+| `src/tools/set_post_body.spec.js` | **Create.** Tool behaviour against MSW. |
+| `src/server.js` | **Modify.** One import and one registry entry. |
+| `src/tools/create_draft_post.js` | **Modify.** Its JSON branch calls the shared validator. |
+| `src/tools/create_draft_post.spec.js` | **Modify.** Rewrite the characterization test that pins unvalidated passthrough. |
+| `src/server.spec.js` | **Modify.** Assert `set_post_body` is registered and publishes a usable schema. |
+| `CLAUDE.md` | **Modify.** Record the contract and the measured facts behind it. |
+
+`document.js` will end up around 200 lines and that is its whole job. Do not put the tool's logging or the API call in it.
+
+---
+
+## Task 1: The document module — marks, text, paragraph, heading
+
+**Files:**
+- Create: `src/api/substack/document.js`
+- Create: `src/api/substack/document.spec.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/api/substack/document.spec.js`:
+
+```js
+import {test, describe, before, after} from 'node:test';
+import assert from 'node:assert/strict';
+import {postBodySchema} from './document.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+
+// setTestEnv is called even though this module reads no env var of its own: CLAUDE.md requires it
+// from every spec whose subject could log, and it keeps the reporter clean if that ever changes.
+let restoreEnv;
+before(() => { restoreEnv = setTestEnv(); });
+after(() => restoreEnv());
+
+const doc = (...content) => ({type: 'doc', content});
+const text = (value) => ({type: 'text', text: value});
+const parse = (value) => postBodySchema.safeParse(value);
+const issues = (value) => parse(value).error.issues.map(i => `${i.path.join('.')}: ${i.message}`);
+
+describe('postBodySchema — paragraphs and text', () => {
+  test('accepts an empty document', () => {
+    assert.equal(parse(doc()).success, true);
+  });
+
+  test('accepts a paragraph of plain text', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [text('hello')]})).success, true);
+  });
+
+  test('accepts a paragraph with no content at all', () => {
+    assert.equal(parse(doc({type: 'paragraph'})).success, true);
+  });
+
+  test('rejects a document whose type is not doc', () => {
+    assert.equal(parse({type: 'paragraph', content: []}).success, false);
+  });
+
+  // The editor writes attrs: {textAlign: null} on every paragraph and heading. A strictObject on
+  // attrs would reject every real post, so attrs are loose and unknown keys survive verbatim.
+  test('preserves attrs the schema does not model', () => {
+    const result = parse(doc({type: 'paragraph', attrs: {textAlign: null}, content: [text('x')]}));
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data.content[0].attrs, {textAlign: null});
+  });
+});
+
+describe('postBodySchema — marks', () => {
+  for (const type of ['strong', 'em', 'code', 'strikethrough']) {
+    test(`accepts the ${type} mark`, () => {
+      const node = {type: 'text', text: 'x', marks: [{type}]};
+
+      assert.equal(parse(doc({type: 'paragraph', content: [node]})).success, true);
+    });
+  }
+
+  test('accepts a link mark carrying an href', () => {
+    const node = {type: 'text', text: 'x', marks: [{type: 'link', attrs: {href: 'https://example.com'}}]};
+
+    assert.equal(parse(doc({type: 'paragraph', content: [node]})).success, true);
+  });
+
+  test('preserves the target and rel the editor adds to a link', () => {
+    const attrs = {href: 'https://example.com', target: '_blank', rel: 'noopener noreferrer nofollow'};
+    const result = parse(doc({type: 'paragraph', content: [{type: 'text', text: 'x', marks: [{type: 'link', attrs}]}]}));
+
+    assert.deepEqual(result.data.content[0].content[0].marks[0].attrs, attrs);
+  });
+
+  test('rejects a link mark with no href, naming the missing attrs', () => {
+    const node = {type: 'text', text: 'x', marks: [{type: 'link'}]};
+
+    assert.match(issues(doc({type: 'paragraph', content: [node]})).join(' '), /marks\.0\.attrs/);
+  });
+
+  // A mark is not a node. A model that emits {type: 'strong'} where a text node belongs gets told so.
+  test('rejects a mark used as a node', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [{type: 'strong', text: 'x'}]})).success, false);
+  });
+});
+
+describe('postBodySchema — headings', () => {
+  test('accepts levels 1 to 6', () => {
+    for (let level = 1; level <= 6; level++) {
+      assert.equal(parse(doc({type: 'heading', attrs: {level}, content: [text('T')]})).success, true, `level ${level}`);
+    }
+  });
+
+  test('rejects level 7', () => {
+    assert.equal(parse(doc({type: 'heading', attrs: {level: 7}, content: [text('T')]})).success, false);
+  });
+
+  test('rejects a heading with no level', () => {
+    assert.match(issues(doc({type: 'heading', content: [text('T')]})).join(' '), /attrs/);
+  });
+
+  // The whole reason the union is discriminated rather than a plain z.union: the message names the
+  // alternatives, which is a repair instruction rather than a complaint.
+  test('names the valid node types when the type is unrecognised', () => {
+    const message = issues(doc({type: 'codeBlock', content: []})).join(' ');
+
+    assert.match(message, /Invalid discriminator value/);
+    assert.match(message, /'paragraph'/);
+    assert.match(message, /'heading'/);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | tail -20
+```
+
+Expected: failure resolving `./document.js` — `Cannot find module`.
+
+- [ ] **Step 3: Write the module**
+
+Create `src/api/substack/document.js`:
+
+```js
+import {z} from "zod";
+
+// The Substack post body, as a ProseMirror document.
+//
+// Every node name and attr shape here was read off a live draft or a live published post on
+// 2026-08-07, never taken from a third-party client — `python-substack` declares the code block as
+// `codeBlock`, which Substack does not render. See the design spec for the survey behind the
+// enumeration: 60 published posts, every node type in use counted.
+//
+// Two rules govern how strict this is, and they pull in opposite directions on purpose:
+//
+//  - `type` is strict. It is a discriminated union so an unrecognised node is rejected with the
+//    valid alternatives named, which is the only feedback an LLM gets to repair the call.
+//  - `attrs` are loose. The editor writes `textAlign: null` on paragraphs and headings and
+//    `nodeId: null` on code blocks; rejecting those would reject every real post and kill any
+//    read-modify-write flow. Required attrs still guard, so a heading without `level` fails.
+
+const looseAttrs = z.looseObject({});
+
+const markSchema = z.discriminatedUnion('type', [
+  z.strictObject({type: z.literal('strong')}).describe('Bold.'),
+  z.strictObject({type: z.literal('em')}).describe('Italic.'),
+  z.strictObject({type: z.literal('code')}).describe('Inline code, for a short literal inside a sentence.'),
+  z.strictObject({type: z.literal('strikethrough')}).describe('Struck through.'),
+  z.strictObject({
+    type: z.literal('link'),
+    attrs: z.looseObject({href: z.string().describe('Absolute URL.')}),
+  }).describe('A link. The visible words are the text node this mark is applied to.'),
+]).describe('An inline mark applied to a text node. A mark is never a node in its own right.');
+
+const textNode = z.strictObject({
+  type: z.literal('text'),
+  text: z.string(),
+  marks: z.array(markSchema).optional().describe('Omit when the text is plain. Marks may combine.'),
+}).describe('A run of text. Split a sentence into several text nodes to mark only part of it.');
+
+const hardBreakNode = z.strictObject({type: z.literal('hard_break')})
+  .describe('A line break inside a paragraph. Prefer separate paragraphs.');
+
+const inlineContent = z.array(z.discriminatedUnion('type', [textNode, hardBreakNode]));
+
+const paragraphNode = z.strictObject({
+  type: z.literal('paragraph'),
+  attrs: looseAttrs.optional(),
+  content: inlineContent.optional().describe('Omit for an empty paragraph.'),
+});
+
+const headingNode = z.strictObject({
+  type: z.literal('heading'),
+  attrs: z.looseObject({level: z.number().int().min(1).max(6)}),
+  content: inlineContent,
+});
+
+export const postBodySchema = z.strictObject({
+  type: z.literal('doc'),
+  content: z.array(z.discriminatedUnion('type', [paragraphNode, headingNode])),
+}).describe('The post body as a Substack ProseMirror document.');
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: all pass, 0 fail.
+
+- [ ] **Step 5: Prove the tests can fail**
+
+Loosen `type` from a discriminated union to a plain union, which is the mistake this design rejected:
+
+```bash
+grep -c "discriminatedUnion('type', \[paragraphNode, headingNode\])" src/api/substack/document.js
+```
+
+Expected: `1`. Now mutate and re-run:
+
+```bash
+perl -0pi -e "s/z\.discriminatedUnion\('type', \[paragraphNode, headingNode\]\)/z.union([paragraphNode, headingNode])/" src/api/substack/document.js
+grep -c "z.union(\[paragraphNode, headingNode\])" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: the grep prints `1` (the mutation landed) and the test named "names the valid node types when the type is unrecognised" fails. Restore:
+
+```bash
+perl -0pi -e "s/z\.union\(\[paragraphNode, headingNode\]\)/z.discriminatedUnion('type', [paragraphNode, headingNode])/" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)'
+```
+
+Expected: green again.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/substack/document.js src/api/substack/document.spec.js
+git commit -m "Add the post body document schema: marks, text, paragraphs, headings"
+```
+
+---
+
+## Task 2: Lists and blockquotes
+
+**Files:**
+- Modify: `src/api/substack/document.js`
+- Modify: `src/api/substack/document.spec.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api/substack/document.spec.js`:
+
+```js
+describe('postBodySchema — lists and quotes', () => {
+  const item = (value) => ({type: 'list_item', content: [{type: 'paragraph', content: [text(value)]}]});
+
+  test('accepts a bulleted list', () => {
+    assert.equal(parse(doc({type: 'bullet_list', content: [item('one'), item('two')]})).success, true);
+  });
+
+  test('accepts a numbered list', () => {
+    assert.equal(parse(doc({type: 'ordered_list', content: [item('one')]})).success, true);
+  });
+
+  test('accepts the start attr the editor writes', () => {
+    const list = {type: 'ordered_list', attrs: {start: 3, type: null, order: 1}, content: [item('three')]};
+    const result = parse(doc(list));
+
+    assert.equal(result.success, true);
+    assert.equal(result.data.content[0].attrs.start, 3);
+  });
+
+  test('accepts a list nested inside a list item', () => {
+    const nested = {
+      type: 'list_item',
+      content: [
+        {type: 'paragraph', content: [text('outer')]},
+        {type: 'bullet_list', content: [item('inner')]},
+      ],
+    };
+
+    assert.equal(parse(doc({type: 'bullet_list', content: [nested]})).success, true);
+  });
+
+  test('rejects a list item outside a list', () => {
+    assert.equal(parse(doc(item('stray'))).success, false);
+  });
+
+  test('rejects bare text directly inside a list item', () => {
+    assert.equal(parse(doc({type: 'bullet_list', content: [{type: 'list_item', content: [text('x')]}]})).success, false);
+  });
+
+  test('accepts a blockquote of paragraphs', () => {
+    const quote = {type: 'blockquote', content: [{type: 'paragraph', content: [text('quoted')]}]};
+
+    assert.equal(parse(doc(quote)).success, true);
+  });
+
+  test('accepts a blockquote containing a list', () => {
+    const quote = {type: 'blockquote', content: [{type: 'bullet_list', content: [item('one')]}]};
+
+    assert.equal(parse(doc(quote)).success, true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -cE '^(not ok|✖)'
+```
+
+Expected: a non-zero count — every new test fails on the discriminator, which does not yet list `bullet_list`.
+
+- [ ] **Step 3: Add the recursive nodes**
+
+In `src/api/substack/document.js`, insert after `headingNode` and before `postBodySchema`:
+
+```js
+// Recursion through getters, which is how zod 4 expresses it. The unions here stay discriminated
+// even though it is more awkward than a plain union: a plain one reports no usable message, and
+// this was measured rather than assumed.
+const listItemNode = z.strictObject({
+  type: z.literal('list_item'),
+  get content() {
+    return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode]))
+      .describe('A paragraph, plus a nested list for sub-items.');
+  },
+});
+
+const bulletListNode = z.strictObject({
+  type: z.literal('bullet_list'),
+  attrs: looseAttrs.optional(),
+  get content() { return z.array(listItemNode); },
+});
+
+const orderedListNode = z.strictObject({
+  type: z.literal('ordered_list'),
+  attrs: z.looseObject({start: z.number().int().optional()}).optional()
+    .describe('Omit unless the list starts somewhere other than 1.'),
+  get content() { return z.array(listItemNode); },
+});
+
+const blockquoteNode = z.strictObject({
+  type: z.literal('blockquote'),
+  get content() { return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode])); },
+});
+```
+
+Then extend the document's union:
+
+```js
+export const postBodySchema = z.strictObject({
+  type: z.literal('doc'),
+  content: z.array(z.discriminatedUnion('type', [
+    paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
+  ])),
+}).describe('The post body as a Substack ProseMirror document.');
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Prove the nesting test can fail**
+
+Make `list_item` accept only paragraphs, so the nested case breaks:
+
+Swap the marker `list_item` accepts, so the nested case breaks. Reversible in place — do **not** use
+`git checkout` here, it would discard this task's uncommitted work:
+
+```bash
+grep -c "paragraphNode, bulletListNode, orderedListNode" src/api/substack/document.js
+perl -pi -e "s/\[paragraphNode, bulletListNode, orderedListNode\]\)\)/[paragraphNode])) \/*MUT*\//" src/api/substack/document.js
+grep -c "MUT" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: the `MUT` grep prints a non-zero count (the mutation landed) and both "accepts a list
+nested inside a list item" and "accepts a blockquote containing a list" fail. Restore:
+
+```bash
+perl -pi -e "s/\[paragraphNode\]\)\) \/\*MUT\*\//[paragraphNode, bulletListNode, orderedListNode]))/" src/api/substack/document.js
+grep -c "MUT" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)'
+```
+
+Expected: `0` markers left and a green run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/substack/document.js src/api/substack/document.spec.js
+git commit -m "Model lists and blockquotes, recursively"
+```
+
+---
+
+## Task 3: Code blocks, rule, and the paywall cap
+
+**Files:**
+- Modify: `src/api/substack/document.js`
+- Modify: `src/api/substack/document.spec.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api/substack/document.spec.js`:
+
+```js
+describe('postBodySchema — code, rules and the paywall', () => {
+  const code = (attrs) => ({type: 'highlighted_code_block', ...(attrs ? {attrs} : {}), content: [text('const a = 1;')]});
+
+  test('accepts a code block with a language', () => {
+    assert.equal(parse(doc(code({language: 'javascript'}))).success, true);
+  });
+
+  test('accepts a code block with no language, which auto-detects', () => {
+    assert.equal(parse(doc(code())).success, true);
+  });
+
+  test('preserves the nodeId the editor writes', () => {
+    const result = parse(doc(code({language: 'python', nodeId: null})));
+
+    assert.deepEqual(result.data.content[0].attrs, {language: 'python', nodeId: null});
+  });
+
+  // Both node names are in live use: older posts carry code_block, the current editor writes
+  // highlighted_code_block. Rejecting the legacy one would reject those posts.
+  test('accepts the legacy code_block', () => {
+    assert.equal(parse(doc({type: 'code_block', content: [text('legacy')]})).success, true);
+  });
+
+  test('accepts a horizontal rule', () => {
+    assert.equal(parse(doc({type: 'horizontal_rule'})).success, true);
+  });
+
+  test('accepts a single paywall', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [text('free')]}, {type: 'paywall'})).success, true);
+  });
+
+  // Measured 2026-08-07: two paywalls are accepted by the API with a 200 and rendered by the editor
+  // as two "Paid content below this line" markers, so which one cuts the post is undefined. Neither
+  // the API nor the editor guards this; this refinement is the only check that exists.
+  test('rejects a second paywall', () => {
+    const result = parse(doc({type: 'paywall'}, {type: 'paragraph'}, {type: 'paywall'}));
+
+    assert.equal(result.success, false);
+    assert.match(result.error.issues.map(i => i.message).join(' '), /at most one paywall/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -cE '^(not ok|✖)'
+```
+
+Expected: non-zero.
+
+- [ ] **Step 3: Add the nodes and the refinement**
+
+Insert after `blockquoteNode`:
+
+```js
+// `highlighted_code_block`, not `codeBlock`: read off the live editor. `python-substack` declares
+// the latter, and a node by that name is not rendered.
+const codeBlockNode = z.strictObject({
+  type: z.literal('highlighted_code_block'),
+  attrs: z.looseObject({
+    language: z.string().optional().describe(
+      'Lowercase highlight.js name — javascript, typescript, python, bash, json, sql, go, rust, ' +
+      'yaml, css, html and similar. Omit to let Substack auto-detect. An unrecognised value is ' +
+      'accepted and then silently rendered as plain text, so omitting beats guessing.'
+    ),
+  }).optional(),
+  content: inlineContent.describe('One text node holding the whole snippet, newlines included.'),
+});
+
+const legacyCodeBlockNode = z.strictObject({
+  type: z.literal('code_block'),
+  attrs: looseAttrs.optional(),
+  content: inlineContent,
+}).describe('The older code block, still present in existing posts. Use highlighted_code_block for new content.');
+
+const horizontalRuleNode = z.strictObject({type: z.literal('horizontal_rule')});
+
+const paywallNode = z.strictObject({type: z.literal('paywall')})
+  .describe('Everything after this node is for paying subscribers only. At most one per document.');
+```
+
+Extend the union and wrap the document in the refinement:
+
+```js
+export const postBodySchema = z.strictObject({
+  type: z.literal('doc'),
+  content: z.array(z.discriminatedUnion('type', [
+    paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
+    codeBlockNode, legacyCodeBlockNode, horizontalRuleNode, paywallNode,
+  ])),
+})
+  .describe('The post body as a Substack ProseMirror document.')
+  // A refinement does not survive into the published JSON Schema — verified — which is why the rule
+  // is also written into paywallNode's description. Without that a model would meet it by failing.
+  .refine(
+    (document) => document.content.filter((node) => node.type === 'paywall').length <= 1,
+    {message: 'A document may contain at most one paywall node.', path: ['content']}
+  );
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Prove the paywall cap can fail**
+
+```bash
+grep -c "length <= 1" src/api/substack/document.js
+perl -pi -e "s/length <= 1/length <= 2/" src/api/substack/document.js
+grep -c "length <= 2" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: the second grep prints `1` and "rejects a second paywall" fails. Restore:
+
+```bash
+perl -pi -e "s/length <= 2/length <= 1/" src/api/substack/document.js
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/substack/document.js src/api/substack/document.spec.js
+git commit -m "Model code blocks and rules, and cap the paywall at one"
+```
+
+---
+
+## Task 4: Images, buttons, and the three opaque nodes
+
+**Files:**
+- Modify: `src/api/substack/document.js`
+- Modify: `src/api/substack/document.spec.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api/substack/document.spec.js`:
+
+```js
+describe('postBodySchema — images, buttons and opaque nodes', () => {
+  const image = {type: 'image2', attrs: {src: 'https://substackcdn.com/image/fetch/x.png', alt: 'A board'}};
+
+  test('accepts an image inside a captionedImage', () => {
+    assert.equal(parse(doc({type: 'captionedImage', content: [image]})).success, true);
+  });
+
+  test('accepts a caption after the image', () => {
+    const caption = {type: 'caption', content: [text('One task per alert.')]};
+
+    assert.equal(parse(doc({type: 'captionedImage', content: [image, caption]})).success, true);
+  });
+
+  test('rejects an image2 outside a captionedImage', () => {
+    assert.equal(parse(doc(image)).success, false);
+  });
+
+  test('rejects an image with no src', () => {
+    const bare = {type: 'image2', attrs: {alt: 'nothing'}};
+
+    assert.match(parse(doc({type: 'captionedImage', content: [bare]})).error.issues.map(i => i.path.join('.')).join(' '), /attrs/);
+  });
+
+  test('preserves the many attrs the editor writes on an image', () => {
+    const rich = {type: 'image2', attrs: {src: 'https://x.dev/a.png', width: 1456, height: 819, belowTheFold: false}};
+    const result = parse(doc({type: 'captionedImage', content: [rich]}));
+
+    assert.equal(result.data.content[0].content[0].attrs.width, 1456);
+  });
+
+  test('accepts a button', () => {
+    const button = {type: 'button', attrs: {url: '%%checkout_url%%', text: 'Subscribe'}};
+
+    assert.equal(parse(doc(button)).success, true);
+  });
+
+  test('rejects a button with no text', () => {
+    assert.equal(parse(doc({type: 'button', attrs: {url: '%%checkout_url%%'}})).success, false);
+  });
+
+  // These three appear in the live archive — digestPostEmbed in 59 of 60 sampled posts — and their
+  // internals were never read. Accepted whole so a read-modify-write round trip preserves them.
+  for (const type of ['digestPostEmbed', 'substack_mentions', 'directMessage']) {
+    test(`accepts ${type} and preserves what it carries`, () => {
+      const node = {type, attrs: {id: 7}, content: [{type: 'anything', nested: true}]};
+      const result = parse(doc(node));
+
+      assert.equal(result.success, true);
+      assert.deepEqual(result.data.content[0], node);
+    });
+  }
+
+  test('rejects a node type outside the enumeration, naming the alternatives', () => {
+    const message = issues(doc({type: 'youtube2', attrs: {videoId: 'x'}})).join(' ');
+
+    assert.match(message, /Invalid discriminator value/);
+    assert.match(message, /'captionedImage'/);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -cE '^(not ok|✖)'
+```
+
+Expected: non-zero.
+
+- [ ] **Step 3: Add the nodes**
+
+Insert after `paywallNode`:
+
+```js
+const captionedImageNode = z.strictObject({
+  type: z.literal('captionedImage'),
+  content: z.array(z.discriminatedUnion('type', [
+    z.strictObject({
+      type: z.literal('image2'),
+      attrs: z.looseObject({
+        src: z.string().describe('Image URL. It must already be hosted by Substack — an external url is stored but does not render.'),
+        alt: z.string().nullable().optional(),
+      }),
+    }),
+    z.strictObject({type: z.literal('caption'), content: inlineContent.optional()}),
+  ])),
+}).describe('An image, optionally followed by a caption node.');
+
+const buttonNode = z.strictObject({
+  type: z.literal('button'),
+  attrs: z.looseObject({
+    url: z.string().describe('Target, or a Substack placeholder: %%checkout_url%% to subscribe, %%share_url%% to share.'),
+    text: z.string().describe('The button label.'),
+  }),
+}).describe('A call-to-action button.');
+
+// A node whose internals were never read. `looseObject` keeps everything it carries — including its
+// content — so a round trip preserves it exactly, while claiming no knowledge we do not have.
+const opaqueNode = (type, description) =>
+  z.looseObject({type: z.literal(type)}).describe(description);
+
+// Present in the live archive, internals never read.
+const digestPostEmbedNode = opaqueNode('digestPostEmbed', 'An embedded post card. Substack inserts this itself; pass it back unchanged.');
+const substackMentionsNode = opaqueNode('substack_mentions', 'A mention of another publication or user.');
+const directMessageNode = opaqueNode('directMessage', 'A direct-message block.');
+```
+
+Extend the union to its final membership:
+
+```js
+    paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
+    codeBlockNode, legacyCodeBlockNode, horizontalRuleNode, paywallNode,
+    captionedImageNode, buttonNode,
+    digestPostEmbedNode, substackMentionsNode, directMessageNode,
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Prove the opaque-node test can fail**
+
+Make `digestPostEmbed` strict, so it stops preserving what it carries:
+
+```bash
+grep -c "opaqueNode('digestPostEmbed'" src/api/substack/document.js
+perl -0pi -e "s/z\.looseObject\(\{type: z\.literal\(type\)\}\)\.describe\(description\)/z.strictObject({type: z.literal(type)}).describe(description)/" src/api/substack/document.js
+grep -c "z.strictObject({type: z.literal(type)})" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -4
+```
+
+Expected: the second grep prints `1` and the three "preserves what it carries" tests fail. Restore:
+
+```bash
+perl -0pi -e "s/z\.strictObject\(\{type: z\.literal\(type\)\}\)\.describe\(description\)/z.looseObject({type: z.literal(type)}).describe(description)/" src/api/substack/document.js
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/substack/document.js src/api/substack/document.spec.js
+git commit -m "Model images, buttons and the three opaque archive nodes"
+```
+
+---
+
+## Task 5: The node tally, and fixtures shaped like real documents
+
+**Files:**
+- Modify: `src/api/substack/document.js`
+- Modify: `src/api/substack/document.spec.js`
+
+Validation cannot report a paywall that was never sent — the head-to-head run produced a document that passes this schema with its paywall missing. The tally is what closes that gap: the caller sees what actually landed.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api/substack/document.spec.js`:
+
+```js
+describe('summarizeNodes', () => {
+  test('counts the node types in a flat document', () => {
+    const document = {type: 'doc', content: [
+      {type: 'paragraph', content: [text('a')]},
+      {type: 'paragraph', content: [text('b')]},
+      {type: 'horizontal_rule'},
+    ]};
+
+    assert.deepEqual(summarizeNodes(document), {paragraph: 2, horizontal_rule: 1});
+  });
+
+  test('counts nodes nested inside lists and quotes', () => {
+    const document = {type: 'doc', content: [{
+      type: 'bullet_list',
+      content: [{type: 'list_item', content: [{type: 'paragraph', content: [text('x')]}]}],
+    }]};
+
+    assert.deepEqual(summarizeNodes(document), {bullet_list: 1, list_item: 1, paragraph: 1});
+  });
+
+  // `text` is excluded on purpose: a tally dominated by hundreds of text runs buries the one number
+  // a caller is looking for, which is whether the paywall and the button are there.
+  test('does not count text or the doc itself', () => {
+    const summary = summarizeNodes({type: 'doc', content: [{type: 'paragraph', content: [text('a'), text('b')]}]});
+
+    assert.deepEqual(summary, {paragraph: 1});
+  });
+
+  test('counts a paywall so a caller can confirm it landed', () => {
+    const summary = summarizeNodes({type: 'doc', content: [{type: 'paywall'}]});
+
+    assert.deepEqual(summary, {paywall: 1});
+  });
+
+  test('returns an empty object for an empty document', () => {
+    assert.deepEqual(summarizeNodes({type: 'doc', content: []}), {});
+  });
+});
+```
+
+Add `summarizeNodes` to the import at the top of the spec:
+
+```js
+import {postBodySchema, summarizeNodes} from './document.js';
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: failures — `summarizeNodes is not a function`.
+
+- [ ] **Step 3: Implement it**
+
+Append to `src/api/substack/document.js`:
+
+```js
+/**
+ * Counts the nodes in a document by type, so a caller can confirm that what it asked for landed.
+ *
+ * Validation cannot do this job: a document with no paywall is as valid as one with a paywall, so
+ * legality has no opinion about an omission. `text` and `doc` are left out — a tally dominated by
+ * text runs buries the numbers that are actually being looked for.
+ */
+export const summarizeNodes = (document) => {
+  const counts = {};
+
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return;
+
+    if (typeof node.type === 'string' && node.type !== 'text' && node.type !== 'doc') {
+      counts[node.type] = (counts[node.type] ?? 0) + 1;
+    }
+
+    if (Array.isArray(node.content)) node.content.forEach(walk);
+  };
+
+  walk(document);
+  return counts;
+};
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Prove it can fail**
+
+```bash
+grep -c "node.type !== 'text'" src/api/substack/document.js
+perl -pi -e "s/node\.type !== 'text' && //" src/api/substack/document.js
+grep -c "node.type !== 'text'" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: the second grep prints `0` (the mutation landed) and "does not count text or the doc
+itself" fails. Restore in place — a `git checkout` would discard this task's uncommitted work:
+
+```bash
+perl -pi -e "s/node\.type !== 'doc'/node.type !== 'text' && node.type !== 'doc'/" src/api/substack/document.js
+grep -c "node.type !== 'text'" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)'
+```
+
+Expected: `1` and a green run.
+
+- [ ] **Step 6: Add the two fixtures the spec calls for**
+
+Unit tests built from the schema outwards prove the schema agrees with itself. These two prove it
+agrees with reality. Append to `src/api/substack/document.spec.js`:
+
+```js
+// Shaped like a real published post rather than like something a writer would compose: every
+// paragraph and heading carries attrs: {textAlign: null}, and the three nodes below appear in the
+// live archive — digestPostEmbed in 59 of 60 sampled posts. If this stops validating, the round trip
+// this contract exists to allow is broken, and no schema-first test would notice.
+const REAL_POST_SHAPE = {
+  type: 'doc',
+  content: [
+    {type: 'digestPostEmbed', attrs: {id: 210189950, publication_id: 2150088}},
+    {type: 'heading', attrs: {textAlign: null, level: 2}, content: [{type: 'text', text: 'A section'}]},
+    {type: 'paragraph', attrs: {textAlign: null}, content: [
+      {type: 'text', text: 'Prose with '},
+      {type: 'text', marks: [{type: 'strong'}], text: 'weight'},
+      {type: 'text', text: ' and a '},
+      {type: 'text', marks: [{type: 'link', attrs: {href: 'https://example.com', target: '_blank', rel: 'noopener noreferrer nofollow', class: null}}], text: 'link'},
+      {type: 'text', text: '.'},
+    ]},
+    {type: 'captionedImage', content: [
+      {type: 'image2', attrs: {src: 'https://substackcdn.com/image/fetch/x.png', srcNoWatermark: null, fullscreen: false, imageSize: 'normal', height: 819, width: 1456, resizeWidth: 728, bytes: null, alt: null, title: null, type: null, href: null, belowTheFold: false, topImage: false, internalRedirect: null, isProcessing: false, align: null, offset: false}},
+      {type: 'caption', content: [{type: 'text', text: 'A caption'}]},
+    ]},
+    {type: 'button', attrs: {url: '%%share_url%%', text: 'Share', action: null, class: 'button-wrapper'}},
+    {type: 'horizontal_rule'},
+    {type: 'code_block', content: [{type: 'text', text: 'legacy snippet'}]},
+    {type: 'substack_mentions', attrs: {publicationId: 2073698}},
+  ],
+};
+
+// The structural shapes a model actually produced when handed the published schema, kept so a later
+// tightening of the schema cannot quietly start rejecting documents that were known to work.
+const MODEL_AUTHORED_SHAPE = {
+  type: 'doc',
+  content: [
+    {type: 'ordered_list', attrs: {start: 3}, content: [
+      {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'three'}]}]},
+    ]},
+    {type: 'bullet_list', content: [
+      {type: 'list_item', content: [
+        {type: 'paragraph', content: [{type: 'text', text: 'context'}]},
+        {type: 'bullet_list', content: [
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'nested'}]}]},
+        ]},
+      ]},
+      {type: 'list_item', content: [{type: 'paragraph', content: [
+        {type: 'text', marks: [{type: 'link', attrs: {href: 'https://example.com/fixed'}}], text: 'a link in a list item'},
+      ]}]},
+    ]},
+    {type: 'blockquote', content: [
+      {type: 'bullet_list', content: [
+        {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'quoted item'}]}]},
+      ]},
+    ]},
+    {type: 'highlighted_code_block', attrs: {language: 'bash'}, content: [{type: 'text', text: 'set -euo pipefail'}]},
+  ],
+};
+
+describe('postBodySchema — real documents', () => {
+  test('accepts a document shaped like a real published post', () => {
+    const result = parse(REAL_POST_SHAPE);
+
+    assert.equal(result.success, true, result.success ? '' : JSON.stringify(result.error?.issues));
+  });
+
+  test('preserves the opaque archive nodes exactly', () => {
+    const result = parse(REAL_POST_SHAPE);
+
+    assert.deepEqual(result.data.content[0], REAL_POST_SHAPE.content[0]);
+    assert.deepEqual(result.data.content.at(-1), REAL_POST_SHAPE.content.at(-1));
+  });
+
+  test('tallies a real-shaped post without drowning in text nodes', () => {
+    assert.deepEqual(summarizeNodes(REAL_POST_SHAPE), {
+      digestPostEmbed: 1, heading: 1, paragraph: 1, captionedImage: 1, image2: 1,
+      caption: 1, button: 1, horizontal_rule: 1, code_block: 1, substack_mentions: 1,
+    });
+  });
+
+  test('accepts the structures a model produced from the published schema', () => {
+    const result = parse(MODEL_AUTHORED_SHAPE);
+
+    assert.equal(result.success, true, result.success ? '' : JSON.stringify(result.error?.issues));
+  });
+});
+```
+
+- [ ] **Step 7: Run them and confirm they pass**
+
+```bash
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: all pass. If the real-post fixture fails, the enumeration in Task 4 is incomplete — read the
+reported path, do not loosen the schema to make it go away.
+
+- [ ] **Step 8: Prove the real-post fixture is load-bearing**
+
+Drop `digestPostEmbed` from the union and confirm the fixture goes red — this is the node that makes
+read-modify-write possible at all:
+
+```bash
+grep -c "digestPostEmbedNode," src/api/substack/document.js
+perl -pi -e "s/    digestPostEmbedNode, substackMentionsNode, directMessageNode,/    substackMentionsNode, directMessageNode, \/*MUT*\//" src/api/substack/document.js
+grep -c "MUT" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -4
+```
+
+Expected: the `MUT` grep is non-zero and the real-post fixture tests fail. Restore:
+
+```bash
+perl -pi -e "s/    substackMentionsNode, directMessageNode, \/\*MUT\*\//    digestPostEmbedNode, substackMentionsNode, directMessageNode,/" src/api/substack/document.js
+grep -c "MUT" src/api/substack/document.js
+node --test src/api/substack/document.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)'
+```
+
+Expected: `0` markers left and a green run.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/api/substack/document.js src/api/substack/document.spec.js
+git commit -m "Add a node tally and fixtures shaped like real documents"
+```
+
+---
+
+## Task 6: The set_post_body tool
+
+**Files:**
+- Create: `src/tools/set_post_body.js`
+- Create: `src/tools/set_post_body.spec.js`
+- Modify: `src/server.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tools/set_post_body.spec.js`:
+
+```js
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {setPostBodyHandler, setPostBodySchema} from './set_post_body.js';
+import {createMswServer, DRAFT_RESPONSE} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const DOC = {type: 'doc', content: [
+  {type: 'paragraph', content: [{type: 'text', text: 'Free intro.'}]},
+  {type: 'paywall'},
+  {type: 'heading', attrs: {level: 2}, content: [{type: 'text', text: 'Paid'}]},
+]};
+const VALID_ARGS = {draft_id: 210218832, body: DOC};
+
+describe('setPostBodySchema', () => {
+  test('requires a draft_id and a body', () => {
+    assert.throws(() => setPostBodySchema.parse({}), z.ZodError);
+    assert.throws(() => setPostBodySchema.parse({draft_id: 1}), z.ZodError);
+  });
+
+  test('rejects an unknown key by name', () => {
+    try {
+      setPostBodySchema.parse({...VALID_ARGS, draft_body: DOC});
+      assert.fail('should have thrown');
+    } catch (error) {
+      assert.match(error.issues.map(i => i.message).join(' '), /Unrecognized key/);
+      assert.match(error.issues.map(i => i.message).join(' '), /draft_body/);
+    }
+  });
+
+  test('rejects a body that is a JSON string rather than an object', () => {
+    assert.throws(() => setPostBodySchema.parse({draft_id: 1, body: JSON.stringify(DOC)}), z.ZodError);
+  });
+});
+
+describe('setPostBodyHandler', () => {
+  test('sends draft_body as a serialized document to the draft', async () => {
+    await setPostBodyHandler(VALID_ARGS);
+
+    const request = msw.requests.at(-1);
+    assert.equal(request.method, 'PUT');
+    assert.match(request.url, /\/drafts\/210218832$/);
+    assert.deepEqual(JSON.parse(request.body.draft_body), DOC);
+  });
+
+  // JSON.stringify, not the object: draft_body goes on the wire as a string. SubstackPost.getDraft
+  // has the same rule, and passing an already-serialized string there double-encoded it once (#4).
+  test('sends draft_body as a string, not as a nested object', async () => {
+    await setPostBodyHandler(VALID_ARGS);
+
+    assert.equal(typeof msw.requests.at(-1).body.draft_body, 'string');
+  });
+
+  test('sends nothing but draft_body, so no other draft field is touched', async () => {
+    await setPostBodyHandler(VALID_ARGS);
+
+    assert.deepEqual(Object.keys(msw.requests.at(-1).body), ['draft_body']);
+  });
+
+  test('returns the tally of what it stored', async () => {
+    const result = await setPostBodyHandler(VALID_ARGS);
+
+    assert.deepEqual(result, {draft_id: 210218832, nodes: {paragraph: 1, paywall: 1, heading: 1}});
+  });
+
+  test('rejects a second paywall without issuing a request', async () => {
+    const body = {type: 'doc', content: [{type: 'paywall'}, {type: 'paywall'}]};
+
+    await assert.rejects(() => setPostBodyHandler({draft_id: 1, body}), z.ZodError);
+    assert.equal(msw.requests.length, 0, 'no request should have been made');
+  });
+
+  test('propagates a failing response', async () => {
+    msw.server.use(msw.draftUpdateHandler(() => HttpResponse.json({}, {status: 404})));
+
+    await assert.rejects(() => setPostBodyHandler(VALID_ARGS), /404/);
+  });
+
+  test('logs its intent before the request and the tally after', async () => {
+    const logs = await captureLogs(() => setPostBodyHandler(VALID_ARGS));
+    const events = logs.map(line => line.msg);
+
+    assert.ok(events.includes('set_post_body.writing'), `expected set_post_body.writing in ${events.join(', ')}`);
+    assert.ok(events.includes('set_post_body.done'));
+    const done = logs.find(line => line.msg === 'set_post_body.done');
+    assert.deepEqual(done.nodes, {paragraph: 1, paywall: 1, heading: 1});
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/tools/set_post_body.spec.js 2>&1 | tail -20
+```
+
+Expected: `Cannot find module './set_post_body.js'`.
+
+- [ ] **Step 3: Write the tool**
+
+Create `src/tools/set_post_body.js`:
+
+```js
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {postBodySchema, summarizeNodes} from "../api/substack/document.js";
+import {logger} from "../logger.js";
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call. A model reaching for the
+// wire name `draft_body` is told that key is unrecognised instead of having it silently dropped and
+// being told `body` is missing.
+//
+// This is the one tool that publishes the document schema. Keeping it here rather than on
+// create_draft_post and update_draft both is deliberate: the schema is ~16 KB, and paying it twice
+// would grow tools/list by over 90% for every session, including those that never write a post.
+export const setPostBodySchema = z.strictObject({
+  draft_id: z
+    .number()
+    .int()
+    .describe(
+      "The numeric id of the draft to write, as returned by list_posts (`id`) or create_draft_post (`draft_id`)."
+    ),
+  body: postBodySchema,
+});
+
+export const setPostBodyHandler = async (args) => {
+  logger.debug('set_post_body.start', {args});
+
+  let validatedArgs;
+
+  try {
+    validatedArgs = setPostBodySchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('set_post_body.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {draft_id, body} = validatedArgs;
+  const nodes = summarizeNodes(body);
+
+  // Logged before the request, not only after: this replaces a body outright, and the previous one
+  // is not recoverable from anywhere in this server.
+  logger.info('set_post_body.writing', {draft_id, nodes});
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  // JSON.stringify, because draft_body goes on the wire as a string. Only this key is sent: PUT is
+  // genuinely partial, so anything absent is left alone rather than cleared.
+  await substack_api.updateDraft(draft_id, {draft_body: JSON.stringify(body)});
+
+  logger.info('set_post_body.done', {draft_id, nodes});
+
+  // The tally, not 'OK'. Validation cannot report a paywall that was never sent — a document
+  // without one is as valid as a document with one — so the only way a caller can confirm that what
+  // it asked for landed is to be told what landed. The log goes to stderr, where a model cannot
+  // read it, which makes the result the only channel back.
+  return {draft_id, nodes};
+};
+```
+
+- [ ] **Step 4: Register it**
+
+In `src/server.js`, add the import beside the others:
+
+```js
+import {setPostBodySchema, setPostBodyHandler} from "./tools/set_post_body.js";
+```
+
+And add the registry entry immediately after the `create_draft_post` entry:
+
+```js
+  set_post_body: {
+    description:
+      "replace the body of a draft with a Substack document. This is the only way to write " +
+      "structured content — headings, lists, links, code blocks, images, buttons and a paywall. " +
+      "Create the draft first with create_draft_post, then call this with its id. The result " +
+      "reports how many nodes of each type were stored, so a caller can confirm that what it " +
+      "asked for is there.",
+    schema: setPostBodySchema,
+    handler: setPostBodyHandler,
+  },
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+node --test src/tools/set_post_body.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+npm test 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: both green, and the full-suite count risen from 590.
+
+- [ ] **Step 6: Prove the double-encoding test can fail**
+
+This is the bug the repository has already shipped once (#4), so its guard has to be real:
+
+```bash
+grep -c "JSON.stringify(body)" src/tools/set_post_body.js
+perl -pi -e "s/\{draft_body: JSON\.stringify\(body\)\}/{draft_body: body}/" src/tools/set_post_body.js
+grep -c "{draft_body: body}" src/tools/set_post_body.js
+node --test src/tools/set_post_body.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: the second grep prints `1` and "sends draft_body as a string, not as a nested object" fails. Restore:
+
+```bash
+perl -pi -e "s/\{draft_body: body\}/{draft_body: JSON.stringify(body)}/" src/tools/set_post_body.js
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tools/set_post_body.js src/tools/set_post_body.spec.js src/server.js
+git commit -m "Add set_post_body, the one tool that publishes the document schema"
+```
+
+---
+
+## Task 7: create_draft_post shares the validator
+
+**Files:**
+- Modify: `src/tools/create_draft_post.js:29-57`
+- Modify: `src/tools/create_draft_post.spec.js`
+
+Today the JSON branch forwards anything with `type: 'doc'` **unvalidated** — the only structured route into this server, and the one with no checks. It starts using the same schema. The schema is not published on this tool, so `tools/list` does not grow.
+
+- [ ] **Step 1: Rewrite the characterization test**
+
+In `src/tools/create_draft_post.spec.js`, find the test named `a ProseMirror document given as JSON is passed through untouched` and replace it with:
+
+```js
+  // Was a characterization test pinning unvalidated passthrough: anything carrying type: 'doc' went
+  // to Substack as-is. It is validated now, so a wrong node name is an error instead of a draft with
+  // its content silently mangled. Changed together with the source, as CLAUDE.md requires.
+  test('a valid ProseMirror document given as JSON is passed through untouched', async () => {
+    const documento = {
+      type: 'doc',
+      content: [
+        {type: 'heading', attrs: {level: 2}, content: [{type: 'text', text: 'Title'}]},
+        {type: 'paragraph', content: [{type: 'text', text: 'Body'}]},
+      ],
+    };
+
+    await createDraftPostHandler({...VALID_ARGS, body: JSON.stringify(documento)});
+
+    assert.deepEqual(JSON.parse(msw.requests.at(-1).body.draft_body), documento);
+  });
+
+  test('an invalid document is rejected rather than forwarded', async () => {
+    const broken = JSON.stringify({type: 'doc', content: [{type: 'codeBlock', content: []}]});
+
+    await assert.rejects(() => createDraftPostHandler({...VALID_ARGS, body: broken}), z.ZodError);
+    assert.equal(msw.requests.length, 0, 'no request should have been made');
+  });
+
+  test('the rejection names the valid node types', async () => {
+    const broken = JSON.stringify({type: 'doc', content: [{type: 'codeBlock', content: []}]});
+    const error = await createDraftPostHandler({...VALID_ARGS, body: broken}).catch(e => e);
+
+    assert.match(error.issues.map(i => i.message).join(' '), /Invalid discriminator value/);
+  });
+
+  // JSON that parses but is not a document keeps its existing behaviour — treated as text — because
+  // it never claimed to be one. Only a value carrying type: 'doc' is held to the schema.
+  test('valid JSON that is not a document is still treated as text', async () => {
+    await createDraftPostHandler({...VALID_ARGS, body: '{"a":1}'});
+
+    const sent = JSON.parse(msw.requests.at(-1).body.draft_body);
+    assert.deepEqual(sent.content[0].content[0].text, '{"a":1}');
+  });
+```
+
+Make sure `z` is imported in that spec — it already is, for the schema tests.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/tools/create_draft_post.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: "an invalid document is rejected rather than forwarded" fails — today the request goes out.
+
+- [ ] **Step 3: Wire in the validator**
+
+In `src/tools/create_draft_post.js`, add the import:
+
+```js
+import {postBodySchema} from "../api/substack/document.js";
+```
+
+Replace the body of `parseBody` (lines 29-57) with:
+
+```js
+const parseBody = (body) => {
+  try {
+    const doc = JSON.parse(body);
+    if (doc && doc.type === 'doc') {
+      // Validated, not forwarded. This branch used to be the one structured route into the server
+      // and the only one with no checks, so a wrong node name created a draft with its content
+      // mangled and said nothing. The schema is shared with set_post_body but deliberately not
+      // published here: validating costs nothing, publishing would cost ~16 KB on every session.
+      const validated = postBodySchema.parse(doc);
+      logger.debug('draft.body.parsed', {format: 'prosemirror', nodes: validated.content.length});
+      return validated;
+    }
+
+    // Valid JSON that is not a document: it goes through as text, and a model that believed
+    // it was sending a document would have no other way to find out.
+    logger.debug('draft.body.json_is_not_a_document', {parsed: doc});
+  } catch (error) {
+    // A ZodError means it *was* a document and a bad one — that must reach the caller. Anything
+    // else is JSON.parse failing, which just means the body is text.
+    if (error instanceof z.ZodError) {
+      logger.error('draft.body.invalid_document', {issues: error.issues});
+      throw error;
+    }
+    // not JSON, treat as plain text
+  }
+
+  const doc = {
+    type: 'doc',
+    content: body
+      .split(/\n+/)
+      .filter(paragraph => paragraph.trim() !== '')
+      .map(paragraph => ({
+        type: 'paragraph',
+        content: [{type: 'text', text: paragraph}],
+      })),
+  };
+
+  logger.debug('draft.body.parsed', {format: 'text', nodes: doc.content.length, chars: body.length});
+  return doc;
+};
+```
+
+Note the `catch` now has to distinguish two failures that previously could not both happen. Getting this wrong turns a validation error into "treated as text", which would publish the broken document as literal JSON — the test in Step 1 is what catches that.
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+node --test src/tools/create_draft_post.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+npm test 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: both green.
+
+- [ ] **Step 5: Prove the ZodError re-throw is load-bearing**
+
+```bash
+grep -c "error instanceof z.ZodError" src/tools/create_draft_post.js
+perl -0pi -e "s/if \(error instanceof z\.ZodError\) \{\n      logger\.error\('draft\.body\.invalid_document', \{issues: error\.issues\}\);\n      throw error;\n    \}\n    //" src/tools/create_draft_post.js
+grep -c "error instanceof z.ZodError" src/tools/create_draft_post.js
+node --test src/tools/create_draft_post.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: the second grep prints `0` and "an invalid document is rejected rather than forwarded"
+fails — the broken document is silently treated as text instead.
+
+Restore by re-inserting the guard (a `git checkout` would discard this task's uncommitted work):
+
+```bash
+perl -0pi -e "s/    \/\/ not JSON, treat as plain text/    if (error instanceof z.ZodError) {\n      logger.error('draft.body.invalid_document', {issues: error.issues});\n      throw error;\n    }\n    \/\/ not JSON, treat as plain text/" src/tools/create_draft_post.js
+grep -c "error instanceof z.ZodError" src/tools/create_draft_post.js
+node --test src/tools/create_draft_post.spec.js 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)'
+```
+
+Expected: `1` and a green run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tools/create_draft_post.js src/tools/create_draft_post.spec.js
+git commit -m "Validate create_draft_post's JSON branch instead of forwarding it"
+```
+
+---
+
+## Task 8: Protocol-level assertions, and both runtimes
+
+**Files:**
+- Modify: `src/server.spec.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/server.spec.js`, inside the outermost `describe` that already covers the registry (match the surrounding style — read the file first):
+
+```js
+describe('set_post_body over the protocol', () => {
+  test('is registered and published with a body parameter', async () => {
+    const {client, close} = await connect();
+
+    try {
+      const {tools} = await client.listTools();
+      const tool = tools.find(t => t.name === 'set_post_body');
+
+      assert.ok(tool, 'set_post_body should be registered');
+      assert.deepEqual(Object.keys(tool.inputSchema.properties).sort(), ['body', 'draft_id']);
+      assert.equal(tool.inputSchema.additionalProperties, false);
+    } finally {
+      await close();
+    }
+  });
+
+  // The published schema is what teaches a model the vocabulary. If the node names stop appearing in
+  // it, the tool still works and every caller has to guess — which no other test would notice.
+  test('publishes the node vocabulary a caller has to know', async () => {
+    const {client, close} = await connect();
+
+    try {
+      const {tools} = await client.listTools();
+      const published = JSON.stringify(tools.find(t => t.name === 'set_post_body').inputSchema);
+
+      for (const type of ['paragraph', 'heading', 'bullet_list', 'highlighted_code_block', 'captionedImage', 'button', 'paywall']) {
+        assert.match(published, new RegExp(`"${type}"`), `${type} should appear in the published schema`);
+      }
+    } finally {
+      await close();
+    }
+  });
+
+  // The recursion has to survive conversion, and draft-7 puts the shared shapes under `definitions`.
+  // A $ref pointing at a definition that is not there would publish a schema no client can resolve.
+  test('publishes a self-contained schema, definitions included', async () => {
+    const {client, close} = await connect();
+
+    try {
+      const {tools} = await client.listTools();
+      const schema = tools.find(t => t.name === 'set_post_body').inputSchema;
+      const refs = [...JSON.stringify(schema).matchAll(/"\$ref":"#\/definitions\/([^"]+)"/g)].map(m => m[1]);
+
+      for (const ref of refs) {
+        assert.ok(schema.definitions?.[ref], `definitions.${ref} should exist`);
+      }
+    } finally {
+      await close();
+    }
+  });
+
+  test('reports a validation error as a result rather than rejecting', async () => {
+    const {client, close} = await connect();
+
+    try {
+      // McpServer turns anything a tool throws into a successful CallToolResult with isError set,
+      // so callTool does not reject. Asserting on a rejection here would check nothing.
+      const result = await client.callTool({
+        name: 'set_post_body',
+        arguments: {draft_id: 1, body: {type: 'doc', content: [{type: 'codeBlock'}]}},
+      });
+
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /codeBlock|discriminator|Invalid/);
+    } finally {
+      await close();
+    }
+  });
+});
+```
+
+`connect()` is the harness this spec already uses — check its exact name in `src/server.spec.js` and in `test/helpers/mcp-harness.js`, and use whatever the file already does rather than introducing a second pattern.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+node --test src/server.spec.js 2>&1 | grep -E '^(not ok|✖)' | head -3
+```
+
+Expected: green if Task 6 landed — in which case **make it fail on purpose** to prove it asserts something. Comment out the `set_post_body` entry in the `tools` registry, re-run, confirm all four tests fail, restore.
+
+- [ ] **Step 3: Run the whole suite on both runtimes**
+
+The floor is exercised on every push by CI, and it is where runtime differences bite:
+
+```bash
+source ~/.nvm/nvm.sh && nvm exec --silent 22 npm test 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+source ~/.nvm/nvm.sh && nvm use && npm test 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+```
+
+Expected: 0 failures on both. Note the output shape differs between them — TAP on 22, spec reporter on 24.
+
+- [ ] **Step 4: Check what the schema costs**
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | SUBSTACK_PUBLICATION_URL=https://test.substack.com SUBSTACK_SESSION_TOKEN=tok SUBSTACK_USER_ID=1 \
+    timeout 5 node src/index.js 2>/dev/null | sed -n '2p' | wc -c
+```
+
+Expected: roughly 50,000–52,000 bytes, up from 34,721. If it is materially larger, something is being published twice — check that `create_draft_post` did not gain the document schema.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server.spec.js
+git commit -m "Assert set_post_body publishes a resolvable schema with the node vocabulary"
+```
+
+---
+
+## Task 9: Verify against the live API, then document it
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+Nothing in this repository ships on inference. The schema was read off a live draft; the code that reproduces it has to be checked the same way, because a node name can be right in the spec and wrong in the source.
+
+- [ ] **Step 1: Write a document using every modelled node into a scratch draft**
+
+Create a throwaway draft with `create_draft_post`, note its `draft_id`, then call `set_post_body` with
+exactly this document. Replace `<SUBSTACK_HOSTED_IMAGE_URL>` with a `src` from an image already on the
+publication — an external URL is stored but does not render, so an invented one proves nothing:
+
+```json
+{"type": "doc", "content": [
+  {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Every node"}]},
+  {"type": "paragraph", "content": [
+    {"type": "text", "text": "Plain, "},
+    {"type": "text", "marks": [{"type": "strong"}], "text": "bold"},
+    {"type": "text", "text": ", "},
+    {"type": "text", "marks": [{"type": "em"}], "text": "italic"},
+    {"type": "text", "text": ", "},
+    {"type": "text", "marks": [{"type": "code"}], "text": "inline_code"},
+    {"type": "text", "text": ", "},
+    {"type": "text", "marks": [{"type": "strikethrough"}], "text": "struck"},
+    {"type": "text", "text": ", and a "},
+    {"type": "text", "marks": [{"type": "link", "attrs": {"href": "https://example.com/verify"}}], "text": "link"},
+    {"type": "text", "text": "."}
+  ]},
+  {"type": "bullet_list", "content": [
+    {"type": "list_item", "content": [
+      {"type": "paragraph", "content": [{"type": "text", "text": "outer item"}]},
+      {"type": "bullet_list", "content": [
+        {"type": "list_item", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "nested item"}]}]}
+      ]}
+    ]}
+  ]},
+  {"type": "ordered_list", "attrs": {"start": 3}, "content": [
+    {"type": "list_item", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "starts at three"}]}]}
+  ]},
+  {"type": "blockquote", "content": [
+    {"type": "bullet_list", "content": [
+      {"type": "list_item", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "quoted item"}]}]}
+    ]}
+  ]},
+  {"type": "highlighted_code_block", "attrs": {"language": "javascript"},
+   "content": [{"type": "text", "text": "const a = 1;\nconsole.log(a);"}]},
+  {"type": "code_block", "content": [{"type": "text", "text": "legacy block"}]},
+  {"type": "horizontal_rule"},
+  {"type": "captionedImage", "content": [
+    {"type": "image2", "attrs": {"src": "<SUBSTACK_HOSTED_IMAGE_URL>", "alt": "A verification image"}},
+    {"type": "caption", "content": [{"type": "text", "text": "The caption"}]}
+  ]},
+  {"type": "button", "attrs": {"url": "%%checkout_url%%", "text": "Subscribe"}},
+  {"type": "paywall"},
+  {"type": "paragraph", "content": [{"type": "text", "text": "Behind the paywall."}]}
+]}
+```
+
+The result's `nodes` tally must come back with `paywall: 1`, `button: 1`, `captionedImage: 1` and
+`highlighted_code_block: 1`. If any of those is absent, stop — the tool dropped something.
+
+- [ ] **Step 2: Confirm it renders**
+
+Open `https://<publication>/publish/post/<draft_id>` and check every construct appears as intended.
+Specifically: the nested bullet is indented under its parent, the numbered list starts at 3, the code
+block's language selector reads **JavaScript** and not "Plain Text", the image shows with its caption
+beneath, the button renders as a button rather than a link, and there is exactly one "Paid content
+below this line" marker.
+
+Two failures only this step catches: a node name that is right in the spec and wrong in the source,
+and a `language` value that maps to nothing — which the API accepts with a 200 and the editor then
+degrades to Plain Text without an error.
+
+- [ ] **Step 3: Confirm the round trip on real posts**
+
+`get_draft` on a **real published post**, `JSON.parse` its `draft_body`, and feed that straight back
+through `set_post_body` on the scratch draft. It must validate untouched.
+
+Do this for **at least five** posts from different points in the archive, not one: the enumeration came
+from a survey, and one post exercises one subset of it. A post using a node the union does not list
+fails loudly and names the alternatives — that is the designed behaviour, and the fix is to read that
+node's shape off a live draft and add it, never to loosen the union.
+
+`digestPostEmbed` alone is in 59 of 60 sampled posts, so if step 3 fails on the first post the three
+opaque nodes are not doing their job.
+
+- [ ] **Step 4: Clean up**
+
+`delete_draft` on the scratch draft, then `get_draft` to confirm it 404s.
+
+- [ ] **Step 5: Record it in CLAUDE.md**
+
+Add to the Substack private-API section, after the draft-lifecycle paragraphs:
+
+```markdown
+**The post body has a contract, and `set_post_body` is where it lives.** `src/api/substack/document.js`
+models the ProseMirror document in zod: a discriminated union over every node type observed in the live
+archive, published as that tool's JSON Schema so a calling model reads the vocabulary from
+`tools/list` rather than guessing. Four measured facts shape it:
+
+- **The code block is `highlighted_code_block`.** `python-substack` declares `codeBlock`, which is not
+  what the editor writes and not what renders. Both `code_block` (older posts) and
+  `highlighted_code_block` (current editor) are in live use, so both are accepted.
+- **`type` is strict and `attrs` are loose**, in opposite directions on purpose. The editor writes
+  `textAlign: null` on every paragraph and heading and `nodeId: null` on code blocks, so strict attrs
+  would reject every real post; a discriminated union on `type` is what produces
+  `Invalid discriminator value. Expected 'paragraph' | 'heading' | …`, the only repair instruction an
+  LLM gets. **A generic unknown-node branch was tried and rejected**: it keeps a malformed `heading`
+  out but reports only the generic branch's error, so the caller never learns which field is wrong.
+  Every observed node type is enumerated instead, including the three whose internals were never read
+  — `digestPostEmbed`, `substack_mentions`, `directMessage` — as `looseObject`s that survive a round
+  trip whole. `digestPostEmbed` alone is in 59 of 60 sampled posts, so this is what makes
+  read-modify-write possible at all.
+- **A document may carry one `paywall`, and we are the only ones enforcing it.** Two are accepted by
+  `PUT /drafts/:id` with a 200 and rendered by the editor as two "Paid content below this line"
+  markers, so which one cuts the post is undefined. The `.refine()` is the only check that exists —
+  and since a refinement does **not** survive into the published JSON Schema, the rule is repeated in
+  the node's own description or a model meets it only by failing.
+- **The code-block `language` is a closed set that fails silently.** `auto` is the auto-detect
+  sentinel, `plaintext` the plain-text value, and an unrecognised name renders as Plain Text with no
+  error — the *sixth* silent-ignore in this API. Omitting the attr beats guessing.
+
+`set_post_body` returns a **node tally**, not `'OK'`, because validation cannot report what was never
+sent: a document with no paywall is exactly as valid as one with a paywall. This was measured — a
+model asked for a paywall through a Markdown contract omitted it, produced valid Markdown, and the
+document it rendered to passes this very schema. The tally is the only way a caller sees what landed.
+
+`create_draft_post`'s JSON branch runs the same validator **without publishing the schema**: validating
+costs nothing, publishing would cost ~16 KB, and it was the last route into this server that accepted
+a body unchecked.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "Record the post body contract and the facts behind it"
+```
+
+---
+
+## Task 10: Finish the branch
+
+- [ ] **Step 1: Rename the branch, which still carries the abandoned approach's name**
+
+```bash
+git branch -m markdown-post-bodies post-body-contract
+```
+
+- [ ] **Step 2: Confirm the whole suite and the package contents**
+
+```bash
+npm test 2>&1 | grep -E '^(#|ℹ) (tests|pass|fail)|^(not ok|✖)'
+npm pack --dry-run 2>&1 | grep -c "spec.js"
+```
+
+Expected: 0 failures, and `0` spec files in the tarball — they are excluded by the `files` negation pattern, and a new directory can break that.
+
+- [ ] **Step 3: Hand off**
+
+Use `superpowers:finishing-a-development-branch` to decide how this integrates.
+
+---
+
+## Notes for whoever executes this
+
+**The open item, carried from the spec:** the code-block language table. `auto` and `plaintext` are confirmed sentinels and the values are lowercase highlight.js names, but the full label-to-value mapping has to be lifted from the editor bundle (`grep` the loaded chunks for `plaintext` — the list is a `{value, label}` array near the "Auto-detect" string) rather than guessed. Until then the schema's description names the common ones and says omitting beats guessing, which is correct and honest; do not invent the rest.
+
+**Do not add** `youtube2`, `subscribeWidget`, `latex`, `footnote`, `poll`, `poetry`, `calloutBlock` or `pullquote` to the union in this plan. The first six exist as names in the editor's "More" menu but their shapes were never read; the last two come only from `python-substack`, the same file that was wrong about `codeBlock`, and do not appear in that menu at all. Each is a later addition after its shape is read off a live draft. A node outside the enumeration fails loudly and names the alternatives, which is the correct behaviour in the meantime.
+
+**`SubstackPost.js` already has a builder** — `paywall()`, `shareButton()`, `customButton()`, `captionedImage()`, `subscribeWithCaption()` — that no tool reaches. This plan does not use it and does not delete it. Its index-based mutation (`content[length - 1]`) cannot express nesting, which is why the schema route exists; removing it is a separate decision.

--- a/docs/superpowers/plans/2026-08-07-post-body-contract.md
+++ b/docs/superpowers/plans/2026-08-07-post-body-contract.md
@@ -1558,7 +1558,7 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
     timeout 5 node src/index.js 2>/dev/null | sed -n '2p' | wc -c
 ```
 
-Expected: roughly 55,000 bytes, up from 34,721 — the document schema measures 20,342 bytes on its own
+Expected: roughly 55,000 bytes, up from 34,721 — the document schema is roughly 21 KB on its own
 once every node carries a description. If it is closer to 75,000, something is being published twice:
 check that `create_draft_post` did not gain the document schema.
 

--- a/docs/superpowers/specs/2026-08-07-markdown-body-design.md
+++ b/docs/superpowers/specs/2026-08-07-markdown-body-design.md
@@ -1,7 +1,22 @@
 # Markdown post bodies — Design
 
 Date: 2026-08-07
-Status: approved
+Status: **superseded** by `2026-08-07-post-body-contract-design.md`, same day, on measurement.
+
+Two numbers ended it. **100% of 60 sampled published posts contain nodes Markdown cannot express** —
+`button` in 60/60, `captionedImage` in 60/60 — so this design could not have reproduced a single real
+post on this publication, and the "images are out of scope, they come later" call below was the whole
+substance rather than the tail of it.
+
+Worse, the safety net here did not hold. In a head-to-head run, a model given the Markdown contract
+**degraded a button to a link and omitted a paywall entirely**, producing valid Markdown and an empty
+`unsupported` list. `unsupported` can only report constructs Markdown *has* and Substack lacks; what
+Markdown *lacks* is substituted upstream, in the model, and arrives as healthy prose. That post would
+have published with its paid section public and nothing in the log to say so.
+
+What survives is the measurement, kept here because it was real: the renderer prototype reproduced a
+hand-written document byte for byte, and Markdown was 5.8× cheaper in emitted bytes. It lost on
+coverage, not on fidelity or cost.
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-08-07-markdown-body-design.md
+++ b/docs/superpowers/specs/2026-08-07-markdown-body-design.md
@@ -1,0 +1,233 @@
+# Markdown post bodies — Design
+
+Date: 2026-08-07
+Status: approved
+
+## Goal
+
+Let a caller write a post body in **Markdown** and have this server translate it into the
+ProseMirror document Substack stores, so that headings, emphasis, links, lists, quotes, code and
+rules become reachable without hand-writing JSON.
+
+Two tools gain it: `create_draft_post`, whose `body` currently produces flat paragraphs only, and
+`update_draft`, which today **cannot change a body at all** — it accepts `draft_title`,
+`draft_subtitle` and `audience`, so a post's body can be set once, at creation, and never again.
+
+## Why this is the gap worth closing
+
+`parseBody` in `src/tools/create_draft_post.js` has exactly two branches: a string that parses as
+JSON with `type: 'doc'` passes through untouched, and anything else is split on `/\n+/` into
+paragraphs. So `## Introduction` reaches the published post as the literal characters `## `, and
+`**bold**` keeps its asterisks. Everything richer requires the model to emit ProseMirror JSON by
+hand — as a *string*, doubly escaped — using node names it cannot discover and that are not even
+internally consistent (`bullet_list` with an underscore, `highlighted_code_block` likewise, but
+`captionedImage` in camelCase). A wrong name is not an error: the draft is created and the content
+is silently mangled.
+
+`src/api/substack/SubstackPost.js` already carries a fluent builder — `paragraph`, `heading`,
+`bulletList`, `orderedList`, `bold`, `italic`, `marks`, `captionedImage`, `paywall`, buttons. It is
+**unreachable**: its own spec exercises it, but no tool calls anything beyond `setTitle`,
+`setSubtitle` and `setBody`. The vocabulary is in the repository already; what is missing is the
+road from text a model writes naturally to that vocabulary.
+
+## Verified facts
+
+Everything below was measured on 2026-08-07 against a live publication
+(`implementing.substack.com`, scratch draft `210218832`) by composing each construct in the real
+editor and reading back `GET /api/v1/drafts/:id`. **The shapes are what Substack itself writes**,
+not inference from a third-party client — and three of them contradict the sources this design
+started from.
+
+### Node shapes as the editor produces them
+
+| Node | Attrs |
+|---|---|
+| `heading` | `{textAlign: null, level: N}` |
+| `paragraph` | `{textAlign: null}` |
+| `bullet_list` | none |
+| `ordered_list` | `{start: 1, type: null, order: 1}` |
+| `list_item` | none; contains a `paragraph` |
+| `blockquote` | none; contains `paragraph`s |
+| `horizontal_rule` | none |
+| `highlighted_code_block` | `{language: '<value>', nodeId: null}`; content is a single `text` node |
+
+Marks: `strong`, `em`, `code` and `strikethrough` carry no attrs. `link` carries **four**:
+`{href, target: '_blank', rel: 'noopener noreferrer nofollow', class: null}`.
+
+### Corrections to the sources
+
+- **The code block is `highlighted_code_block`, not `codeBlock`.** `python-substack`'s `nodes.py`
+  declares `CODE_BLOCK = "codeBlock"`; the editor writes `highlighted_code_block`. Following that
+  library here would have produced a node Substack does not render.
+- **The `link` mark is not `{href}` alone.** Both `python-substack` and `SubstackPost.js` build only
+  `href`. The editor writes `target` and `rel` as well.
+- **`ordered_list` does carry attrs.** `python-substack` omits them; `SubstackPost.js` writes
+  `{start: 1, order: 1}` and is missing `type: null`.
+- **`strikethrough` is real**, confirming the one mark `python-substack` listed that no other source
+  did.
+
+### What the API does with what we send
+
+`PUT /api/v1/drafts/:id` **accepts `draft_body`** (200) and **stores it verbatim**. It normalises
+nothing: a link given only `href` stays that way, a `heading` without `textAlign` stays without it,
+an `ordered_list` without attrs keeps no attrs, and a `language` outside the accepted set is kept as
+given. The server is a dumb store; the editor is the only validator.
+
+Reloading the editor on those minimal shapes renders **all of them correctly** — link, heading,
+ordered list, rule and code block. So the renderer may emit the minimal form, and should: every
+attr we invent is an attr we can get wrong, and `target`/`rel` are the editor's presentation choice
+rather than something a document requires.
+
+### The code-block language is a closed set that fails silently
+
+`language: 'sh'` renders, but the editor's own dropdown reports it as **Plain Text** — the value is
+unrecognised and quietly ignored, with no highlighting and no error. This is the *fifth* member of
+the silent-ignore family already documented in CLAUDE.md (`columnView`, the export's columns,
+`get_analytics` extras, `get_post_stats.order_by`).
+
+The editor bundle uses `auto` as the auto-detect sentinel and `plaintext` for Plain Text, with
+lowercase highlight.js-style values. The dropdown lists a subset (JavaScript, TypeScript, JSX, TSX,
+Python, CSS, HTML, JSON, Bash, Markdown, SQL, YAML, Go, Rust, Java, C, C++, C#…) while the bundle
+also references `php`, `dockerfile`, `xml`, `bash` and `shell` — so the accepted set is wider than
+the menu, and the full table must be lifted from the bundle at implementation time rather than
+guessed.
+
+### Editor input rules, for context
+
+Typing `#`…`######`, `**x**`, `*x*`, `` `x` ``, `~~x~~`, `- `, `1. `, `> ` and ``` in the editor all
+convert. `[text](url)` does **not** — the editor has no link input rule. This says nothing about
+what we may send; it is why the link shape had to be read from an existing published post instead.
+
+## The dependency: `marked`
+
+`marked@18.0.9`, **zero transitive dependencies**. `markdown-it` brings six, and this repository has
+two runtime dependencies in total (`@modelcontextprotocol/sdk`, `zod`), so the difference is
+material. Only `marked.lexer()` is used — the token tree — never the HTML renderer.
+
+Writing the parser by hand was considered and rejected. CLAUDE.md's own criterion, set by `csv.js`
+(hand-written, ~40 lines) against leaving HTML alone, is whether the grammar is bounded. CommonMark
+is not: emphasis resolution and nested-list continuation are where hand-rolled parsers fail, and
+they fail *silently*, mangling a post rather than throwing. Markdown belongs on the HTML side of
+that line.
+
+Token shapes, confirmed by running the lexer: blocks are `heading{depth}`, `paragraph`,
+`list{ordered, start, items}`, `blockquote`, `code{lang, text}`, `hr`, `space`; inline are `text`,
+`strong`, `em`, `codespan`, `link{href}`, `del`. Both blocks and inlines nest through `tokens`, and
+a `list_item`'s inline content sits one level deeper, wrapped in a `text` token that itself carries
+`tokens`.
+
+## Architecture
+
+A new module, `src/api/substack/markdown.js`, sitting beside `csv.js` and filling the same role: a
+bounded translation with no I/O, no env reads and its own colocated spec. It exports one pure
+function.
+
+```
+markdownToDoc(markdown) → {doc: {type: 'doc', content: [...]}, unsupported: string[]}
+```
+
+**It does not go through `SubstackPost`'s builder.** That builder mutates
+`draft_body.content[length - 1]` by index, which cannot express nesting: a `list_item` holding a
+`paragraph` holding marked text is three levels deep and index access sees one. A pure
+token-to-node function nests naturally and is testable without a draft. `SubstackPost` keeps
+receiving a finished document through `setBody`, exactly as today.
+
+### The mapping
+
+| Markdown | Node emitted |
+|---|---|
+| `#`…`######` | `heading` + `attrs.level` |
+| paragraph | `paragraph` |
+| `**x**` / `*x*` / `` `x` `` / `~~x~~` | mark `strong` / `em` / `code` / `strikethrough` |
+| `[x](u)` | mark `link` + `attrs.href` |
+| `- x` | `bullet_list` › `list_item` › `paragraph` |
+| `1. x` | `ordered_list` › `list_item` › `paragraph`, `attrs.start` only when not 1 |
+| `> x` | `blockquote` › `paragraph` |
+| ` ```lang ` | `highlighted_code_block` + `attrs.language` when the language maps |
+| `---` | `horizontal_rule` |
+
+Minimal attrs throughout: no `textAlign`, no `target`/`rel`, no `nodeId` — all verified to render.
+
+A fence whose language does not map emits the node **without** `attrs.language`, so it auto-detects
+rather than carrying a value the editor will discard. The dropped language is reported (below), not
+swallowed.
+
+Single newlines inside a paragraph are normalised to a single space, so no `text` node ever contains
+`\n`. Whether Substack treats an embedded newline as a space or a break was not measured, and
+normalising avoids depending on the answer.
+
+### Nothing is dropped in silence
+
+Any construct the renderer cannot map is named in `unsupported`, which the tools return alongside
+their result — GFM tables, raw HTML blocks, images, hard breaks, and unmapped code languages. This
+is the same hazard CLAUDE.md documents five times over, seen from the side where *we* would be the
+ones creating it: a table that vanishes reads as "the model forgot the table", not as "the server
+does not support tables".
+
+Flat strings rather than structured entries, because the consumer is a language model reading a
+result, and `'table'` or `'code language "sh"'` needs no schema to interpret.
+
+## Tool surface
+
+`create_draft_post.body` keeps its type and its escape hatch: a string that parses as a
+ProseMirror document still passes through untouched, and everything else is now Markdown rather
+than flat paragraphs. The description states both.
+
+`update_draft` gains an optional `body`, rendered by the same function. It is named `body` and not
+`draft_body` deliberately: that tool otherwise uses wire names (`draft_title`, `draft_subtitle`)
+because there the value *is* what goes on the wire, whereas here the wire carries a serialized
+document — calling it `draft_body` would invite a caller to pass exactly that. The existing
+"no fields to update" guard and its message grow to include it.
+
+Both tools return `unsupported` when it is non-empty, and omit it otherwise.
+
+## Behaviour changes to declare
+
+- **A single newline no longer starts a paragraph.** Today `/\n+/` splits on one; in Markdown a lone
+  newline continues the paragraph. The new behaviour is the correct one, and
+  `create_draft_post.spec.js` pins the old one in a test named "a single newline also starts a new
+  paragraph" — that test is rewritten, not quietly adjusted, and its CHARACTERIZATION comment
+  updated in the same commit.
+- **`*`, `#`, `_` and `` ` `` are now interpreted.** Prose containing them changes meaning; a caller
+  wanting the literal character escapes it. This is the cost of Markdown by default, and it is
+  stated in the `body` description rather than discovered.
+
+## Testing
+
+`markdown.spec.js`, colocated, table-driven per construct: each of the nine mappings, marks nested
+inside list items and blockquotes, adjacent and overlapping marks, an ordered list with a non-1
+start, a fence with a mapped language, a fence with an unmapped one, and each `unsupported` entry.
+Plus the boundaries `parseBody` already covers — empty string, surplus blank lines, valid JSON that
+is not a document, malformed JSON.
+
+Per CLAUDE.md, **no new test is trusted on a first green run**: each is confirmed by breaking the
+source on purpose — dropping a mark, renaming `highlighted_code_block`, removing the `unsupported`
+push — and the mutation is grepped for before the run, since a regex that fails to match leaves the
+file untouched and reads exactly like a test asserting nothing.
+
+Tool-level tests keep their MSW shape and assert on the `draft_body` actually sent.
+
+## Verification after implementation
+
+The same live check that produced the facts above, run against the renderer's own output: PUT a
+document containing every construct into a scratch draft, reload the editor, confirm each renders,
+then remove the draft. Two things this catches that a unit test cannot — a node name that is right
+in the spec and wrong in the code, and a language value that maps to nothing.
+
+## Out of scope
+
+Images (they need the image-upload endpoint, whose host the two available sources disagree about and
+neither verifies), LaTeX, footnotes, poetry, polls and paywall markers. The editor's "More" menu
+lists each of those by name, so they exist — but their node shapes were not read, and a name in a
+menu is not a schema.
+
+Callouts and pullquotes stay out for a stronger reason: `python-substack` declares `calloutBlock`
+and `pullquote`, and **neither appears in that menu**. Given that the same file was wrong about
+`codeBlock`, they are unverified claims rather than known nodes, and adopting them on that authority
+is the mistake this design already caught once.
+
+## Open items
+
+The code-block language table. Its existence and its failure mode are established; the specific
+label-to-value pairs must be read out of the editor bundle during implementation, and the fallback
+when a fence language is absent from it is already decided — omit the attr, report the language.

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -124,6 +124,43 @@ Then two deliberate relaxations, each with its own reason:
   the `unsupported` idea moved to the input side, where the earlier experiment proved it actually
   fires.
 
+### At most one paywall, and we are the only ones enforcing it
+
+A document may carry **one** `paywall` node. Measured on 2026-08-07: a body with two paywalls is
+accepted by `PUT /api/v1/drafts/:id` with a **200**, stored with both, and the editor then renders
+**both** as "Paid content below this line" — so neither the API nor the editor guards this, and which
+of the two actually cuts the post is undefined.
+
+So this constraint does not mirror a server rule; it is a `.refine()` on the document that will be the
+only check in existence. That makes it worth having rather than presumptuous: two paywalls is not a
+style preference, it is an ambiguous post, and the failure is invisible until a paying subscriber sees
+what a free one also saw.
+
+The line this stays on: the schema encodes **Substack's rules**, not editorial taste. Levels 1–6, a
+`caption` only inside a `captionedImage`, `href` required on a link, one paywall — all properties of
+the format. Requiring that a post *have* a heading, an image or a paywall would be our preference
+wearing the format's clothes, and would reject a perfectly good three-paragraph post.
+
+### The result echoes what was stored
+
+Validation cannot deliver "the post came out the way we wanted", and the experiment behind this design
+proves it: the Markdown model produced a document that **passes this very schema** and had lost its
+paywall. Nothing was illegal; something was missing, and legality has no opinion about missing.
+
+So `set_post_body` returns the shape of what it stored, not `'OK'`:
+
+```
+{draft_id, nodes: {paragraph: 12, heading: 3, captionedImage: 1, button: 1, paywall: 1},
+ passed_through: ['digestPostEmbed']}
+```
+
+A caller that asked for a paywall can see whether there is one. This is the same reasoning that makes
+`create_draft_post` return `draft_id` rather than `'OK'` — the log goes to stderr where the model
+cannot read it, so the result is the only channel back. A node tally costs a few lines and closes
+precisely the gap validation is blind to.
+
+### The error messages
+
 The discriminated union is what makes the errors worth publishing. Measured on the real schema:
 
 ```
@@ -139,8 +176,9 @@ including a two-deep nested list, and converting to draft-7 with a self-containe
 ## Testing
 
 `document.spec.js`, colocated and table-driven: every modelled node, marks nested inside list items
-and blockquotes, `attrs` passthrough, an unknown node type reaching `passed_through`, and the four
-error messages above pinned by wording — `src/server.spec.js` already pins validation wording on
+and blockquotes, `attrs` passthrough, an unknown node type reaching `passed_through`, a second
+`paywall` rejected, the node tally counting what was stored, and the four error messages above pinned
+by wording — `src/server.spec.js` already pins validation wording on
 purpose, because a degraded message breaks nothing by itself and only an assertion catches it.
 
 Two fixtures earn their place: a **real post document** pulled from the publication, asserting it

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -90,7 +90,8 @@ so all of them get modelled and nothing has to be waved through.
 carried by one tool instead of two — publishing it on both `create_draft_post` and `update_draft` would
 double its cost for every session, including those that never write a post.
 
-**The finished schema publishes at 20,342 bytes**, measured on the implemented module rather than on the
+**The finished schema publishes at roughly 21 KB** (20,342 bytes when this was written, 21,094 after the
+`order` attribute was added later on the branch), measured on the implemented module rather than on the
 prototype that suggested 16 KB: the extra four node types and the descriptions on every branch account
 for the difference. Against a `tools/list` of 34.7 KB before this work, one copy is a ~59% increase and
 two would have been ~117%.

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -238,7 +238,7 @@ option, and the names it generates are machine-made (`__schema0`…).
 So the 16 KB figure is not a ceiling that better factoring would lower — it is what this schema costs
 through the SDK, and each further node carrying inline content adds roughly another 1.7 KB. Worth
 knowing before anyone tries to optimise it, and worth re-measuring rather than assuming if the node
-list grows much beyond the current fourteen.
+list grows much beyond the current fifteen.
 
 ## Limits
 

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -74,11 +74,12 @@ Substack lacks. What Markdown *lacks* gets substituted upstream, inside the mode
 healthy prose. The post publishes with its paid section public and nothing anywhere says so — the
 exact silent-drop class CLAUDE.md documents five times over, except authored by us.
 
-### What strictness costs
+### What naive strictness would cost
 
-`digestPostEmbed` sits in 59 of 60 real posts and is not a node worth modelling. A schema that
-rejects unknown node types therefore **rejects 59 of 60 real documents**, killing any
-read-modify-write flow on the first try. This is decided below, not left open.
+`digestPostEmbed` sits in 59 of 60 real posts. A schema modelling only the nodes a *writer* needs
+would therefore **reject 59 of 60 real documents**, killing any read-modify-write flow on the first
+try. The survey is what makes this fixable rather than a trade-off: it enumerates every type in use,
+so all of them get modelled and nothing has to be waved through.
 
 ## Architecture
 
@@ -106,27 +107,44 @@ This is the one place where "validate without publishing" is exactly right: publ
 model the vocabulary — worth 16 KB where structure is authored — while validating protects even where
 nothing was taught. Nothing new can enter this server unvalidated.
 
-### Node coverage and the permissive tail
+### Node coverage
 
 Modelled, with their verified shapes: `paragraph`, `heading`, `bullet_list`, `ordered_list`,
 `list_item`, `blockquote`, `highlighted_code_block`, `code_block` (legacy, accepted not encouraged),
 `horizontal_rule`, `captionedImage`/`image2`/`caption`, `button`, `paywall`. Marks: `strong`, `em`,
 `code`, `strikethrough`, `link`.
 
-Then two deliberate relaxations, each with its own reason:
+Then two deliberate choices, each with its own reason:
 
 - **`attrs` on a known node are permissive** (`looseObject`), so `textAlign: null` and `nodeId: null`
   survive a round trip untouched. Required attrs still guard: a heading missing `level` is an error,
   and a typo'd `levl` fails on the *absent* `level` rather than passing.
-- **An unknown node type is accepted, preserved verbatim, and named in the result** as
-  `passed_through`. Accepting it silently would hand back the silent-drop problem — a mistyped
-  `codeBlock` would sail through — so the report is what keeps the discriminated union's teeth. It is
-  the `unsupported` idea moved to the input side, where the earlier experiment proved it actually
-  fires.
+- **Every node type observed in the live archive is modelled**, so there is no generic passthrough
+  branch. The 60-post survey enumerates the whole set: `paragraph`, `heading`, `text`, `blockquote`,
+  `bullet_list`, `ordered_list`, `list_item`, `horizontal_rule`, `hard_break`, `code_block`,
+  `highlighted_code_block`, `captionedImage`, `image2`, `caption`, `button`, `paywall`,
+  `digestPostEmbed`, `substack_mentions`, `directMessage`. The three whose internals were never read —
+  `digestPostEmbed`, `substack_mentions`, `directMessage` — are modelled as a `looseObject` on their
+  literal `type`: everything else passes through preserved, which is enough for a round trip and
+  honest about knowing no more than that.
+
+  **A generic "unknown node" branch was tried and rejected on measurement.** Wrapping the union as
+  `z.union([known, looseObject({type: string})])` does keep a malformed `heading` out — but the only
+  issue reported becomes the generic branch's, so the caller is told "this is a modelled node, match
+  its shape" and never *which* field is wrong. That trades away the exact thing the discriminated
+  union was chosen for. Enumerating instead keeps every message sharp, and a genuinely new Substack
+  node then fails **loudly**, naming the types it could have been — visible, which is the opposite of
+  the silent drop this design exists to prevent.
+
+  The residual risk is stated rather than engineered away: the enumeration comes from 60 posts of one
+  publication, so a node this publication has never used — `youtube2`, a footnote, LaTeX, a poll —
+  blocks a round trip until it is added. Adding one is a line in the union, and the failure says so.
 
 ### At most one paywall, and we are the only ones enforcing it
 
-A document may carry **one** `paywall` node. Measured on 2026-08-07: a body with two paywalls is
+A document may carry **one** `paywall` node, enforced by a `.refine()` on the document. A refinement
+does **not** survive into the published JSON Schema — verified — so the rule is also stated in the
+`paywall` node's own `.describe()`, or a model would meet it only by failing. Measured on 2026-08-07: a body with two paywalls is
 accepted by `PUT /api/v1/drafts/:id` with a **200**, stored with both, and the editor then renders
 **both** as "Paid content below this line" — so neither the API nor the editor guards this, and which
 of the two actually cuts the post is undefined.
@@ -150,8 +168,8 @@ paywall. Nothing was illegal; something was missing, and legality has no opinion
 So `set_post_body` returns the shape of what it stored, not `'OK'`:
 
 ```
-{draft_id, nodes: {paragraph: 12, heading: 3, captionedImage: 1, button: 1, paywall: 1},
- passed_through: ['digestPostEmbed']}
+{draft_id, nodes: {paragraph: 12, heading: 3, captionedImage: 1, button: 1, paywall: 1,
+ digestPostEmbed: 1}}
 ```
 
 A caller that asked for a paywall can see whether there is one. This is the same reasoning that makes
@@ -176,8 +194,8 @@ including a two-deep nested list, and converting to draft-7 with a self-containe
 ## Testing
 
 `document.spec.js`, colocated and table-driven: every modelled node, marks nested inside list items
-and blockquotes, `attrs` passthrough, an unknown node type reaching `passed_through`, a second
-`paywall` rejected, the node tally counting what was stored, and the four error messages above pinned
+and blockquotes, `attrs` passthrough, each of the three opaque nodes accepted, a node type
+outside the enumeration rejected with the alternatives named, a second `paywall` rejected, the node tally counting what was stored, and the four error messages above pinned
 by wording — `src/server.spec.js` already pins validation wording on
 purpose, because a degraded message breaks nothing by itself and only an assertion catches it.
 

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -1,0 +1,174 @@
+# A validated contract for the post body — Design
+
+Date: 2026-08-07
+Status: approved
+Supersedes: `2026-08-07-markdown-body-design.md`
+
+## Goal
+
+Give the post body a real contract: the Substack ProseMirror document, modelled in zod, published as
+the tool's own JSON Schema so the calling model reads the node vocabulary in-band, and validated on
+the way in so a wrong node name is an error rather than a mangled post.
+
+Today there is no contract at all. `create_draft_post.body` is a string: a value that parses as JSON
+with `type: 'doc'` is forwarded **unvalidated**, and everything else is split on `/\n+/` into flat
+paragraphs. So the only route to a structured post is the unvalidated one, and `update_draft` cannot
+touch a body at all.
+
+## The measurements this rests on
+
+Two head-to-head runs on 2026-08-07, plus a survey of the live publication. Everything below is
+measured, not argued.
+
+### What the publication actually contains
+
+60 published posts sampled across the archive (offsets 0, 50, 100, 200, 400, 700), counting real
+nodes in `draft_body`:
+
+- Markdown-expressible: `paragraph` 782, `heading` 244, `horizontal_rule` 121, `list_item` 97,
+  `blockquote` 55, `bullet_list` 31, `ordered_list` 1. Marks: `strong` 195, `link` 126, `em` 25,
+  `code` 7 — and `strikethrough` **zero**.
+- Not Markdown-expressible: `captionedImage` 201, `image2` 201, `button` 76, `digestPostEmbed` 60,
+  plus `paywall`, `substack_mentions`, `directMessage`, `caption`.
+
+**60 posts out of 60 contain at least one node Markdown cannot produce.** `button` in 60/60,
+`captionedImage` in 60/60, `digestPostEmbed` in 59/60.
+
+Two facts fall out of the same tally. `code_block` (16 occurrences) and `highlighted_code_block` (5)
+are **both in live use** — older posts carry the former, the current editor writes the latter — so
+the schema must accept both. And a `strikethrough` mark this publication has never used does not
+need designing for.
+
+### Head-to-head: five briefs, two contracts, ten fresh models
+
+Each model saw only its own contract and its own brief — no design context. Scoring runs on the
+**final document**, identically for both, by predicates over the produced nodes; the harness was
+mutation-tested first and all six deliberate corruptions turned a check red.
+
+| Brief | Markdown | Document | bytes (md) | bytes (doc) |
+|---|---|---|---|---|
+| Plain prose | 5/5 | 5/5 | 359 | 1,520 |
+| Rich formatting | 9/9 | 9/9 | 685 | 3,241 |
+| Code-heavy | 7/7 | 7/7 | 607 | 3,020 |
+| Substack-native | **4/8** | 8/8 | 402 | 1,659 |
+| Structural edge cases | 5/5 | 5/5 | 361 | 4,462 |
+| **Total** | **30/34** | **34/34** | 2,414 | 13,902 |
+
+- **The document validated 5/5 on the first attempt, zero repair rounds.** A 16 KB published schema
+  is enough for a model to get nested lists, `ordered_list` with `start: 3`, a link inside a list
+  item, a blockquote containing a list, a paywall, a button and a captioned image right first time.
+- **Where both can express a construct the result is semantically identical** — `em` on exactly
+  "not", `code` on exactly `API_KEY`, `strong` on "Boring", the link on the intended words, all three
+  code blocks with matching languages and lengths, and a `${API_KEY:?…}` shell guard intact.
+- The document costs **5.8× more bytes**, and the ratio tracks structure rather than length: 4.2× on
+  plain prose, **12.4×** on the structural brief.
+
+### The failure that decided it
+
+On the Substack-native brief the Markdown model degraded the button to `[Subscribe](%%checkout_url%%)`
+and dropped the paywall. The output was valid Markdown, it rendered to a document that **passes this
+very schema**, and `unsupported` came back **empty**.
+
+That is the whole argument. A report of unsupported constructs can only name what Markdown *has* and
+Substack lacks. What Markdown *lacks* gets substituted upstream, inside the model, and reaches us as
+healthy prose. The post publishes with its paid section public and nothing anywhere says so — the
+exact silent-drop class CLAUDE.md documents five times over, except authored by us.
+
+### What strictness costs
+
+`digestPostEmbed` sits in 59 of 60 real posts and is not a node worth modelling. A schema that
+rejects unknown node types therefore **rejects 59 of 60 real documents**, killing any
+read-modify-write flow on the first try. This is decided below, not left open.
+
+## Architecture
+
+### A dedicated tool, so the schema is published once
+
+`set_post_body(draft_id, body)`. Creation and body-writing become separate verbs, and the 16 KB
+schema is carried by one tool instead of two — publishing it on both `create_draft_post` and
+`update_draft` would add ~32 KB to a `tools/list` that is 34.7 KB today, a 92% increase paid by every
+session including those that never write a post.
+
+It PUTs `draft_body` to `PUT /api/v1/drafts/:id`, verified to accept it and to store it **verbatim**:
+no normalisation, no filled-in defaults. The server is a dumb store and the editor is the only
+validator, which is why the validation has to live here.
+
+`src/api/substack/document.js` holds the schema and nothing else — no I/O, no env reads — beside
+`csv.js` and in the same spirit: one bounded translation with its own colocated spec.
+
+### One validator, two doors — and the second door does not pay for it
+
+`create_draft_post.body` keeps its type and its plain-text behaviour, but its JSON branch stops being
+a hole: the parsed value is validated **against the same schema**, and the same error message comes
+back. The schema is not published on that tool, so the cost is zero and the protection is total.
+
+This is the one place where "validate without publishing" is exactly right: publishing teaches a
+model the vocabulary — worth 16 KB where structure is authored — while validating protects even where
+nothing was taught. Nothing new can enter this server unvalidated.
+
+### Node coverage and the permissive tail
+
+Modelled, with their verified shapes: `paragraph`, `heading`, `bullet_list`, `ordered_list`,
+`list_item`, `blockquote`, `highlighted_code_block`, `code_block` (legacy, accepted not encouraged),
+`horizontal_rule`, `captionedImage`/`image2`/`caption`, `button`, `paywall`. Marks: `strong`, `em`,
+`code`, `strikethrough`, `link`.
+
+Then two deliberate relaxations, each with its own reason:
+
+- **`attrs` on a known node are permissive** (`looseObject`), so `textAlign: null` and `nodeId: null`
+  survive a round trip untouched. Required attrs still guard: a heading missing `level` is an error,
+  and a typo'd `levl` fails on the *absent* `level` rather than passing.
+- **An unknown node type is accepted, preserved verbatim, and named in the result** as
+  `passed_through`. Accepting it silently would hand back the silent-drop problem — a mistyped
+  `codeBlock` would sail through — so the report is what keeps the discriminated union's teeth. It is
+  the `unsupported` idea moved to the input side, where the earlier experiment proved it actually
+  fires.
+
+The discriminated union is what makes the errors worth publishing. Measured on the real schema:
+
+```
+content.0.type: Invalid discriminator value. Expected 'paragraph' | 'heading' | 'bullet_list' | …
+content.0: Unrecognized key: "attrs"
+content.0.content.0.marks.0.attrs: Invalid input: expected object, received undefined
+```
+
+Exact path, and the valid alternatives named. A plain `z.union` gives none of that, so the union must
+stay discriminated even where recursion makes it awkward — verified working through zod's getter form,
+including a two-deep nested list, and converting to draft-7 with a self-contained `definitions` block.
+
+## Testing
+
+`document.spec.js`, colocated and table-driven: every modelled node, marks nested inside list items
+and blockquotes, `attrs` passthrough, an unknown node type reaching `passed_through`, and the four
+error messages above pinned by wording — `src/server.spec.js` already pins validation wording on
+purpose, because a degraded message breaks nothing by itself and only an assertion catches it.
+
+Two fixtures earn their place: a **real post document** pulled from the publication, asserting it
+validates and that `digestPostEmbed` is reported rather than rejected; and the five briefs' documents
+from this experiment, asserting the shapes a model actually produces stay accepted.
+
+Per CLAUDE.md no new test is trusted on a first green run — each is confirmed by breaking the source,
+with the mutation grepped for before the run.
+
+## Behaviour changes to declare
+
+- `create_draft_post`'s JSON branch now **rejects** an invalid document instead of forwarding it. The
+  characterization test asserting a document "is passed through untouched" is rewritten, and its
+  comment updated in the same commit.
+- `create_draft_post.body` stays plain-text-to-paragraphs. It is *not* becoming Markdown: that design
+  is superseded, and the `/\n+/` split keeps its current behaviour, single newlines included.
+
+## Verification after implementation
+
+`set_post_body` against a scratch draft carrying every modelled node, then the editor reloaded to
+confirm each renders — the same loop that produced the node shapes, and the only thing that catches a
+name right in the spec and wrong in the code. Then a real post read, validated, and written back
+unchanged, asserting the round trip preserves what it passed through.
+
+## Open items
+
+The code-block language table. `auto` is the auto-detect sentinel, `plaintext` the plain-text value,
+and values are lowercase highlight.js names of which the dropdown shows a subset — the bundle also
+references `php`, `dockerfile` and `xml`. An unrecognised value renders as Plain Text **silently**, so
+the pairs are to be lifted from the editor bundle rather than guessed, and the schema describes the
+common ones without pretending to be exhaustive.

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -57,6 +57,7 @@ mutation-tested first and all six deliberate corruptions turned a check red.
 - **The document validated 5/5 on the first attempt, zero repair rounds.** A 16 KB published schema
   is enough for a model to get nested lists, `ordered_list` with `start: 3`, a link inside a list
   item, a blockquote containing a list, a paywall, a button and a captioned image right first time.
+  (That trial ran against a 16 KB prototype; the shipped schema is 20.3 KB, richer in descriptions.)
 - **Where both can express a construct the result is semantically identical** — `em` on exactly
   "not", `code` on exactly `API_KEY`, `strong` on "Boring", the link on the intended words, all three
   code blocks with matching languages and lengths, and a `${API_KEY:?…}` shell guard intact.
@@ -85,10 +86,14 @@ so all of them get modelled and nothing has to be waved through.
 
 ### A dedicated tool, so the schema is published once
 
-`set_post_body(draft_id, body)`. Creation and body-writing become separate verbs, and the 16 KB
-schema is carried by one tool instead of two — publishing it on both `create_draft_post` and
-`update_draft` would add ~32 KB to a `tools/list` that is 34.7 KB today, a 92% increase paid by every
-session including those that never write a post.
+`set_post_body(draft_id, body)`. Creation and body-writing become separate verbs, and the schema is
+carried by one tool instead of two — publishing it on both `create_draft_post` and `update_draft` would
+double its cost for every session, including those that never write a post.
+
+**The finished schema publishes at 20,342 bytes**, measured on the implemented module rather than on the
+prototype that suggested 16 KB: the extra four node types and the descriptions on every branch account
+for the difference. Against a `tools/list` of 34.7 KB before this work, one copy is a ~59% increase and
+two would have been ~117%.
 
 It PUTs `draft_body` to `PUT /api/v1/drafts/:id`, verified to accept it and to store it **verbatim**:
 no normalisation, no filled-in defaults. The server is a dumb store and the editor is the only

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -123,7 +123,7 @@ Then two deliberate choices, each with its own reason:
   branch. The 60-post survey enumerates the whole set: `paragraph`, `heading`, `text`, `blockquote`,
   `bullet_list`, `ordered_list`, `list_item`, `horizontal_rule`, `hard_break`, `code_block`,
   `highlighted_code_block`, `captionedImage`, `image2`, `caption`, `button`, `paywall`,
-  `digestPostEmbed`, `substack_mentions`, `directMessage`. The three whose internals were never read —
+  `digestPostEmbed`, `substack_mentions`, `directMessage`, `youtube2`. The three whose internals were never read —
   `digestPostEmbed`, `substack_mentions`, `directMessage` — are modelled as a `looseObject` on their
   literal `type`: everything else passes through preserved, which is enough for a round trip and
   honest about knowing no more than that.
@@ -136,9 +136,15 @@ Then two deliberate choices, each with its own reason:
   node then fails **loudly**, naming the types it could have been — visible, which is the opposite of
   the silent drop this design exists to prevent.
 
-  The residual risk is stated rather than engineered away: the enumeration comes from 60 posts of one
-  publication, so a node this publication has never used — `youtube2`, a footnote, LaTeX, a poll —
-  blocks a round trip until it is added. Adding one is a line in the union, and the failure says so.
+  **The enumeration had to be widened once already, which is the honest measure of this risk.** The
+  first survey covered `implementing` only. Sampling the second publication, `quickviewai`, found
+  `youtube2` — `{videoId}`, no content — in **33 of 40** posts, so the union as first drafted would
+  have blocked a round trip on most of that archive. Both publications are now covered.
+
+  The residual risk is stated rather than engineered away: a node neither publication has used — a
+  footnote, LaTeX, a poll, a subscribe widget — still blocks a round trip until its shape is read off
+  a live draft and added. Adding one is a line in the union, and the failure names the alternatives
+  rather than going quiet.
 
 ### At most one paywall, and we are the only ones enforcing it
 

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -227,6 +227,19 @@ confirm each renders — the same loop that produced the node shapes, and the on
 name right in the spec and wrong in the code. Then a real post read, validated, and written back
 unchanged, asserting the round trip preserves what it passed through.
 
+### What the 16 KB is actually made of
+
+Measured during the Task 1 review: the SDK converts with `z4mini.toJSONSchema(schema, {target, io})`
+and passes no `reused` option, so shared subtrees are **inlined**, not referenced. On a two-node
+schema that already means 80% of the published bytes are two verbatim copies of the inline-content and
+mark union. Passing `reused: 'ref'` would shrink it, but `registerTool` gives no way to reach that
+option, and the names it generates are machine-made (`__schema0`…).
+
+So the 16 KB figure is not a ceiling that better factoring would lower — it is what this schema costs
+through the SDK, and each further node carrying inline content adds roughly another 1.7 KB. Worth
+knowing before anyone tries to optimise it, and worth re-measuring rather than assuming if the node
+list grows much beyond the current fourteen.
+
 ## Limits
 
 **Images can be referenced but not uploaded**, and this is the design's sharpest practical limit:

--- a/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
+++ b/docs/superpowers/specs/2026-08-07-post-body-contract-design.md
@@ -227,6 +227,36 @@ confirm each renders — the same loop that produced the node shapes, and the on
 name right in the spec and wrong in the code. Then a real post read, validated, and written back
 unchanged, asserting the round trip preserves what it passed through.
 
+## Limits
+
+**Images can be referenced but not uploaded**, and this is the design's sharpest practical limit:
+`captionedImage` appears in 60 of 60 sampled posts, while `image2.src` must already point at a
+Substack-hosted asset. A post that reuses an existing image works; a post that needs a new one does
+not.
+
+An attempt to settle the upload endpoint on 2026-08-07 **failed, and the failure is the finding.**
+`POST /api/v1/image` on the publication host was tried three ways — `{image: <data URL>}` as JSON (the
+fork's shape), as `application/x-www-form-urlencoded` (python-substack's shape, since `requests`'
+`data=` is form-encoded rather than JSON), and as `multipart/form-data`. **All three hang.** The
+browser's own network log shows the request pending indefinitely: the server accepts the connection and
+never answers, past a minute. A cross-origin attempt at `substack.com/api/v1/image` never settled
+either.
+
+So neither source's claim is confirmed, and the endpoint as both describe it does not respond to a real
+logged-in session. This belongs beside `audience_insights/location` and `visitor_sources` — documented
+endpoints that do not work — except that here the documentation is a third party's rather than
+Substack's own. **Do not implement an upload from either signature.**
+
+Settling it means watching the editor upload something itself, which is a different kind of work from
+replaying a request: it needs a file reaching a file picker or a paste event. Deliberately not folded
+into this design.
+
+Nodes that stay out until their shape is read off a live draft: LaTeX, footnotes, polls, poetry,
+recipes, the subscribe widget, and the financial chart — all names in the editor's "More" menu, none
+with a shape anyone has verified. `calloutBlock` and `pullquote` stay out for a stronger reason: they
+come only from `python-substack`, the file that was wrong about `codeBlock`, and appear in that menu
+nowhere.
+
 ## Open items
 
 The code-block language table. `auto` is the auto-detect sentinel, `plaintext` the plain-text value,

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -1,0 +1,57 @@
+import {z} from "zod";
+
+// The Substack post body, as a ProseMirror document.
+//
+// Every node name and attr shape here was read off a live draft or a live published post on
+// 2026-08-07, never taken from a third-party client — `python-substack` declares the code block as
+// `codeBlock`, which Substack does not render. See the design spec for the survey behind the
+// enumeration: 60 published posts, every node type in use counted.
+//
+// Two rules govern how strict this is, and they pull in opposite directions on purpose:
+//
+//  - `type` is strict. It is a discriminated union so an unrecognised node is rejected with the
+//    valid alternatives named, which is the only feedback an LLM gets to repair the call.
+//  - `attrs` are loose. The editor writes `textAlign: null` on paragraphs and headings and
+//    `nodeId: null` on code blocks; rejecting those would reject every real post and kill any
+//    read-modify-write flow. Required attrs still guard, so a heading without `level` fails.
+
+const looseAttrs = z.looseObject({});
+
+const markSchema = z.discriminatedUnion('type', [
+  z.strictObject({type: z.literal('strong')}).describe('Bold.'),
+  z.strictObject({type: z.literal('em')}).describe('Italic.'),
+  z.strictObject({type: z.literal('code')}).describe('Inline code, for a short literal inside a sentence.'),
+  z.strictObject({type: z.literal('strikethrough')}).describe('Struck through.'),
+  z.strictObject({
+    type: z.literal('link'),
+    attrs: z.looseObject({href: z.string().describe('Absolute URL.')}),
+  }).describe('A link. The visible words are the text node this mark is applied to.'),
+]).describe('An inline mark applied to a text node. A mark is never a node in its own right.');
+
+const textNode = z.strictObject({
+  type: z.literal('text'),
+  text: z.string(),
+  marks: z.array(markSchema).optional().describe('Omit when the text is plain. Marks may combine.'),
+}).describe('A run of text. Split a sentence into several text nodes to mark only part of it.');
+
+const hardBreakNode = z.strictObject({type: z.literal('hard_break')})
+  .describe('A line break inside a paragraph. Prefer separate paragraphs.');
+
+const inlineContent = z.array(z.discriminatedUnion('type', [textNode, hardBreakNode]));
+
+const paragraphNode = z.strictObject({
+  type: z.literal('paragraph'),
+  attrs: looseAttrs.optional(),
+  content: inlineContent.optional().describe('Omit for an empty paragraph.'),
+});
+
+const headingNode = z.strictObject({
+  type: z.literal('heading'),
+  attrs: z.looseObject({level: z.number().int().min(1).max(6)}),
+  content: inlineContent,
+});
+
+export const postBodySchema = z.strictObject({
+  type: z.literal('doc'),
+  content: z.array(z.discriminatedUnion('type', [paragraphNode, headingNode])),
+}).describe('The post body as a Substack ProseMirror document.');

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -15,7 +15,7 @@ import {z} from "zod";
 //    `nodeId: null` on code blocks; rejecting those would reject every real post and kill any
 //    read-modify-write flow. Required attrs still guard, so a heading without `level` fails.
 
-const looseAttrs = z.looseObject({});
+const looseAttrs = z.looseObject({}).describe('Editor-written attributes; pass them back unchanged.');
 
 const markSchema = z.discriminatedUnion('type', [
   z.strictObject({type: z.literal('strong')}).describe('Bold.'),
@@ -43,13 +43,23 @@ const paragraphNode = z.strictObject({
   type: z.literal('paragraph'),
   attrs: looseAttrs.optional(),
   content: inlineContent.optional().describe('Omit for an empty paragraph.'),
-});
+}).describe('A paragraph of text — the most common node in the document.');
 
+const headingAttrs = looseAttrs.extend({
+  level: z.number().int().min(1).max(6).describe('Heading level, 1 (largest) to 6 (smallest).'),
+}).describe('Editor-written attributes; pass them back unchanged.');
+
+// content is optional, matching paragraphNode, rather than required as ProseMirror would allow:
+// zero empty headings turned up across the 12 real published posts sampled for this design, so the
+// evidence for either choice is weak, but the consequence is not. Rejecting a real document breaks
+// the read-modify-write round trip this contract exists to protect; accepting a contentless heading
+// is at worst a cosmetic authoring mistake. Do not tighten this back to required without
+// remeasuring against a larger sample.
 const headingNode = z.strictObject({
   type: z.literal('heading'),
-  attrs: z.looseObject({level: z.number().int().min(1).max(6)}),
-  content: inlineContent,
-});
+  attrs: headingAttrs,
+  content: inlineContent.optional().describe('Omit for an empty heading.'),
+}).describe('A section heading, levels 1 to 6.');
 
 export const postBodySchema = z.strictObject({
   type: z.literal('doc'),

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -177,3 +177,29 @@ export const postBodySchema = z.strictObject({
     (document) => document.content.filter((node) => node.type === 'paywall').length <= 1,
     {message: 'A document may contain at most one paywall node.', path: ['content']}
   );
+
+/**
+ * Counts the nodes in a document by type, so a caller can confirm that what it asked for landed.
+ *
+ * Validation cannot do this job: a document with no paywall is exactly as valid as one with a
+ * paywall, so legality has no opinion about an omission. This was measured — a model asked for a
+ * paywall through a Markdown contract omitted it, produced valid Markdown, and the document it
+ * rendered to passes this very schema. `text` and `doc` are left out because a tally dominated by
+ * text runs buries the numbers actually being looked for.
+ */
+export const summarizeNodes = (document) => {
+  const counts = {};
+
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return;
+
+    if (typeof node.type === 'string' && node.type !== 'text' && node.type !== 'doc') {
+      counts[node.type] = (counts[node.type] ?? 0) + 1;
+    }
+
+    if (Array.isArray(node.content)) node.content.forEach(walk);
+  };
+
+  walk(document);
+  return counts;
+};

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -117,11 +117,57 @@ const horizontalRuleNode = z.strictObject({type: z.literal('horizontal_rule')})
 const paywallNode = z.strictObject({type: z.literal('paywall')})
   .describe('Everything after this node is for paying subscribers only. At most one per document.');
 
+const captionedImageNode = z.strictObject({
+  type: z.literal('captionedImage'),
+  content: z.array(z.discriminatedUnion('type', [
+    z.strictObject({
+      type: z.literal('image2'),
+      attrs: looseAttrs.extend({
+        src: z.string().describe('Image URL. It must already be hosted by Substack — an external url is stored but does not render.'),
+        alt: z.string().nullable().optional(),
+      }),
+    }).describe('The image itself. Only valid inside a captionedImage.'),
+    z.strictObject({
+      type: z.literal('caption'),
+      content: inlineContent.optional(),
+    }).describe('The caption under an image. Only valid inside a captionedImage.'),
+  ])),
+}).describe('An image, optionally followed by a caption node.');
+
+const buttonNode = z.strictObject({
+  type: z.literal('button'),
+  attrs: looseAttrs.extend({
+    url: z.string().describe('Target, or a Substack placeholder: %%checkout_url%% to subscribe, %%share_url%% to share.'),
+    text: z.string().describe('The button label.'),
+  }),
+}).describe('A call-to-action button.');
+
+// Verified 2026-08-07 on the quickviewai publication, where it appears in 33 of 40 sampled posts:
+// exactly `{videoId}` and no content, identical in every occurrence. `SubstackPost.youtubeVideo()`
+// already builds this shape, so on this one node the existing builder was right.
+const youtubeNode = z.strictObject({
+  type: z.literal('youtube2'),
+  attrs: looseAttrs.extend({videoId: z.string().describe('The YouTube video id, not the watch URL.')}),
+}).describe('An embedded YouTube video.');
+
+// A node whose internals were never read. `looseObject` keeps everything it carries — including its
+// content — so a round trip preserves it exactly, while claiming no knowledge we do not have.
+const opaqueNode = (type, description) =>
+  z.looseObject({type: z.literal(type)}).describe(description);
+
+// Present in the live archive, internals never read. digestPostEmbed alone is in 59 of 60 sampled
+// posts, so these three are what make a read-modify-write round trip possible at all.
+const digestPostEmbedNode = opaqueNode('digestPostEmbed', 'An embedded post card. Substack inserts this itself; pass it back unchanged.');
+const substackMentionsNode = opaqueNode('substack_mentions', 'A mention of another publication or user.');
+const directMessageNode = opaqueNode('directMessage', 'A direct-message block.');
+
 export const postBodySchema = z.strictObject({
   type: z.literal('doc'),
   content: z.array(z.discriminatedUnion('type', [
     paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
     codeBlockNode, legacyCodeBlockNode, horizontalRuleNode, paywallNode,
+    captionedImageNode, buttonNode, youtubeNode,
+    digestPostEmbedNode, substackMentionsNode, directMessageNode,
   ])),
 })
   .describe('The post body as a Substack ProseMirror document.')

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -79,10 +79,20 @@ const bulletListNode = z.strictObject({
   get content() { return z.array(listItemNode); },
 }).describe('A bulleted list.');
 
+// `order` is what renders, not `start` — measured 2026-08-08 against the live editor, which is the
+// only thing that could have caught it. A list given `{start: 3}` is stored verbatim, answers 200, and
+// then numbers from 1 with no error anywhere; `{order: 3}` numbers from 3. The editor itself writes
+// both (`{start: 1, type: null, order: 1}`), which is why reading one of its documents suggests either
+// would do. Describing `start` as the one to set would have made this the sixth silent-ignore in this
+// API and the first of our own making.
 const orderedListNode = z.strictObject({
   type: z.literal('ordered_list'),
-  attrs: looseAttrs.extend({start: z.number().int().optional()}).optional()
-    .describe('Omit unless the list starts somewhere other than 1.'),
+  attrs: looseAttrs.extend({
+    order: z.number().int().optional()
+      .describe('The number the list starts from. Omit for 1. This is the attr that renders.'),
+    start: z.number().int().optional()
+      .describe('Written by the editor next to `order` and ignored by the renderer. Set `order` instead.'),
+  }).optional(),
   get content() { return z.array(listItemNode); },
 }).describe('A numbered list.');
 

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -61,7 +61,39 @@ const headingNode = z.strictObject({
   content: inlineContent.optional().describe('Omit for an empty heading.'),
 }).describe('A section heading, levels 1 to 6.');
 
+// Recursion through getters, which is how zod 4 expresses it. The unions here stay discriminated
+// even though a plain `z.union` would be less awkward: a plain one reports no usable message, which
+// was measured rather than assumed — a malformed node came back as "this is a modelled node, match
+// its shape" with no mention of which field was wrong.
+const listItemNode = z.strictObject({
+  type: z.literal('list_item'),
+  get content() {
+    return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode]))
+      .describe('A paragraph, plus a nested list for sub-items.');
+  },
+}).describe('One item of a list. Its text goes in a paragraph, never directly in the item.');
+
+const bulletListNode = z.strictObject({
+  type: z.literal('bullet_list'),
+  attrs: looseAttrs.optional(),
+  get content() { return z.array(listItemNode); },
+}).describe('A bulleted list.');
+
+const orderedListNode = z.strictObject({
+  type: z.literal('ordered_list'),
+  attrs: looseAttrs.extend({start: z.number().int().optional()}).optional()
+    .describe('Omit unless the list starts somewhere other than 1.'),
+  get content() { return z.array(listItemNode); },
+}).describe('A numbered list.');
+
+const blockquoteNode = z.strictObject({
+  type: z.literal('blockquote'),
+  get content() { return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode])); },
+}).describe('A quotation. Holds paragraphs and lists, not bare text.');
+
 export const postBodySchema = z.strictObject({
   type: z.literal('doc'),
-  content: z.array(z.discriminatedUnion('type', [paragraphNode, headingNode])),
+  content: z.array(z.discriminatedUnion('type', [
+    paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
+  ])),
 }).describe('The post body as a Substack ProseMirror document.');

--- a/src/api/substack/document.js
+++ b/src/api/substack/document.js
@@ -91,9 +91,43 @@ const blockquoteNode = z.strictObject({
   get content() { return z.array(z.discriminatedUnion('type', [paragraphNode, bulletListNode, orderedListNode])); },
 }).describe('A quotation. Holds paragraphs and lists, not bare text.');
 
+// `highlighted_code_block`, not `codeBlock`: read off the live editor. `python-substack` declares
+// the latter, and a node by that name is not rendered.
+const codeBlockNode = z.strictObject({
+  type: z.literal('highlighted_code_block'),
+  attrs: looseAttrs.extend({
+    language: z.string().optional().describe(
+      'Lowercase highlight.js name — javascript, typescript, python, bash, json, sql, go, rust, ' +
+      'yaml, css, html and similar. Omit to let Substack auto-detect. An unrecognised value is ' +
+      'accepted and then silently rendered as plain text, so omitting beats guessing.'
+    ),
+  }).optional(),
+  content: inlineContent.describe('One text node holding the whole snippet, newlines included.'),
+}).describe('A syntax-highlighted code block.');
+
+const legacyCodeBlockNode = z.strictObject({
+  type: z.literal('code_block'),
+  attrs: looseAttrs.optional(),
+  content: inlineContent,
+}).describe('The older code block, still present in existing posts. Use highlighted_code_block for new content.');
+
+const horizontalRuleNode = z.strictObject({type: z.literal('horizontal_rule')})
+  .describe('A horizontal divider.');
+
+const paywallNode = z.strictObject({type: z.literal('paywall')})
+  .describe('Everything after this node is for paying subscribers only. At most one per document.');
+
 export const postBodySchema = z.strictObject({
   type: z.literal('doc'),
   content: z.array(z.discriminatedUnion('type', [
     paragraphNode, headingNode, bulletListNode, orderedListNode, blockquoteNode,
+    codeBlockNode, legacyCodeBlockNode, horizontalRuleNode, paywallNode,
   ])),
-}).describe('The post body as a Substack ProseMirror document.');
+})
+  .describe('The post body as a Substack ProseMirror document.')
+  // A refinement does not survive into the published JSON Schema — verified — which is why the rule
+  // is also written into paywallNode's description. Without that a model would meet it by failing.
+  .refine(
+    (document) => document.content.filter((node) => node.type === 'paywall').length <= 1,
+    {message: 'A document may contain at most one paywall node.', path: ['content']}
+  );

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -231,3 +231,45 @@ describe('postBodySchema — lists and quotes', () => {
     assert.equal(parse(doc(quote)).success, true);
   });
 });
+
+describe('postBodySchema — code, rules and the paywall', () => {
+  const code = (attrs) => ({type: 'highlighted_code_block', ...(attrs ? {attrs} : {}), content: [text('const a = 1;')]});
+
+  test('accepts a code block with a language', () => {
+    assert.equal(parse(doc(code({language: 'javascript'}))).success, true);
+  });
+
+  test('accepts a code block with no language, which auto-detects', () => {
+    assert.equal(parse(doc(code())).success, true);
+  });
+
+  test('preserves the nodeId the editor writes', () => {
+    const result = parse(doc(code({language: 'python', nodeId: null})));
+
+    assert.deepEqual(result.data.content[0].attrs, {language: 'python', nodeId: null});
+  });
+
+  // Both node names are in live use: older posts carry code_block, the current editor writes
+  // highlighted_code_block. Rejecting the legacy one would reject those posts.
+  test('accepts the legacy code_block', () => {
+    assert.equal(parse(doc({type: 'code_block', content: [text('legacy')]})).success, true);
+  });
+
+  test('accepts a horizontal rule', () => {
+    assert.equal(parse(doc({type: 'horizontal_rule'})).success, true);
+  });
+
+  test('accepts a single paywall', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [text('free')]}, {type: 'paywall'})).success, true);
+  });
+
+  // Measured 2026-08-07: two paywalls are accepted by the API with a 200 and rendered by the editor
+  // as two "Paid content below this line" markers, so which one cuts the post is undefined. Neither
+  // the API nor the editor guards this; this refinement is the only check that exists.
+  test('rejects a second paywall', () => {
+    const result = parse(doc({type: 'paywall'}, {type: 'paragraph'}, {type: 'paywall'}));
+
+    assert.equal(result.success, false);
+    assert.match(result.error.issues.map(i => i.message).join(' '), /at most one paywall/i);
+  });
+});

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -191,12 +191,30 @@ describe('postBodySchema — lists and quotes', () => {
     assert.equal(parse(doc({type: 'ordered_list', content: [item('one')]})).success, true);
   });
 
-  test('accepts the start attr the editor writes', () => {
+  test('accepts the full attr bag the editor writes on a numbered list', () => {
     const list = {type: 'ordered_list', attrs: {start: 3, type: null, order: 1}, content: [item('three')]};
     const result = parse(doc(list));
 
     assert.equal(result.success, true);
-    assert.equal(result.data.content[0].attrs.start, 3);
+    assert.deepEqual(result.data.content[0].attrs, {start: 3, type: null, order: 1});
+  });
+
+  // Measured 2026-08-08 against the live editor: `order` is what renders, `start` is stored and
+  // ignored. A list given only {start: 3} numbers from 1, with a 200 and no error, so the schema
+  // describes `order` as the one to set. Both are accepted because the editor writes both.
+  test('accepts order, which is the attr that renders', () => {
+    const result = parse(doc({type: 'ordered_list', attrs: {order: 3}, content: [item('three')]}));
+
+    assert.equal(result.success, true);
+    assert.equal(result.data.content[0].attrs.order, 3);
+  });
+
+  test('describes order as the renderer-visible attr and start as ignored', () => {
+    const json = z.toJSONSchema(postBodySchema, {target: 'draft-7', io: 'input'});
+    const published = JSON.stringify(json);
+
+    assert.match(published, /the attr that renders/);
+    assert.match(published, /ignored by the renderer/);
   });
 
   test('accepts a list nested inside a list item', () => {

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -1,5 +1,6 @@
 import {test, describe, before, after} from 'node:test';
 import assert from 'node:assert/strict';
+import {z} from 'zod';
 import {postBodySchema} from './document.js';
 import {setTestEnv} from '../../../test/helpers/env.js';
 
@@ -12,7 +13,15 @@ after(() => restoreEnv());
 const doc = (...content) => ({type: 'doc', content});
 const text = (value) => ({type: 'text', text: value});
 const parse = (value) => postBodySchema.safeParse(value);
-const issues = (value) => parse(value).error.issues.map(i => `${i.path.join('.')}: ${i.message}`);
+
+// Guarded the way CLAUDE.md documents for callTool results: reading .error.issues on a parse that
+// unexpectedly succeeded throws a TypeError that buries the real diff under an unrelated stack.
+const issues = (value) => {
+  const result = parse(value);
+
+  assert.equal(result.success, false, 'expected the parse to fail, but it succeeded');
+  return result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`);
+};
 
 describe('postBodySchema — paragraphs and text', () => {
   test('accepts an empty document', () => {
@@ -98,5 +107,62 @@ describe('postBodySchema — headings', () => {
     assert.match(message, /Invalid discriminator value/);
     assert.match(message, /'paragraph'/);
     assert.match(message, /'heading'/);
+  });
+
+  test('accepts a heading with no content at all', () => {
+    assert.equal(parse(doc({type: 'heading', attrs: {level: 2}})).success, true);
+  });
+
+  test('rejects heading level 0', () => {
+    assert.equal(parse(doc({type: 'heading', attrs: {level: 0}, content: [text('T')]})).success, false);
+  });
+
+  test('rejects a fractional heading level', () => {
+    assert.equal(parse(doc({type: 'heading', attrs: {level: 2.5}, content: [text('T')]})).success, false);
+  });
+});
+
+describe('postBodySchema — strictness', () => {
+  // CLAUDE.md: a plain z.object strips unknown keys silently, which would delete a node key this
+  // schema does not model from a read-modify-write round trip. strictObject is what turns that into
+  // a reported error instead, so every node level gets its own check rather than trusting one.
+  test('rejects an unknown key on the document root, naming it', () => {
+    assert.match(issues({type: 'doc', content: [], bogus: true}).join(' '), /Unrecognized key.*bogus/);
+  });
+
+  test('rejects an unknown key on a paragraph node, naming it', () => {
+    assert.match(issues(doc({type: 'paragraph', content: [], bogus: true})).join(' '), /Unrecognized key.*bogus/);
+  });
+
+  test('rejects an unknown key on a heading node, naming it', () => {
+    const node = {type: 'heading', attrs: {level: 1}, content: [text('T')], bogus: true};
+
+    assert.match(issues(doc(node)).join(' '), /Unrecognized key.*bogus/);
+  });
+
+  test('rejects an unknown key on a text node, naming it', () => {
+    const node = {type: 'text', text: 'x', bogus: true};
+
+    assert.match(issues(doc({type: 'paragraph', content: [node]})).join(' '), /Unrecognized key.*bogus/);
+  });
+
+  test('rejects a text node with no text', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [{type: 'text'}]})).success, false);
+  });
+});
+
+describe('postBodySchema — descriptions', () => {
+  // Regression guard for the exact hazard CLAUDE.md records: this schema publishes as a tool's
+  // JSON Schema and the description is the only vocabulary a calling model gets, so stripping every
+  // .describe() call must fail a test, not just read badly. z.toJSONSchema with these exact options
+  // is the call the SDK itself makes (server/zod-json-schema-compat.js), not an approximation of it.
+  test('every content node carries a description in the published schema', () => {
+    const json = z.toJSONSchema(postBodySchema, {target: 'draft-7', io: 'input'});
+    const branches = json.properties.content.items.oneOf;
+
+    assert.ok(branches.length > 0);
+    for (const branch of branches) {
+      assert.ok(branch.description, `${branch.properties.type.const} node has no description`);
+    }
   });
 });

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -1,7 +1,7 @@
 import {test, describe, before, after} from 'node:test';
 import assert from 'node:assert/strict';
 import {z} from 'zod';
-import {postBodySchema} from './document.js';
+import {postBodySchema, summarizeNodes} from './document.js';
 import {setTestEnv} from '../../../test/helpers/env.js';
 
 // setTestEnv is called even though this module reads no env var of its own: CLAUDE.md requires it
@@ -341,5 +341,127 @@ describe('postBodySchema — images, buttons and opaque nodes', () => {
 
     assert.match(message, /Invalid discriminator value/);
     assert.match(message, /'captionedImage'/);
+  });
+});
+
+describe('summarizeNodes', () => {
+  test('counts the node types in a flat document', () => {
+    const document = {type: 'doc', content: [
+      {type: 'paragraph', content: [text('a')]},
+      {type: 'paragraph', content: [text('b')]},
+      {type: 'horizontal_rule'},
+    ]};
+
+    assert.deepEqual(summarizeNodes(document), {paragraph: 2, horizontal_rule: 1});
+  });
+
+  test('counts nodes nested inside lists and quotes', () => {
+    const document = {type: 'doc', content: [{
+      type: 'bullet_list',
+      content: [{type: 'list_item', content: [{type: 'paragraph', content: [text('x')]}]}],
+    }]};
+
+    assert.deepEqual(summarizeNodes(document), {bullet_list: 1, list_item: 1, paragraph: 1});
+  });
+
+  // `text` is excluded on purpose: a tally dominated by hundreds of text runs buries the one number
+  // a caller is looking for, which is whether the paywall and the button are there.
+  test('does not count text or the doc itself', () => {
+    const summary = summarizeNodes({type: 'doc', content: [{type: 'paragraph', content: [text('a'), text('b')]}]});
+
+    assert.deepEqual(summary, {paragraph: 1});
+  });
+
+  test('counts a paywall so a caller can confirm it landed', () => {
+    const summary = summarizeNodes({type: 'doc', content: [{type: 'paywall'}]});
+
+    assert.deepEqual(summary, {paywall: 1});
+  });
+
+  test('returns an empty object for an empty document', () => {
+    assert.deepEqual(summarizeNodes({type: 'doc', content: []}), {});
+  });
+});
+
+// Shaped like a real published post rather than like something a writer would compose: every
+// paragraph and heading carries attrs: {textAlign: null}, and the nodes below appear in the live
+// archive — digestPostEmbed in 59 of 60 sampled posts. If this stops validating, the round trip this
+// contract exists to allow is broken, and no schema-first test would notice.
+const REAL_POST_SHAPE = {
+  type: 'doc',
+  content: [
+    {type: 'digestPostEmbed', attrs: {id: 210189950, publication_id: 2150088}},
+    {type: 'heading', attrs: {textAlign: null, level: 2}, content: [{type: 'text', text: 'A section'}]},
+    {type: 'paragraph', attrs: {textAlign: null}, content: [
+      {type: 'text', text: 'Prose with '},
+      {type: 'text', marks: [{type: 'strong'}], text: 'weight'},
+      {type: 'text', text: ' and a '},
+      {type: 'text', marks: [{type: 'link', attrs: {href: 'https://example.com', target: '_blank', rel: 'noopener noreferrer nofollow', class: null}}], text: 'link'},
+      {type: 'text', text: '.'},
+    ]},
+    {type: 'captionedImage', content: [
+      {type: 'image2', attrs: {src: 'https://substackcdn.com/image/fetch/x.png', srcNoWatermark: null, fullscreen: false, imageSize: 'normal', height: 819, width: 1456, resizeWidth: 728, bytes: null, alt: null, title: null, type: null, href: null, belowTheFold: false, topImage: false, internalRedirect: null, isProcessing: false, align: null, offset: false}},
+      {type: 'caption', content: [{type: 'text', text: 'A caption'}]},
+    ]},
+    {type: 'button', attrs: {url: '%%share_url%%', text: 'Share', action: null, class: 'button-wrapper'}},
+    {type: 'horizontal_rule'},
+    {type: 'code_block', content: [{type: 'text', text: 'legacy snippet'}]},
+    {type: 'substack_mentions', attrs: {publicationId: 2073698}},
+  ],
+};
+
+// The structural shapes a model actually produced when handed the published schema, kept so a later
+// tightening cannot quietly start rejecting documents that were known to work.
+const MODEL_AUTHORED_SHAPE = {
+  type: 'doc',
+  content: [
+    {type: 'ordered_list', attrs: {start: 3}, content: [
+      {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'three'}]}]},
+    ]},
+    {type: 'bullet_list', content: [
+      {type: 'list_item', content: [
+        {type: 'paragraph', content: [{type: 'text', text: 'context'}]},
+        {type: 'bullet_list', content: [
+          {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'nested'}]}]},
+        ]},
+      ]},
+      {type: 'list_item', content: [{type: 'paragraph', content: [
+        {type: 'text', marks: [{type: 'link', attrs: {href: 'https://example.com/fixed'}}], text: 'a link in a list item'},
+      ]}]},
+    ]},
+    {type: 'blockquote', content: [
+      {type: 'bullet_list', content: [
+        {type: 'list_item', content: [{type: 'paragraph', content: [{type: 'text', text: 'quoted item'}]}]},
+      ]},
+    ]},
+    {type: 'highlighted_code_block', attrs: {language: 'bash'}, content: [{type: 'text', text: 'set -euo pipefail'}]},
+  ],
+};
+
+describe('postBodySchema — real documents', () => {
+  test('accepts a document shaped like a real published post', () => {
+    const result = parse(REAL_POST_SHAPE);
+
+    assert.equal(result.success, true, result.success ? '' : JSON.stringify(result.error?.issues));
+  });
+
+  test('preserves the opaque archive nodes exactly', () => {
+    const result = parse(REAL_POST_SHAPE);
+
+    assert.deepEqual(result.data.content[0], REAL_POST_SHAPE.content[0]);
+    assert.deepEqual(result.data.content.at(-1), REAL_POST_SHAPE.content.at(-1));
+  });
+
+  test('tallies a real-shaped post without drowning in text nodes', () => {
+    assert.deepEqual(summarizeNodes(REAL_POST_SHAPE), {
+      digestPostEmbed: 1, heading: 1, paragraph: 1, captionedImage: 1, image2: 1,
+      caption: 1, button: 1, horizontal_rule: 1, code_block: 1, substack_mentions: 1,
+    });
+  });
+
+  test('accepts the structures a model produced from the published schema', () => {
+    const result = parse(MODEL_AUTHORED_SHAPE);
+
+    assert.equal(result.success, true, result.success ? '' : JSON.stringify(result.error?.issues));
   });
 });

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -1,0 +1,102 @@
+import {test, describe, before, after} from 'node:test';
+import assert from 'node:assert/strict';
+import {postBodySchema} from './document.js';
+import {setTestEnv} from '../../../test/helpers/env.js';
+
+// setTestEnv is called even though this module reads no env var of its own: CLAUDE.md requires it
+// from every spec whose subject could log, and it keeps the reporter clean if that ever changes.
+let restoreEnv;
+before(() => { restoreEnv = setTestEnv(); });
+after(() => restoreEnv());
+
+const doc = (...content) => ({type: 'doc', content});
+const text = (value) => ({type: 'text', text: value});
+const parse = (value) => postBodySchema.safeParse(value);
+const issues = (value) => parse(value).error.issues.map(i => `${i.path.join('.')}: ${i.message}`);
+
+describe('postBodySchema — paragraphs and text', () => {
+  test('accepts an empty document', () => {
+    assert.equal(parse(doc()).success, true);
+  });
+
+  test('accepts a paragraph of plain text', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [text('hello')]})).success, true);
+  });
+
+  test('accepts a paragraph with no content at all', () => {
+    assert.equal(parse(doc({type: 'paragraph'})).success, true);
+  });
+
+  test('rejects a document whose type is not doc', () => {
+    assert.equal(parse({type: 'paragraph', content: []}).success, false);
+  });
+
+  // The editor writes attrs: {textAlign: null} on every paragraph and heading. A strictObject on
+  // attrs would reject every real post, so attrs are loose and unknown keys survive verbatim.
+  test('preserves attrs the schema does not model', () => {
+    const result = parse(doc({type: 'paragraph', attrs: {textAlign: null}, content: [text('x')]}));
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data.content[0].attrs, {textAlign: null});
+  });
+});
+
+describe('postBodySchema — marks', () => {
+  for (const type of ['strong', 'em', 'code', 'strikethrough']) {
+    test(`accepts the ${type} mark`, () => {
+      const node = {type: 'text', text: 'x', marks: [{type}]};
+
+      assert.equal(parse(doc({type: 'paragraph', content: [node]})).success, true);
+    });
+  }
+
+  test('accepts a link mark carrying an href', () => {
+    const node = {type: 'text', text: 'x', marks: [{type: 'link', attrs: {href: 'https://example.com'}}]};
+
+    assert.equal(parse(doc({type: 'paragraph', content: [node]})).success, true);
+  });
+
+  test('preserves the target and rel the editor adds to a link', () => {
+    const attrs = {href: 'https://example.com', target: '_blank', rel: 'noopener noreferrer nofollow'};
+    const result = parse(doc({type: 'paragraph', content: [{type: 'text', text: 'x', marks: [{type: 'link', attrs}]}]}));
+
+    assert.deepEqual(result.data.content[0].content[0].marks[0].attrs, attrs);
+  });
+
+  test('rejects a link mark with no href, naming the missing attrs', () => {
+    const node = {type: 'text', text: 'x', marks: [{type: 'link'}]};
+
+    assert.match(issues(doc({type: 'paragraph', content: [node]})).join(' '), /marks\.0\.attrs/);
+  });
+
+  // A mark is not a node. A model that emits {type: 'strong'} where a text node belongs gets told so.
+  test('rejects a mark used as a node', () => {
+    assert.equal(parse(doc({type: 'paragraph', content: [{type: 'strong', text: 'x'}]})).success, false);
+  });
+});
+
+describe('postBodySchema — headings', () => {
+  test('accepts levels 1 to 6', () => {
+    for (let level = 1; level <= 6; level++) {
+      assert.equal(parse(doc({type: 'heading', attrs: {level}, content: [text('T')]})).success, true, `level ${level}`);
+    }
+  });
+
+  test('rejects level 7', () => {
+    assert.equal(parse(doc({type: 'heading', attrs: {level: 7}, content: [text('T')]})).success, false);
+  });
+
+  test('rejects a heading with no level', () => {
+    assert.match(issues(doc({type: 'heading', content: [text('T')]})).join(' '), /attrs/);
+  });
+
+  // The whole reason the union is discriminated rather than a plain z.union: the message names the
+  // alternatives, which is a repair instruction rather than a complaint.
+  test('names the valid node types when the type is unrecognised', () => {
+    const message = issues(doc({type: 'codeBlock', content: []})).join(' ');
+
+    assert.match(message, /Invalid discriminator value/);
+    assert.match(message, /'paragraph'/);
+    assert.match(message, /'heading'/);
+  });
+});

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -153,16 +153,29 @@ describe('postBodySchema — strictness', () => {
 
 describe('postBodySchema — descriptions', () => {
   // Regression guard for the exact hazard CLAUDE.md records: this schema publishes as a tool's
-  // JSON Schema and the description is the only vocabulary a calling model gets, so stripping every
+  // JSON Schema and the description is the only vocabulary a calling model gets, so stripping any
   // .describe() call must fail a test, not just read badly. z.toJSONSchema with these exact options
   // is the call the SDK itself makes (server/zod-json-schema-compat.js), not an approximation of it.
-  test('every content node carries a description in the published schema', () => {
+  //
+  // The walk covers the whole converted schema, not just the top-level document union: list_item,
+  // image2 and caption (Tasks 2-4) are reachable only nested — inside list nodes and inside
+  // captionedImage — never as a top-level branch, and marks are nested under every text node. A
+  // check that only indexed into content.items.oneOf would be blind to exactly the nodes and marks
+  // that live one level down.
+  test('every node and mark in the published schema carries a description', () => {
     const json = z.toJSONSchema(postBodySchema, {target: 'draft-7', io: 'input'});
-    const branches = json.properties.content.items.oneOf;
+    const missing = [];
 
-    assert.ok(branches.length > 0);
-    for (const branch of branches) {
-      assert.ok(branch.description, `${branch.properties.type.const} node has no description`);
-    }
+    const walk = (node) => {
+      if (!node || typeof node !== 'object') return;
+      for (const branch of node.oneOf ?? []) {
+        const name = branch.properties?.type?.const;
+        if (name && !branch.description) missing.push(name);
+      }
+      for (const value of Object.values(node)) walk(value);
+    };
+
+    walk(json);
+    assert.deepEqual(missing, [], `undescribed: ${missing.join(', ')}`);
   });
 });

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -273,3 +273,73 @@ describe('postBodySchema — code, rules and the paywall', () => {
     assert.match(result.error.issues.map(i => i.message).join(' '), /at most one paywall/i);
   });
 });
+
+describe('postBodySchema — images, buttons and opaque nodes', () => {
+  const image = {type: 'image2', attrs: {src: 'https://substackcdn.com/image/fetch/x.png', alt: 'A board'}};
+
+  test('accepts an image inside a captionedImage', () => {
+    assert.equal(parse(doc({type: 'captionedImage', content: [image]})).success, true);
+  });
+
+  test('accepts a caption after the image', () => {
+    const caption = {type: 'caption', content: [text('One task per alert.')]};
+
+    assert.equal(parse(doc({type: 'captionedImage', content: [image, caption]})).success, true);
+  });
+
+  test('rejects an image2 outside a captionedImage', () => {
+    assert.equal(parse(doc(image)).success, false);
+  });
+
+  test('rejects an image with no src', () => {
+    const bare = {type: 'image2', attrs: {alt: 'nothing'}};
+
+    assert.match(parse(doc({type: 'captionedImage', content: [bare]})).error.issues.map(i => i.path.join('.')).join(' '), /attrs/);
+  });
+
+  test('preserves the many attrs the editor writes on an image', () => {
+    const rich = {type: 'image2', attrs: {src: 'https://x.dev/a.png', width: 1456, height: 819, belowTheFold: false}};
+    const result = parse(doc({type: 'captionedImage', content: [rich]}));
+
+    assert.equal(result.data.content[0].content[0].attrs.width, 1456);
+  });
+
+  test('accepts a button', () => {
+    const button = {type: 'button', attrs: {url: '%%checkout_url%%', text: 'Subscribe'}};
+
+    assert.equal(parse(doc(button)).success, true);
+  });
+
+  test('rejects a button with no text', () => {
+    assert.equal(parse(doc({type: 'button', attrs: {url: '%%checkout_url%%'}})).success, false);
+  });
+
+  // These three appear in the live archive — digestPostEmbed in 59 of 60 sampled posts — and their
+  // internals were never read. Accepted whole so a read-modify-write round trip preserves them.
+  for (const type of ['digestPostEmbed', 'substack_mentions', 'directMessage']) {
+    test(`accepts ${type} and preserves what it carries`, () => {
+      const node = {type, attrs: {id: 7}, content: [{type: 'anything', nested: true}]};
+      const result = parse(doc(node));
+
+      assert.equal(result.success, true);
+      assert.deepEqual(result.data.content[0], node);
+    });
+  }
+
+  // In 33 of 40 sampled posts on the second publication. Its absence would have blocked the round
+  // trip on most of that archive — which is what a survey of only one publication had missed.
+  test('accepts a youtube embed', () => {
+    assert.equal(parse(doc({type: 'youtube2', attrs: {videoId: '0chZFIZLR_0'}})).success, true);
+  });
+
+  test('rejects a youtube embed with no videoId', () => {
+    assert.equal(parse(doc({type: 'youtube2', attrs: {}})).success, false);
+  });
+
+  test('rejects a node type outside the enumeration, naming the alternatives', () => {
+    const message = issues(doc({type: 'subscribeWidget', attrs: {}})).join(' ');
+
+    assert.match(message, /Invalid discriminator value/);
+    assert.match(message, /'captionedImage'/);
+  });
+});

--- a/src/api/substack/document.spec.js
+++ b/src/api/substack/document.spec.js
@@ -179,3 +179,55 @@ describe('postBodySchema — descriptions', () => {
     assert.deepEqual(missing, [], `undescribed: ${missing.join(', ')}`);
   });
 });
+
+describe('postBodySchema — lists and quotes', () => {
+  const item = (value) => ({type: 'list_item', content: [{type: 'paragraph', content: [text(value)]}]});
+
+  test('accepts a bulleted list', () => {
+    assert.equal(parse(doc({type: 'bullet_list', content: [item('one'), item('two')]})).success, true);
+  });
+
+  test('accepts a numbered list', () => {
+    assert.equal(parse(doc({type: 'ordered_list', content: [item('one')]})).success, true);
+  });
+
+  test('accepts the start attr the editor writes', () => {
+    const list = {type: 'ordered_list', attrs: {start: 3, type: null, order: 1}, content: [item('three')]};
+    const result = parse(doc(list));
+
+    assert.equal(result.success, true);
+    assert.equal(result.data.content[0].attrs.start, 3);
+  });
+
+  test('accepts a list nested inside a list item', () => {
+    const nested = {
+      type: 'list_item',
+      content: [
+        {type: 'paragraph', content: [text('outer')]},
+        {type: 'bullet_list', content: [item('inner')]},
+      ],
+    };
+
+    assert.equal(parse(doc({type: 'bullet_list', content: [nested]})).success, true);
+  });
+
+  test('rejects a list item outside a list', () => {
+    assert.equal(parse(doc(item('stray'))).success, false);
+  });
+
+  test('rejects bare text directly inside a list item', () => {
+    assert.equal(parse(doc({type: 'bullet_list', content: [{type: 'list_item', content: [text('x')]}]})).success, false);
+  });
+
+  test('accepts a blockquote of paragraphs', () => {
+    const quote = {type: 'blockquote', content: [{type: 'paragraph', content: [text('quoted')]}]};
+
+    assert.equal(parse(doc(quote)).success, true);
+  });
+
+  test('accepts a blockquote containing a list', () => {
+    const quote = {type: 'blockquote', content: [{type: 'bullet_list', content: [item('one')]}]};
+
+    assert.equal(parse(doc(quote)).success, true);
+  });
+});

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -155,6 +155,7 @@ describe('entrypoint — stdio transport', () => {
       'list_subscriptions',
       'publish_draft',
       'restack_item',
+      'set_post_body',
       'update_draft',
     ]);
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {createDraftPostSchema, createDraftPostHandler} from "./tools/create_draft_post.js";
+import {setPostBodySchema, setPostBodyHandler} from "./tools/set_post_body.js";
 import {listSubscribersSchema, listSubscribersHandler} from "./tools/list_subscribers.js";
 import {exportSubscribersSchema, exportSubscribersHandler} from "./tools/export_subscribers.js";
 import {listPostsSchema, listPostsHandler} from "./tools/list_posts.js";
@@ -31,6 +32,19 @@ export const tools = {
     description: "create a draft post on your Substack account.",
     schema: createDraftPostSchema,
     handler: createDraftPostHandler,
+  },
+  set_post_body: {
+    // This is the only tool that publishes the document schema, and the description points at it
+    // rather than restating the node list: the schema is the vocabulary, and a summary here would be
+    // a second copy of it that can drift.
+    description:
+      "replace the body of a draft with a Substack document. This is the only way to write " +
+      "structured content — headings, lists, links, code blocks, images, buttons and a paywall. " +
+      "Create the draft first with create_draft_post, then call this with its id. The result " +
+      "reports how many nodes of each type were stored, so a caller can confirm that what it " +
+      "asked for is there. An image must already be hosted by Substack: this cannot upload one.",
+    schema: setPostBodySchema,
+    handler: setPostBodyHandler,
   },
   list_subscribers: {
     // The engagement caveat still belongs in the description: this endpoint takes the fields it

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -416,3 +416,41 @@ describe('MCP server — set_post_body over the protocol', () => {
     }
   });
 });
+
+describe('MCP server — the cost of the published document schema', () => {
+  // The document schema is the largest thing this server publishes, and the reason it lives on
+  // set_post_body alone. Nothing else stops someone adding `body: postBodySchema` to a second tool,
+  // where it would be paid again by every session — including the ones that never write a post. This
+  // test is that stop: it asserts the node vocabulary appears in exactly one tool's inputSchema.
+  test('publishes the document vocabulary on exactly one tool', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      const carrying = tools
+        .filter(tool => JSON.stringify(tool.inputSchema).includes('"highlighted_code_block"'))
+        .map(tool => tool.name);
+
+      assert.deepEqual(carrying, ['set_post_body']);
+    } finally {
+      await close();
+    }
+  });
+
+  // Not an exact byte count — that would rot on every node added. A ceiling, so a change that
+  // doubles what every session downloads fails here instead of going unnoticed.
+  test('keeps the published schema under 32 KB', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      const schema = tools.find(tool => tool.name === 'set_post_body').inputSchema;
+      const bytes = JSON.stringify(schema).length;
+
+      assert.ok(bytes < 32768, `the published schema is ${bytes} bytes, which is over the 32 KB ceiling`);
+      assert.ok(bytes > 8192, `the published schema is only ${bytes} bytes — did the node union shrink?`);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -331,3 +331,88 @@ describe('MCP server — call_tool', () => {
     }
   });
 });
+
+describe('MCP server — set_post_body over the protocol', () => {
+  async function publishedSchema() {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const {tools} = await client.listTools();
+      return tools.find(tool => tool.name === 'set_post_body')?.inputSchema;
+    } finally {
+      await close();
+    }
+  }
+
+  test('is registered and published with exactly a draft_id and a body', async () => {
+    const schema = await publishedSchema();
+
+    assert.ok(schema, 'set_post_body should be registered');
+    assert.deepEqual(Object.keys(schema.properties).sort(), ['body', 'draft_id']);
+    assert.equal(schema.additionalProperties, false);
+  });
+
+  // The published schema is what teaches a model the vocabulary. If the node names stop appearing in
+  // it the tool still works and every caller has to guess, which no other test would notice.
+  test('publishes the node vocabulary a caller has to know', async () => {
+    const published = JSON.stringify(await publishedSchema());
+
+    for (const type of [
+      'paragraph', 'heading', 'bullet_list', 'ordered_list', 'blockquote',
+      'highlighted_code_block', 'code_block', 'horizontal_rule', 'paywall',
+      'captionedImage', 'image2', 'caption', 'button', 'youtube2',
+      'digestPostEmbed', 'substack_mentions', 'directMessage',
+      'strong', 'em', 'code', 'strikethrough', 'link',
+    ]) {
+      assert.match(published, new RegExp(`"${type}"`), `${type} should appear in the published schema`);
+    }
+  });
+
+  // The recursion has to survive conversion, and draft-7 puts the shared shapes under `definitions`.
+  // Asserting the refs *exist* first is the point: with no recursion the schema contains none, so a
+  // loop over discovered refs would pass while checking nothing.
+  test('publishes a self-contained schema, definitions included', async () => {
+    const schema = await publishedSchema();
+    const refs = [...JSON.stringify(schema).matchAll(/"\$ref":"#\/definitions\/([^"]+)"/g)].map(m => m[1]);
+
+    assert.ok(refs.length > 0, 'the recursive list and blockquote nodes should produce at least one $ref');
+
+    for (const ref of refs) {
+      assert.ok(schema.definitions?.[ref], `definitions.${ref} should exist`);
+    }
+  });
+
+  // McpServer turns anything a tool throws into a *successful* CallToolResult with isError set, so
+  // callTool does not reject. Asserting on a rejection here would check nothing.
+  test('reports an unmodelled node as an error result rather than rejecting', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const result = await client.callTool({
+        name: 'set_post_body',
+        arguments: {draft_id: 1, body: {type: 'doc', content: [{type: 'codeBlock'}]}},
+      });
+
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /discriminator|codeBlock|Invalid/);
+    } finally {
+      await close();
+    }
+  });
+
+  test('reports a second paywall as an error result', async () => {
+    const {client, close} = await connectMcpClient();
+
+    try {
+      const result = await client.callTool({
+        name: 'set_post_body',
+        arguments: {draft_id: 1, body: {type: 'doc', content: [{type: 'paywall'}, {type: 'paywall'}]}},
+      });
+
+      assert.equal(result.isError, true);
+      assert.match(result.content[0].text, /at most one paywall/i);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -1,7 +1,9 @@
 import {test, describe, before, after, afterEach} from 'node:test';
+import {readFileSync} from 'node:fs';
 import assert from 'node:assert/strict';
 import {HttpResponse} from 'msw';
 import {connectMcpClient} from '../test/helpers/mcp-harness.js';
+import {tools} from './server.js';
 import {createMswServer, DRAFTS_URL} from '../test/helpers/msw-server.js';
 import {setTestEnv} from '../test/helpers/env.js';
 import {captureLogs} from '../test/helpers/capture-logs.js';
@@ -452,5 +454,30 @@ describe('MCP server — the cost of the published document schema', () => {
     } finally {
       await close();
     }
+  });
+});
+
+describe('README — documents every registered tool', () => {
+  // The README is the only documentation a user of the published package reads, and nothing else
+  // keeps it in step with the registry: set_post_body shipped registered but undocumented, and no
+  // test noticed. This compares the two sets in both directions, because each failure hurts
+  // differently — a tool missing from the README is invisible to whoever installs the package, while
+  // a README entry with no tool behind it sends someone to call something that answers an error.
+  const readmeToolNames = () => {
+    const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+    // Only lowercase snake_case names: the same markup wraps the two installation options
+    // ("Option 1: Using NPX"), which are not tools.
+    return [...readme.matchAll(/<summary><strong>([a-z_]+)<\/strong>/g)].map(match => match[1]).sort();
+  };
+
+  test('every registered tool has a README section, and every documented tool is registered', () => {
+    assert.deepEqual(readmeToolNames(), Object.keys(tools).sort());
+  });
+
+  test('no tool is documented twice', () => {
+    const documented = readmeToolNames();
+
+    assert.deepEqual(documented, [...new Set(documented)]);
   });
 });

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -62,6 +62,7 @@ describe('MCP server — list_tools', () => {
     'list_subscriptions',
     'publish_draft',
     'restack_item',
+    'set_post_body',
     'update_draft',
   ];
 

--- a/src/tools/create_draft_post.js
+++ b/src/tools/create_draft_post.js
@@ -1,6 +1,7 @@
 import {z} from "zod";
 import SubstackApi from "../api/substack/SubstackApi.js";
 import SubstackPost from "../api/substack/SubstackPost.js";
+import {postBodySchema} from "../api/substack/document.js";
 import {logger} from "../logger.js";
 
 
@@ -22,7 +23,7 @@ export const createDraftPostSchema = z.strictObject({
   body: z
     .string()
     .describe(
-      "The body of the post to be created. Either plain text (paragraphs separated by blank lines) or a JSON string of a Substack document, e.g. {\"type\":\"doc\",\"content\":[...]}."
+      "The body of the post. Plain text becomes one paragraph per line — Markdown is NOT interpreted, so `## Heading` would appear literally. A JSON string of a Substack document also works and is validated against the same schema set_post_body publishes; an unrecognised node name is an error rather than a mangled post. For structured content prefer set_post_body, where that schema is published and the node vocabulary is visible."
     ),
 });
 
@@ -30,14 +31,27 @@ const parseBody = (body) => {
   try {
     const doc = JSON.parse(body);
     if (doc && doc.type === 'doc') {
-      logger.debug('draft.body.parsed', {format: 'prosemirror', nodes: doc.content?.length ?? 0});
-      return doc;
+      // Validated, not forwarded. This branch used to be the one structured route into the server and
+      // the only one with no checks, so a wrong node name created a draft with its content mangled and
+      // said nothing. The schema is shared with set_post_body but deliberately not published here:
+      // validating costs nothing, publishing would cost another 20 KB on every session.
+      const validated = postBodySchema.parse(doc);
+      logger.debug('draft.body.parsed', {format: 'prosemirror', nodes: validated.content.length});
+      return validated;
     }
 
     // Valid JSON that is not a document: it goes through as text, and a model that believed
     // it was sending a document would have no other way to find out.
     logger.debug('draft.body.json_is_not_a_document', {parsed: doc});
   } catch (error) {
+    // Two different failures land here now, and confusing them is the trap: a ZodError means it *was*
+    // a document and a bad one, which must reach the caller. Anything else is JSON.parse failing,
+    // which only means the body is prose. Treating a ZodError as prose would publish the broken
+    // document as literal JSON text.
+    if (error instanceof z.ZodError) {
+      logger.error('draft.body.invalid_document', {issues: error.issues});
+      throw error;
+    }
     // not JSON, treat as plain text
   }
 

--- a/src/tools/create_draft_post.js
+++ b/src/tools/create_draft_post.js
@@ -34,7 +34,7 @@ const parseBody = (body) => {
       // Validated, not forwarded. This branch used to be the one structured route into the server and
       // the only one with no checks, so a wrong node name created a draft with its content mangled and
       // said nothing. The schema is shared with set_post_body but deliberately not published here:
-      // validating costs nothing, publishing would cost another 20 KB on every session.
+      // validating costs nothing, publishing would cost another ~21 KB on every session.
       const validated = postBodySchema.parse(doc);
       logger.debug('draft.body.parsed', {format: 'prosemirror', nodes: validated.content.length});
       return validated;

--- a/src/tools/create_draft_post.spec.js
+++ b/src/tools/create_draft_post.spec.js
@@ -161,7 +161,12 @@ describe('createDraftPostHandler — body conversion', () => {
     assert.deepEqual(paragraphTexts(doc), ['First', 'Second']);
   });
 
-  test('a ProseMirror document given as JSON is passed through untouched', async () => {
+  // Was a characterization test pinning *unvalidated* passthrough: anything carrying type: 'doc' went
+  // to Substack as-is, so a wrong node name created a draft with its content silently mangled. It is
+  // validated now against the same schema set_post_body publishes, without publishing it here — so the
+  // protection costs nothing and this was the last route into the server that accepted a body
+  // unchecked. Changed together with the source, as CLAUDE.md requires.
+  test('a valid ProseMirror document given as JSON is passed through untouched', async () => {
     const doc = {
       type: 'doc',
       content: [
@@ -171,6 +176,29 @@ describe('createDraftPostHandler — body conversion', () => {
     };
 
     assert.deepEqual(await sendAndDecode(JSON.stringify(doc)), doc);
+  });
+
+  test('an invalid document is rejected rather than forwarded', async () => {
+    const broken = JSON.stringify({type: 'doc', content: [{type: 'codeBlock', content: []}]});
+
+    await assert.rejects(() => createDraftPostHandler({...VALID_ARGS, body: broken}), z.ZodError);
+    assert.equal(msw.requests.length, 0, 'no request should have been made');
+  });
+
+  test('the rejection names the valid node types, so the caller can repair it', async () => {
+    const broken = JSON.stringify({type: 'doc', content: [{type: 'codeBlock', content: []}]});
+    const error = await createDraftPostHandler({...VALID_ARGS, body: broken}).catch(e => e);
+
+    const message = error.issues.map(i => i.message).join(' ');
+    assert.match(message, /Invalid discriminator value/);
+    assert.match(message, /'highlighted_code_block'/);
+  });
+
+  test('records the invalid document before rethrowing', async () => {
+    const broken = JSON.stringify({type: 'doc', content: [{type: 'codeBlock', content: []}]});
+    const logs = await captureLogs(() => createDraftPostHandler({...VALID_ARGS, body: broken}).catch(() => {}));
+
+    assert.ok(logs.some(line => line.msg === 'draft.body.invalid_document'), logs.map(l => l.msg).join(', '));
   });
 
   test('valid JSON that is not a document is treated as text', async () => {

--- a/src/tools/set_post_body.js
+++ b/src/tools/set_post_body.js
@@ -9,9 +9,12 @@ import {logger} from "../logger.js";
 // then being told `body` is missing.
 //
 // This is the one tool that publishes the document schema. Keeping it here rather than on
-// create_draft_post and update_draft both is deliberate: the schema measures 20,342 bytes, and paying
-// it twice would grow tools/list by over 100% for every session, including those that never write a
-// post. create_draft_post shares the same validator without publishing it, so nothing is unguarded.
+// create_draft_post and update_draft both is deliberate: the schema publishes at roughly 21 KB against
+// a tools/list that is about 35 KB without it, so paying for it twice would more than double what every
+// session downloads, including the sessions that never write a post. The figure is deliberately not
+// exact — it grows with every node added, and `src/server.spec.js` measures the real one — but the
+// order of magnitude is what the decision rests on. create_draft_post shares this validator without
+// publishing it, so nothing is left unguarded.
 export const setPostBodySchema = z.strictObject({
   draft_id: z
     .number()

--- a/src/tools/set_post_body.js
+++ b/src/tools/set_post_body.js
@@ -1,0 +1,63 @@
+import {z} from "zod";
+import SubstackApi from "../api/substack/SubstackApi.js";
+import {postBodySchema, summarizeNodes} from "../api/substack/document.js";
+import {logger} from "../logger.js";
+
+// strictObject, not object: an unknown key must be reported rather than stripped, since the
+// validation message is the only feedback an LLM gets to repair the call. A model reaching for the
+// wire name `draft_body` is told that key is unrecognised instead of having it silently dropped and
+// then being told `body` is missing.
+//
+// This is the one tool that publishes the document schema. Keeping it here rather than on
+// create_draft_post and update_draft both is deliberate: the schema measures 20,342 bytes, and paying
+// it twice would grow tools/list by over 100% for every session, including those that never write a
+// post. create_draft_post shares the same validator without publishing it, so nothing is unguarded.
+export const setPostBodySchema = z.strictObject({
+  draft_id: z
+    .number()
+    .int()
+    .describe(
+      "The numeric id of the draft to write, as returned by list_posts (`id`) or create_draft_post (`draft_id`)."
+    ),
+  body: postBodySchema,
+});
+
+export const setPostBodyHandler = async (args) => {
+  logger.debug('set_post_body.start', {args});
+
+  // McpServer already validated against this schema before dispatching, so over MCP this parse never
+  // rejects. It is kept so the handler stays safe when called directly, which is how its tests run.
+  let validatedArgs;
+
+  try {
+    validatedArgs = setPostBodySchema.parse(args);
+  } catch (error) {
+    // `issues`, not `errors`: zod 4 renamed it, and reading the old name yields undefined.
+    logger.error('set_post_body.args.invalid', {issues: error.issues ?? error.message});
+    throw error;
+  }
+
+  const {draft_id, body} = validatedArgs;
+  const nodes = summarizeNodes(body);
+
+  // Logged before the request, not only after: this replaces a body outright, and the one it replaces
+  // is not recoverable from anywhere in this server.
+  logger.info('set_post_body.writing', {draft_id, nodes});
+
+  const substack_api = new SubstackApi({
+    publication_url: process.env.SUBSTACK_PUBLICATION_URL,
+    auth_token: process.env.SUBSTACK_SESSION_TOKEN,
+  });
+
+  // JSON.stringify, because draft_body goes on the wire as a string. Only this key is sent: PUT is
+  // genuinely partial, so anything absent is left alone rather than cleared.
+  await substack_api.updateDraft(draft_id, {draft_body: JSON.stringify(body)});
+
+  logger.info('set_post_body.done', {draft_id, nodes});
+
+  // The tally, not 'OK'. Validation cannot report a paywall that was never sent — a document without
+  // one is exactly as valid as a document with one — so the only way a caller can confirm that what
+  // it asked for landed is to be told what landed. The log goes to stderr, where a model cannot read
+  // it, which makes the result the only channel back.
+  return {draft_id, nodes};
+};

--- a/src/tools/set_post_body.spec.js
+++ b/src/tools/set_post_body.spec.js
@@ -1,0 +1,144 @@
+import {test, describe, before, after, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {HttpResponse} from 'msw';
+import {setPostBodyHandler, setPostBodySchema} from './set_post_body.js';
+import {createMswServer, DRAFT_RESPONSE} from '../../test/helpers/msw-server.js';
+import {setTestEnv} from '../../test/helpers/env.js';
+import {captureLogs} from '../../test/helpers/capture-logs.js';
+
+const msw = createMswServer();
+let restoreEnv;
+
+before(() => {
+  restoreEnv = setTestEnv();
+  msw.start();
+});
+afterEach(() => msw.reset());
+after(() => {
+  msw.stop();
+  restoreEnv();
+});
+
+const DOC = {type: 'doc', content: [
+  {type: 'paragraph', content: [{type: 'text', text: 'Free intro.'}]},
+  {type: 'paywall'},
+  {type: 'heading', attrs: {level: 2}, content: [{type: 'text', text: 'Paid'}]},
+]};
+const VALID_ARGS = {draft_id: 210218832, body: DOC};
+
+describe('setPostBodySchema', () => {
+  test('requires a draft_id and a body', () => {
+    assert.throws(() => setPostBodySchema.parse({}), z.ZodError);
+    assert.throws(() => setPostBodySchema.parse({draft_id: 1}), z.ZodError);
+  });
+
+  // The wire name is draft_body, so a model reaching for it must be told the key is unrecognised
+  // rather than having it silently dropped and then being told `body` is missing.
+  test('rejects an unknown key by name', () => {
+    try {
+      setPostBodySchema.parse({...VALID_ARGS, draft_body: DOC});
+      assert.fail('should have thrown');
+    } catch (error) {
+      const message = error.issues.map(i => i.message).join(' ');
+      assert.match(message, /Unrecognized key/);
+      assert.match(message, /draft_body/);
+    }
+  });
+
+  test('rejects a body that is a JSON string rather than an object', () => {
+    assert.throws(() => setPostBodySchema.parse({draft_id: 1, body: JSON.stringify(DOC)}), z.ZodError);
+  });
+
+  test('rejects a body carrying an unmodelled node type', () => {
+    const body = {type: 'doc', content: [{type: 'codeBlock', content: []}]};
+
+    assert.throws(() => setPostBodySchema.parse({draft_id: 1, body}), z.ZodError);
+  });
+});
+
+describe('setPostBodyHandler', () => {
+  test('sends draft_body as a serialized document to the draft', async () => {
+    await setPostBodyHandler(VALID_ARGS);
+
+    const request = msw.requests.at(-1);
+    assert.equal(request.method, 'PUT');
+    assert.match(request.url, /\/drafts\/210218832$/);
+    assert.deepEqual(JSON.parse(request.body.draft_body), DOC);
+  });
+
+  // JSON.stringify, not the object: draft_body goes on the wire as a string. SubstackPost.getDraft
+  // has the same rule, and handing it an already-serialized string double-encoded it once (#4).
+  test('sends draft_body as a string, not as a nested object', async () => {
+    await setPostBodyHandler(VALID_ARGS);
+
+    assert.equal(typeof msw.requests.at(-1).body.draft_body, 'string');
+  });
+
+  test('sends nothing but draft_body, so no other draft field is touched', async () => {
+    await setPostBodyHandler(VALID_ARGS);
+
+    assert.deepEqual(Object.keys(msw.requests.at(-1).body), ['draft_body']);
+  });
+
+  test('returns the tally of what it stored', async () => {
+    const result = await setPostBodyHandler(VALID_ARGS);
+
+    assert.deepEqual(result, {draft_id: 210218832, nodes: {paragraph: 1, paywall: 1, heading: 1}});
+  });
+
+  test('rejects a second paywall without issuing a request', async () => {
+    const body = {type: 'doc', content: [{type: 'paywall'}, {type: 'paywall'}]};
+
+    await assert.rejects(() => setPostBodyHandler({draft_id: 1, body}), z.ZodError);
+    assert.equal(msw.requests.length, 0, 'no request should have been made');
+  });
+
+  test('propagates a failing response', async () => {
+    msw.server.use(msw.draftUpdateHandler(() => HttpResponse.json({}, {status: 404})));
+
+    await assert.rejects(() => setPostBodyHandler(VALID_ARGS), /404/);
+  });
+
+  test('logs its intent before the request and the tally after', async () => {
+    const logs = await captureLogs(() => setPostBodyHandler(VALID_ARGS));
+    const events = logs.map(line => line.msg);
+
+    assert.ok(events.includes('set_post_body.writing'), `expected set_post_body.writing in ${events.join(', ')}`);
+    assert.ok(events.includes('set_post_body.done'));
+
+    const done = logs.find(line => line.msg === 'set_post_body.done');
+    assert.deepEqual(done.nodes, {paragraph: 1, paywall: 1, heading: 1});
+  });
+
+  // The write replaces a body outright and the previous one is not recoverable from anywhere in this
+  // server, so the intent line has to precede the request rather than only report its outcome.
+  test('logs the intent before the response comes back', async () => {
+    msw.server.use(msw.draftUpdateHandler(() => HttpResponse.json({}, {status: 500})));
+
+    const logs = await captureLogs(() => setPostBodyHandler(VALID_ARGS).catch(() => {}));
+
+    assert.ok(logs.some(line => line.msg === 'set_post_body.writing'));
+    assert.ok(!logs.some(line => line.msg === 'set_post_body.done'));
+  });
+
+  test('records the validation issues when the arguments are rejected', async () => {
+    const logs = await captureLogs(() => setPostBodyHandler({draft_id: 'not a number', body: DOC}).catch(() => {}));
+
+    assert.ok(logs.some(line => line.msg === 'set_post_body.args.invalid'));
+  });
+
+  test('reads the env vars at call time, not at module import', async () => {
+    assert.ok(DRAFT_RESPONSE, 'the msw helper should expose a draft response');
+
+    const previous = process.env.SUBSTACK_PUBLICATION_URL;
+    process.env.SUBSTACK_PUBLICATION_URL = 'https://elsewhere.substack.com';
+
+    try {
+      await setPostBodyHandler(VALID_ARGS).catch(() => {});
+      assert.match(msw.requests.at(-1)?.url ?? 'https://elsewhere.substack.com', /elsewhere|drafts/);
+    } finally {
+      process.env.SUBSTACK_PUBLICATION_URL = previous;
+    }
+  });
+});

--- a/src/tools/set_post_body.spec.js
+++ b/src/tools/set_post_body.spec.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {z} from 'zod';
 import {HttpResponse} from 'msw';
 import {setPostBodyHandler, setPostBodySchema} from './set_post_body.js';
-import {createMswServer, DRAFT_RESPONSE} from '../../test/helpers/msw-server.js';
+import {createMswServer} from '../../test/helpers/msw-server.js';
 import {setTestEnv} from '../../test/helpers/env.js';
 import {captureLogs} from '../../test/helpers/capture-logs.js';
 
@@ -111,6 +111,17 @@ describe('setPostBodyHandler', () => {
     assert.deepEqual(done.nodes, {paragraph: 1, paywall: 1, heading: 1});
   });
 
+  // Renaming a log line is the cheapest mutation for a logging assertion, so every line this handler
+  // writes needs one — otherwise deleting it leaves the suite green and the session becomes
+  // undebuggable from the log alone, which is the whole point of writing it.
+  test('records the arguments it received', async () => {
+    const logs = await captureLogs(() => setPostBodyHandler(VALID_ARGS));
+    const start = logs.find(line => line.msg === 'set_post_body.start');
+
+    assert.ok(start, `expected set_post_body.start in ${logs.map(l => l.msg).join(', ')}`);
+    assert.deepEqual(start.args, VALID_ARGS);
+  });
+
   // The write replaces a body outright and the previous one is not recoverable from anywhere in this
   // server, so the intent line has to precede the request rather than only report its outcome.
   test('logs the intent before the response comes back', async () => {
@@ -128,17 +139,31 @@ describe('setPostBodyHandler', () => {
     assert.ok(logs.some(line => line.msg === 'set_post_body.args.invalid'));
   });
 
-  test('reads the env vars at call time, not at module import', async () => {
-    assert.ok(DRAFT_RESPONSE, 'the msw helper should expose a draft response');
+  test('authenticates with the token taken from the env vars', async () => {
+    await setPostBodyHandler(VALID_ARGS);
 
-    const previous = process.env.SUBSTACK_PUBLICATION_URL;
-    process.env.SUBSTACK_PUBLICATION_URL = 'https://elsewhere.substack.com';
+    assert.equal(
+      msw.requests.at(-1).headers.cookie,
+      'substack.sid=test-session-token; connect.sid=test-session-token;'
+    );
+  });
+
+  // Asserts on the cookie rather than on the publication host, because swapping the host would send
+  // the request somewhere MSW has no handler for and `onUnhandledRequest: 'error'` would fail the test
+  // for the wrong reason. The token is the observable consequence available without leaving the mock.
+  test('reads the env vars at call time, not at module import', async () => {
+    const previous = process.env.SUBSTACK_SESSION_TOKEN;
+    process.env.SUBSTACK_SESSION_TOKEN = 'rotated-at-call-time';
 
     try {
-      await setPostBodyHandler(VALID_ARGS).catch(() => {});
-      assert.match(msw.requests.at(-1)?.url ?? 'https://elsewhere.substack.com', /elsewhere|drafts/);
+      await setPostBodyHandler(VALID_ARGS);
+
+      assert.equal(
+        msw.requests.at(-1).headers.cookie,
+        'substack.sid=rotated-at-call-time; connect.sid=rotated-at-call-time;'
+      );
     } finally {
-      process.env.SUBSTACK_PUBLICATION_URL = previous;
+      process.env.SUBSTACK_SESSION_TOKEN = previous;
     }
   });
 });


### PR DESCRIPTION
The post body had no contract. `create_draft_post.body` is a string: a value parsing as JSON with
`type: 'doc'` was forwarded **unvalidated**, everything else split on `/\n+/` into flat paragraphs. So
the only route to structured content was the unchecked one — a wrong node name created a draft with its
content silently mangled — and `update_draft` could not touch a body at all.

This adds `set_post_body(draft_id, body)`, where `body` is the Substack ProseMirror document modelled in
zod and published as the tool's own JSON Schema, so a calling model reads the node vocabulary from
`tools/list` instead of guessing.

## What changed

| | |
|---|---|
| `src/api/substack/document.js` | New. The schema — 15 node types, 5 marks — plus `summarizeNodes`. Pure: no I/O, no env, no logging. |
| `src/tools/set_post_body.js` | New. Validates, PUTs `draft_body` and nothing else, returns a node tally. |
| `src/tools/create_draft_post.js` | Its JSON branch now runs the same validator **without publishing the schema**. |
| `docs/superpowers/specs/` | The design, plus the superseded Markdown design it replaced. |

677 tests (from 590), 0 failures on **both** Node 22 (the `engines` floor) and Node 24. `tools/list`
goes from 34.7 KB to 56 KB — the schema is 20 KB and is carried by one tool on purpose; on
`create_draft_post` and `update_draft` too it would more than double.

## Why a document contract rather than Markdown

A Markdown renderer was designed, approved, and then killed by measurement. Both specs are in the diff,
the first marked superseded, because the reasoning that led there was sound until the data arrived.

- **100% of 60 sampled published posts contain nodes Markdown cannot express** — `button` in 60/60,
  `captionedImage` in 60/60. It could not have reproduced a single real post.
- In a head-to-head over five briefs with ten fresh models, the document scored **34/34 against 30/34**
  and validated **5/5 first try, zero repair rounds**. Where both can express a construct the output is
  semantically identical.
- The Markdown side **degraded a button to a link and dropped a paywall**, producing valid Markdown with
  an empty `unsupported` list: that report can only name what Markdown *has* and Substack lacks, never
  what Markdown *lacks*. The post would have published with its paid section public.

## The facts the schema encodes, all measured

- **The code block is `highlighted_code_block`.** `python-substack` declares `codeBlock`, which does not
  render. Both it and the legacy `code_block` are accepted — 16 occurrences against 5 in the survey.
- **`order` numbers a list, not `start`.** `{start: 3}` is stored verbatim, answers 200 and renders from
  **1**; `{order: 3}` renders from 3. The editor writes both, so reading its own output suggests either
  would do. Found by the live verification step and nothing else could have caught it.
- **`type` is strict, `attrs` are loose.** The editor writes `textAlign: null` everywhere, so strict
  attrs would reject every real post; the discriminated union is what produces `Invalid discriminator
  value. Expected 'paragraph' | 'heading' | …`. A generic unknown-node branch was tried and **rejected**:
  it keeps a malformed `heading` out but reports only the generic error, so the caller never learns which
  field is wrong. Every observed type is enumerated instead, including three read-only-as-opaque —
  `digestPostEmbed` alone is in 59 of 60 posts, which is what makes read-modify-write possible.
- **One `paywall` per document, and we are the only ones enforcing it.** Two are accepted with a 200 and
  rendered as two "Paid content below this line" markers. Since a `.refine()` does not survive into the
  published schema, the rule is repeated in the node's description.
- **Both publications had to be surveyed.** The first pass missed `youtube2`, which is in 33 of 40
  sampled posts on the second one.

## Verified against the live API

- A document using every modelled node written to a scratch draft, then the editor reloaded: every
  construct renders, including the nested list, the code block's language selector reading JavaScript
  rather than Plain Text, the captioned image and a single paywall marker.
- **22 real posts across both publications validate** — no unknown node, no unknown mark, every required
  attr present, paywall counts always 0 or 1.

## What a reviewer should know

- **Images can be referenced but not uploaded**, the sharpest limit here: `image2.src` must already point
  at a Substack-hosted asset. `POST /api/v1/image` was tried as JSON, form-urlencoded and multipart and
  **all three hang** — pending past a minute with no response — so neither `python-substack`'s signature
  nor the fork's is confirmed. CLAUDE.md says not to implement an upload from either.
- **`set_post_body` returns a node tally, not `'OK'`**, because validation cannot report what was never
  sent: a document with no paywall is exactly as valid as one with a paywall.
- **The descriptions are load-bearing and a test enforces them**, walking the whole converted schema and
  naming any union branch without one. The walk is recursive because `list_item`, `image2` and `caption`
  are reachable only nested — a top-level-only version left stripping every mark description green.
- **`create_draft_post.body` is not becoming Markdown.** Plain text still means one paragraph per line;
  `## Heading` still arrives literally. Its characterization test changed in the same commit as the
  source, as CLAUDE.md requires.
- Nineteen deliberate mutations were run across the branch to prove the new tests can fail. The most
  useful: replacing every `strictObject` with `z.object` originally left the suite green, which would
  have silently stripped unmodelled keys out of a round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)