### PR TITLE
docs: make Docker quick start visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,9 @@ Ask your client:
 The client should call `list_posts` with `status: "drafts"`. If it fails, check the client's MCP
 logs and the [logging section](#-logs) below before opening an issue.
 
-<details>
-<summary><strong>Use Docker instead of Node.js</strong></summary>
+### Docker quick start
 
-With Docker installed, use this server configuration:
+To use the published Docker image instead of Node.js, add this server configuration:
 
 ```json
 {
@@ -94,8 +93,6 @@ With Docker installed, use this server configuration:
   }
 }
 ```
-
-</details>
 
 ## 🛠 Available Tools
 
@@ -637,7 +634,7 @@ Then add to your MCP config:
 }
 ```
 
-### Docker
+### Docker (build from source)
 
 ```bash
 git clone https://github.com/marcomoauro/substack-mcp.git


### PR DESCRIPTION
## Summary

- show the published Docker image configuration directly in the quick start
- remove the collapsed `<details>` wrapper
- distinguish the production image from the local build-from-source instructions

## Verification

- 748/748 tests pass
- all 5 README JSON/JSONL examples parse
- `git diff --check` passes