### PR TITLE
Fix export_subscribers aborting on the export's pending poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,24 @@ GET  <url>                                                                  → 
 ```
 
 Verified end to end. The dashboard's polling backoff is `1, 5, 10, 30`, then `60` repeated;
-`EXPORT_POLL_BACKOFF_SECONDS` mirrors it, except the first poll happens immediately because a small
-export is usually already done. Four things this flow gets wrong if taken at face value:
+`EXPORT_POLL_BACKOFF_SECONDS` mirrors it, and the first poll happens immediately — which is free
+now but was not always: see the pending state below. Five things this flow gets wrong if taken at
+face value:
+
+- **The pending poll is a `400`, not a 200 with an absent `url`.** While the file is generating,
+  `GET /subscriber_set/export/<id>` answers `400 {"error":"Export not ready","type":"single"}`;
+  a 200 without a `url` was **never observed at any point**. Measured 2026-09-03 at 250ms
+  intervals: ~3s of 400s on a *6-row* export, then `200 {"url": "…/file"}`. This file previously
+  claimed the opposite, and the cost of that was total: since the first poll is immediate, every
+  export aborted on its first request with a bare `400 Bad Request` (issue #25). Note what made it
+  invisible — the suite mocked the pending state as `200 {}`, so 748 tests stayed green while the
+  tool failed 100% of the time in production. **A mock of a state nobody has observed is an
+  assumption wearing a test's clothes.** `SubstackApi.getSubscriberSetExport` now translates that
+  one body into `{pending: true}` and rethrows every other 400, so the tool's loop is unchanged —
+  an absent `url` still means retry, which costs nothing and covers the state if it ever exists.
+  This is also why `readBody` attaches `status` and `body` to the error it throws: the message
+  carries only the status, so the body explaining the refusal was readable in the log and nowhere
+  else, and no caller could tell one 400 from another.
 
 - **The CSV header carries human LABELS, not column keys** — `Emails opened (6mo)`, not
   `num_email_opens`. `COLUMN_KEY_BY_LABEL` is the reverse map; it works because the labels are
@@ -553,6 +569,27 @@ a logging assertion. **Check the mutation actually landed** before trusting a gr
 `sed`/`perl` regex that fails to match leaves the file untouched and reads exactly like a test
 that asserts nothing. Grep the file for a marker first. The whole suite runs in well under a
 second, so a mutation costs nothing.
+
+**A fixture that represents an API *state* must cite where that state was observed** — a date, a
+captured log line — and anything not observed has to say so. The mocks are written by us, so the
+suite measures this repo's model of Substack and never Substack; a bug of the form "the API does
+something we have not seen" is *structurally invisible* to it, however thorough it is. Issue #25
+is the demonstration: the export's pending state was mocked as `200 {}`, the real state is a
+`400`, and no assertion over that mock could have failed because it described the wrong universe.
+Note which mocks are exposed. A happy-path fixture is corrected by real use sooner or later; a
+fixture for a **transient or error** state is corrected by nobody, because nothing exercises it
+until something exercises it constantly. Suspect those first.
+
+**Verify a time-dependent flow by running the real handler, never by hand.** Polling, retry,
+backoff, TTL and expiry all mean the code and a human occupy different timing regimes: hand-issued
+requests land seconds apart, `export_subscribers` polls 200ms after asking for the file, and the
+window it lands in is ~3s wide. A manual walk through the endpoints cannot enter that window and
+the code cannot avoid it, so curl-by-curl "verified end to end" is not a verification of the same
+program. The technique that works is already in this file — the token check drove
+`create_draft_post` → `update_draft` → `get_draft` → `delete_draft` **through the real handlers**
+with `SUBSTACK_MCP_LOG_LEVEL=debug` and read the log. Do that once per tool whose flow is
+multi-step or timed, and keep the log: it is the only check that can contradict an assumption
+rather than confirm it.
 
 ## Style
 

--- a/src/api/substack/SubstackApi.js
+++ b/src/api/substack/SubstackApi.js
@@ -42,7 +42,15 @@ export default class SubstackApi {
         body,
       });
 
-      throw new Error(`SubstackAPIException: ${response.status} ${response.statusText}`);
+      // The message carries only the status, which is all a caller ever saw: issue #25 surfaced as
+      // a bare "400 Bad Request" that named neither the failing step nor Substack's own
+      // explanation. The status and body ride along so a caller can tell one 400 from another
+      // without re-reading the log.
+      const error = new Error(`SubstackAPIException: ${response.status} ${response.statusText}`);
+      error.status = response.status;
+      error.body = body;
+
+      throw error;
     }
 
     return response.text();
@@ -504,15 +512,34 @@ export default class SubstackApi {
   }
 
   /**
-   * Polls one export. Answers `{url}` once the file is ready; the url is absent while it is still
-   * being generated.
+   * Polls one export. Answers `{url}` once the file is ready and `{pending: true}` while Substack
+   * is still generating it.
+   *
+   * **The pending state is a 400, not a 200 with an absent url**, which is the opposite of what
+   * every other endpoint here does and is why this method exists rather than the caller polling
+   * `request` directly. Measured live 2026-09-03 on a 6-row export: ~3s of
+   * `400 {"error":"Export not ready","type":"single"}`, then `200 {url}`. A 200 without a url was
+   * never observed at any point — the earlier reading of this endpoint had it backwards, and since
+   * the tool's first poll is immediate, every export aborted on its first request (issue #25).
+   *
+   * Only that one body is a state. Any other refusal still throws: an export that will never
+   * arrive has to fail now rather than poll until the caller's wait budget runs out.
    */
   async getSubscriberSetExport(export_id) {
-    return this.request({
-      method: 'GET',
-      path: `/subscriber_set/export/${export_id}`,
-      referer: '/publish/subscribers',
-    });
+    try {
+      return await this.request({
+        method: 'GET',
+        path: `/subscriber_set/export/${export_id}`,
+        referer: '/publish/subscribers',
+      });
+    } catch (error) {
+      if (error.status === 400 && /Export not ready/i.test(error.body ?? '')) {
+        logger.debug('substack.export.pending', {export_id});
+        return {pending: true};
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/src/api/substack/SubstackApi.spec.js
+++ b/src/api/substack/SubstackApi.spec.js
@@ -328,6 +328,45 @@ describe('SubstackApi — subscriber set and export', () => {
     assert.equal(new URL(msw.requests[0].url).pathname, `/api/v1/subscriber_set/export/${EXPORT_ID}`);
   });
 
+  // Measured live 2026-09-03: while Substack is still generating the file the poll answers
+  // 400 {"error":"Export not ready"} — NOT a 200 with an absent url. It stayed there for ~3s on a
+  // 6-row export. Reported as issue #25, where it aborted every single export.
+  test('getSubscriberSetExport reports a not-ready export as pending instead of throwing', async () => {
+    msw.server.use(msw.exportStatusHandler(() =>
+      HttpResponse.json({error: 'Export not ready', type: 'single'}, {status: 400})
+    ));
+
+    const result = await createApi().getSubscriberSetExport(EXPORT_ID);
+
+    assert.deepEqual(result, {pending: true});
+  });
+
+  // Only that one 400 is a state; every other refusal is still a refusal. Swallowing them all
+  // would turn a rejected set id into an export that polls until the wait budget runs out.
+  test('getSubscriberSetExport still throws on a 400 that is not the pending state', async () => {
+    msw.server.use(msw.exportStatusHandler(() =>
+      HttpResponse.json({error: 'Subscriber set not found', type: 'single'}, {status: 400})
+    ));
+
+    const error = await createApi().getSubscriberSetExport(EXPORT_ID).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+  });
+
+  // The thrown message carries only the status, so without these the body Substack sent to explain
+  // the refusal is readable in the log and nowhere else — which is what made #25 present as a bare
+  // "400 Bad Request" with no hint of which of the four steps failed.
+  test('a failing status attaches its status and body to the error', async () => {
+    msw.server.use(msw.exportStatusHandler(() =>
+      HttpResponse.json({error: 'Export not ready', type: 'single'}, {status: 418})
+    ));
+
+    const error = await createApi().getSubscriberSetExport(EXPORT_ID).catch((e) => e);
+
+    assert.equal(error.status, 418);
+    assert.match(error.body, /Export not ready/);
+  });
+
   // The export answers with a relative url, so it has to be resolved against the publication host
   // rather than concatenated onto publication_url — which already ends in /api/v1 and would produce
   // /api/v1/api/v1/...

--- a/src/tools/export_subscribers.spec.js
+++ b/src/tools/export_subscribers.spec.js
@@ -260,6 +260,35 @@ describe('exportSubscribersHandler — polling', () => {
     assert.deepEqual(clock.slept, [EXPORT_POLL_BACKOFF_SECONDS[0], EXPORT_POLL_BACKOFF_SECONDS[1]]);
   });
 
+  // Issue #25: the live pending state is a 400, and the first poll is immediate, so every export
+  // hit it and aborted before the file was ever ready. Verified against the real API on
+  // 2026-09-03: ~3s of 400 {"error":"Export not ready"}, then 200 {url}.
+  test('keeps polling through the 400 the live API answers while the file is generating', async () => {
+    msw.server.use(msw.exportStatusHandler((exportId, attempt) =>
+      attempt < 3
+        ? HttpResponse.json({error: 'Export not ready', type: 'single'}, {status: 400})
+        : HttpResponse.json({url: EXPORT_FILE_PATH}, {status: 200})
+    ));
+
+    const clock = fakeClock();
+    const result = await run({}, clock);
+
+    assert.equal(result.count, 2);
+    assert.deepEqual(clock.slept, [EXPORT_POLL_BACKOFF_SECONDS[0], EXPORT_POLL_BACKOFF_SECONDS[1]]);
+  });
+
+  // A 400 that is not the pending state means the export will never arrive, so polling it to the
+  // end of the wait budget would replace a clear refusal with a slow timeout.
+  test('aborts on a 400 that is not the pending state', async () => {
+    msw.server.use(msw.exportStatusHandler(() =>
+      HttpResponse.json({error: 'Subscriber set not found', type: 'single'}, {status: 400})
+    ));
+
+    const error = await run({}, fakeClock()).catch((e) => e);
+
+    assert.match(error.message, /^SubstackAPIException: 400\b/);
+  });
+
   test('follows the documented backoff rather than a fixed interval', async () => {
     assert.deepEqual(EXPORT_POLL_BACKOFF_SECONDS.slice(0, 4), [1, 5, 10, 30]);
     assert.equal(EXPORT_POLL_BACKOFF_SECONDS.at(-1), 60);


### PR DESCRIPTION
Fixes #25.

`export_subscribers` failed on **every** call, with any arguments. The reported symptom is real and 100% reproducible; the reported cause is not the one.

## The cause is the poll, not the query

While Substack generates the file, `GET /subscriber_set/export/<id>` answers `400 {"error":"Export not ready","type":"single"}` — **not** a 200 with an absent `url`, which is what this repo believed and what the suite mocked. The tool's first poll is immediate and generation takes ~3s even for 6 rows, so every export hit that 400 and `readBody` turned it into a fatal error.

Measured live 2026-09-03, polling a fresh 6-row export at 250ms:

```
+0.17s 400 Export not ready
 ...   400 Export not ready      (7 polls)
+2.71s 400 Export not ready
+3.29s 200 {"url":"/api/v1/subscriber_set/export/…/file"}
```

A `200` with an absent `url` was never observed at any point. The polling condition tested a state that does not exist, while the state that does exist threw.

The failure rate is 100% rather than intermittent because of a *conjunction*: the first poll is immediate **and** any non-2xx is fatal. Either alone would have been harmless — the optimisation meant to save one second is what guarantees the first poll lands inside the 400 window.

## What the issue got wrong, for the record

The reported cause — `buildSubscriberQuery` passing `sort_direction` to `createSubscriberSet` — is not reachable. `export_subscribers` takes only the `filters` object and drops the rest (`export_subscribers.js:111`), `sort_direction` is never part of that function's output, and the tool's schema does not expose sorting at all. Live: `POST /subscriber_set` with `{"query":{"activity_rating_gte":4}}` → `200`. Intercepting a real no-argument call gives `{"query":{}}`, the body the issue itself lists as 200. A test already pinned that body (`export_subscribers.spec.js:122`). Acting on the stated cause would have changed nothing and left the tool broken.

## The change

- `getSubscriberSetExport` translates that one body into `{pending: true}` and **rethrows every other 400** — an export that will never arrive has to fail now rather than poll out the caller's wait budget.
- `readBody` attaches `status` and `body` to the error it throws. The message carried only the status, so Substack's explanation of a refusal was readable in the log and nowhere else, and no caller could tell one 400 from another. That is why this presented as a bare `400 Bad Request` naming none of the four steps — and, I'd argue, why the issue's diagnosis went wrong: an uninformative error does not just slow diagnosis down, it invites a plausible wrong one.

`export_subscribers.js` is **unchanged**: `{pending: true}` carries no `url`, so the existing loop, backoff, budget and timeout message all work as they are, and an absent `url` still means retry in case that state ever exists.

## Verification

- **Live, end to end, after the fix** — the same call that previously threw `SubstackAPIException: 400 Bad Request`:

```
POST /subscriber_set              → 200
POST /subscriber_set/export       → 200
GET  /export/…  +0.2s             → 400  → substack.export.pending
GET  /export/…  +1.3s             → 400  → substack.export.pending
GET  /export/…  +6.3s             → 200  {url}
GET  /export/…/file               → 200  text/csv
export_subscribers.done  count: 6, waited_seconds: 6
```

- 5 new tests, **confirmed red before the fix**, covering the pending 400, a non-pending 400 still aborting, and `status`/`body` on the error.
- `753 pass / 0 fail` on both supported runtimes (the `engines` floor, 22, and `.nvmrc`, 24).
- Protocol surface unchanged: handshake ok, 27 tools.

## Why 748 green tests missed it

The pending state was mocked as `200 {}`, so the suite stayed green while the tool failed every time in production. That mock described the wrong universe, so no assertion over it could have failed however thorough it was — the mocks are ours, so the suite measures this repo's model of Substack and never Substack.

`CLAUDE.md` therefore gains the two rules that follow, next to "A new test that passes on the first run has proven nothing":

1. A fixture representing an API **state** must cite where that state was observed; a transient or error-state fixture is corrected by nobody, unlike a happy-path one, so those are the ones to suspect.
2. A **time-dependent** flow is verified by running the real handler, never by hand. Hand-issued requests land seconds apart and cannot enter a 3-second window; the code polls 200ms in and cannot avoid it. The technique was already in the file — the token check drove the real handlers and read the log — it just had not been applied here.

## Out of scope, noted while verifying

`group_membership` **does** export (measured: 46 columns requested → 45 returned, only `tag_ids` missing). `CLAUDE.md` and the tool's own description still claim two columns are undeliverable, which misleads a calling model. Left for a separate change rather than mixed into a bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
